### PR TITLE
#53 #55  post-processing methods - creation of pheval output

### DIFF
--- a/src/pheval/analyse/analysis.py
+++ b/src/pheval/analyse/analysis.py
@@ -312,8 +312,8 @@ class AssessVariantPrioritisation:
         variant_match = VariantPrioritisationResultData(
             self.phenopacket_path,
             GenomicVariant(
-                chrom=result_entry["chrom"],
-                pos=result_entry["pos"],
+                chrom=result_entry["chromosome"],
+                pos=result_entry["start"],
                 ref=result_entry["ref"],
                 alt=result_entry["alt"],
             ),
@@ -353,7 +353,7 @@ class AssessVariantPrioritisation:
             variant_match = VariantPrioritisationResultData(self.phenopacket_path, variant)
             for _index, result in self.standardised_variant_results.iterrows():
                 result_variant = GenomicVariant(
-                    chrom=result["chrom"], pos=result["pos"], ref=result["ref"], alt=result["alt"]
+                    chrom=result["chromosome"], pos=result["start"], ref=result["ref"], alt=result["alt"]
                 )
                 if variant == result_variant:
                     variant_match = self.record_matched_variant(rank_stats, result)

--- a/src/pheval/analyse/analysis.py
+++ b/src/pheval/analyse/analysis.py
@@ -353,7 +353,10 @@ class AssessVariantPrioritisation:
             variant_match = VariantPrioritisationResultData(self.phenopacket_path, variant)
             for _index, result in self.standardised_variant_results.iterrows():
                 result_variant = GenomicVariant(
-                    chrom=result["chromosome"], pos=result["start"], ref=result["ref"], alt=result["alt"]
+                    chrom=result["chromosome"],
+                    pos=result["start"],
+                    ref=result["ref"],
+                    alt=result["alt"],
                 )
                 if variant == result_variant:
                     variant_match = self.record_matched_variant(rank_stats, result)

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -62,7 +62,7 @@ class RankedPhEvalVariantResult:
 
 class ResultSorter:
     def __init__(
-            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
+        self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
     ):
         self.pheval_results = pheval_results
         self.ranking_method = ranking_method
@@ -101,7 +101,7 @@ class ScoreRanker:
 
 
 def rank_pheval_results(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
@@ -120,8 +120,9 @@ def rank_pheval_results(
     return ranked_result
 
 
-def create_pheval_result(pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
-                         ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
+def create_pheval_result(
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
+) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
     sorted_pheval_result = ResultSorter(pheval_result, ranking_method).sort_pheval_results()
     return rank_pheval_results(sorted_pheval_result)

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -144,6 +144,7 @@ def rank_pheval_result(
 
 
 def return_sort_order(sort_order_str: str) -> SortOrder:
+    """Return the SortOrder Enum from string derived from config."""
     try:
         return SortOrder[sort_order_str.upper()]
     except KeyError:

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -66,12 +66,15 @@ class ResultSorter:
         self.ranking_method = ranking_method
 
     def sort_by_decreasing_score(self):
+        """Sort results in descending order."""
         return sorted(self.pheval_results, key=operator.attrgetter('score'), reverse=True)
 
     def sort_by_increasing_score(self):
+        """Sort results in ascending order."""
         return sorted(self.pheval_results, key=operator.attrgetter('score'), reverse=False)
 
     def sort_pheval_results(self):
+        """Sort results with best score first."""
         return (
             self.sort_by_increasing_score() if self.ranking_method.lower() == "pvalue"
             else self.sort_by_decreasing_score()

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -79,3 +79,24 @@ class ResultSorter:
             self.sort_by_increasing_score() if self.ranking_method.lower() == "pvalue"
             else self.sort_by_decreasing_score()
         )
+
+
+@dataclass
+class ScoreRanker:
+    rank: int = 0
+    current_score: float = float('inf')
+    count: int = 0
+
+    def rank_scores(self, round_score):
+        """Add ranks to a result, equal scores are given the same rank e.g., 1,1,3."""
+        if round_score > self.current_score:
+            raise ValueError(
+                f"Input score {round_score} is greater than previous score of {self.current_score}. "
+                f"Scores must be provided in reverse numerical order i.e. highest to lowest.")
+        self.count += 1
+        if self.current_score == round_score:
+            return self.rank
+        self.current_score = round_score
+        self.rank = self.count
+        return self.rank
+

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -65,8 +65,8 @@ class RankedPhEvalVariantResult:
 
 
 class SortOrder(Enum):
-    ASC = 1
-    DESC = 2
+    ASCENDING = 1
+    DESCENDING = 2
 
 
 class ResultSorter:
@@ -103,10 +103,10 @@ class ScoreRanker:
 
     def _check_rank_order(self, round_score: float):
         match self.sort_order:
-            case SortOrder.ASC:
+            case SortOrder.ASCENDING:
                 if round_score < self.current_score != float("inf"):
                     raise ValueError("Results are not correctly sorted!")
-            case SortOrder.DESC:
+            case SortOrder.DESCENDING:
                 if round_score > self.current_score != float("inf"):
                     raise ValueError("Results are not correctly sorted!")
 

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -76,20 +76,20 @@ class ResultSorter:
         self.pheval_results = pheval_results
         self.ranking_method = ranking_method
 
-    def sort_by_decreasing_score(self):
+    def _sort_by_decreasing_score(self):
         """Sort results in descending order."""
         return sorted(self.pheval_results, key=operator.attrgetter("score"), reverse=True)
 
-    def sort_by_increasing_score(self):
+    def _sort_by_increasing_score(self):
         """Sort results in ascending order."""
         return sorted(self.pheval_results, key=operator.attrgetter("score"), reverse=False)
 
-    def sort_pheval_results(self):
+    def _sort_pheval_results(self):
         """Sort results with best score first."""
         return (
-            self.sort_by_increasing_score()
+            self._sort_by_increasing_score()
             if self.ranking_method.lower() == "pvalue"
-            else self.sort_by_decreasing_score()
+            else self._sort_by_decreasing_score()
         )
 
 
@@ -110,7 +110,7 @@ class ScoreRanker:
                 if round_score > self.current_score != float("inf"):
                     raise ValueError("Results are not correctly sorted!")
 
-    def rank_scores(self, round_score: float):
+    def _rank_scores(self, round_score: float):
         """Add ranks to a result, equal scores are given the same rank e.g., 1,1,3."""
         self._check_rank_order(round_score)
         self.count += 1
@@ -121,7 +121,7 @@ class ScoreRanker:
         return self.rank
 
 
-def rank_pheval_result(
+def _rank_pheval_result(
         pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
@@ -131,11 +131,11 @@ def rank_pheval_result(
     for result in pheval_result:
         ranked_result.append(
             RankedPhEvalGeneResult(
-                pheval_gene_result=result, rank=score_ranker.rank_scores(result.score)
+                pheval_gene_result=result, rank=score_ranker._rank_scores(result.score)
             )
         ) if type(result) == PhEvalGeneResult else ranked_result.append(
             RankedPhEvalVariantResult(
-                pheval_variant_result=result, rank=score_ranker.rank_scores(result.score)
+                pheval_variant_result=result, rank=score_ranker._rank_scores(result.score)
             )
         )
     return ranked_result
@@ -145,8 +145,8 @@ def create_pheval_result(
         pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
-    sorted_pheval_result = ResultSorter(pheval_result, ranking_method).sort_pheval_results()
-    return rank_pheval_result(sorted_pheval_result)
+    sorted_pheval_result = ResultSorter(pheval_result, ranking_method)._sort_pheval_results()
+    return _rank_pheval_result(sorted_pheval_result)
 
 
 def write_pheval_gene_result(

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -101,7 +101,7 @@ class ScoreRanker:
     def __init__(self, sort_order: SortOrder):
         self.sort_order = sort_order
 
-    def _check_rank_order(self, round_score: float):
+    def _check_rank_order(self, round_score: float) -> None:
         if self.sort_order == SortOrder.ASCENDING and round_score < self.current_score != float(
                 "inf"
         ):
@@ -111,7 +111,7 @@ class ScoreRanker:
         ):
             raise ValueError("Results are not correctly sorted!")
 
-    def rank_scores(self, round_score: float):
+    def rank_scores(self, round_score: float) -> int:
         """Add ranks to a result, equal scores are given the same rank e.g., 1,1,3."""
         self._check_rank_order(round_score)
         self.count += 1

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -62,7 +62,7 @@ class RankedPhEvalVariantResult:
 
 class ResultSorter:
     def __init__(
-        self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
+            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
     ):
         self.pheval_results = pheval_results
         self.ranking_method = ranking_method
@@ -101,7 +101,7 @@ class ScoreRanker:
 
 
 def rank_pheval_results(
-    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
+        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
@@ -118,3 +118,10 @@ def rank_pheval_results(
             )
         )
     return ranked_result
+
+
+def create_pheval_result(pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
+                         ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
+    """Create PhEval gene/variant result with corresponding ranks."""
+    sorted_pheval_result = ResultSorter(pheval_result, ranking_method).sort_pheval_results()
+    return rank_pheval_results(sorted_pheval_result)

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -100,7 +100,7 @@ class ScoreRanker:
         return self.rank
 
 
-def rank_pheval_results(
+def rank_pheval_result(
     pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -87,7 +87,6 @@ class ResultSorter:
         )
 
 
-@dataclass
 class ScoreRanker:
     rank: int = 0
     current_score: float = float("inf")

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -102,13 +102,21 @@ class ScoreRanker:
         self.sort_order = sort_order
 
     def _check_rank_order(self, round_score: float):
-        match self.sort_order:
-            case SortOrder.ASCENDING:
-                if round_score < self.current_score != float("inf"):
-                    raise ValueError("Results are not correctly sorted!")
-            case SortOrder.DESCENDING:
-                if round_score > self.current_score != float("inf"):
-                    raise ValueError("Results are not correctly sorted!")
+        if self.sort_order == SortOrder.ASCENDING and round_score < self.current_score != float(
+            "inf"
+        ):
+            raise ValueError("Results are not correctly sorted!")
+        elif self.sort_order == SortOrder.DESCENDING and round_score > self.current_score != float(
+            "inf"
+        ):
+            raise ValueError("Results are not correctly sorted!")
+        # match self.sort_order:
+        #     case SortOrder.ASCENDING:
+        #         if round_score < self.current_score != float("inf"):
+        #             raise ValueError("Results are not correctly sorted!")
+        #     case SortOrder.DESCENDING:
+        #         if round_score > self.current_score != float("inf"):
+        #             raise ValueError("Results are not correctly sorted!")
 
     def rank_scores(self, round_score: float):
         """Add ranks to a result, equal scores are given the same rank e.g., 1,1,3."""

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -84,7 +84,7 @@ class ResultSorter:
         """Sort results in ascending order."""
         return sorted(self.pheval_results, key=operator.attrgetter("score"), reverse=False)
 
-    def _sort_pheval_results(self):
+    def sort_pheval_results(self):
         """Sort results with best score first."""
         return (
             self._sort_by_increasing_score()
@@ -110,7 +110,7 @@ class ScoreRanker:
                 if round_score > self.current_score != float("inf"):
                     raise ValueError("Results are not correctly sorted!")
 
-    def _rank_scores(self, round_score: float):
+    def rank_scores(self, round_score: float):
         """Add ranks to a result, equal scores are given the same rank e.g., 1,1,3."""
         self._check_rank_order(round_score)
         self.count += 1
@@ -131,11 +131,11 @@ def _rank_pheval_result(
     for result in pheval_result:
         ranked_result.append(
             RankedPhEvalGeneResult(
-                pheval_gene_result=result, rank=score_ranker._rank_scores(result.score)
+                pheval_gene_result=result, rank=score_ranker.rank_scores(result.score)
             )
         ) if type(result) == PhEvalGeneResult else ranked_result.append(
             RankedPhEvalVariantResult(
-                pheval_variant_result=result, rank=score_ranker._rank_scores(result.score)
+                pheval_variant_result=result, rank=score_ranker.rank_scores(result.score)
             )
         )
     return ranked_result
@@ -145,7 +145,7 @@ def create_pheval_result(
         pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
-    sorted_pheval_result = ResultSorter(pheval_result, ranking_method)._sort_pheval_results()
+    sorted_pheval_result = ResultSorter(pheval_result, ranking_method).sort_pheval_results()
     return _rank_pheval_result(sorted_pheval_result)
 
 

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -92,11 +92,6 @@ class ScoreRanker:
 
     def rank_scores(self, round_score):
         """Add ranks to a result, equal scores are given the same rank e.g., 1,1,3."""
-        if round_score > self.current_score:
-            raise ValueError(
-                f"Input score {round_score} is greater than previous score of {self.current_score}. "
-                f"Scores must be provided in reverse numerical order i.e. highest to lowest."
-            )
         self.count += 1
         if self.current_score == round_score:
             return self.rank

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -125,4 +125,4 @@ def create_pheval_result(
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
     sorted_pheval_result = ResultSorter(pheval_result, ranking_method).sort_pheval_results()
-    return rank_pheval_results(sorted_pheval_result)
+    return rank_pheval_result(sorted_pheval_result)

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -1,3 +1,4 @@
+import operator
 from dataclasses import dataclass
 
 
@@ -57,3 +58,21 @@ class RankedPhEvalVariantResult:
             "score": self.pheval_variant_result.score,
             "rank": self.rank,
         }
+
+
+class ResultSorter:
+    def __init__(self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str):
+        self.pheval_results = pheval_results
+        self.ranking_method = ranking_method
+
+    def sort_by_decreasing_score(self):
+        return sorted(self.pheval_results, key=operator.attrgetter('score'), reverse=True)
+
+    def sort_by_increasing_score(self):
+        return sorted(self.pheval_results, key=operator.attrgetter('score'), reverse=False)
+
+    def sort_pheval_results(self):
+        return (
+            self.sort_by_increasing_score() if self.ranking_method.lower() == "pvalue"
+            else self.sort_by_decreasing_score()
+        )

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -71,10 +71,10 @@ class SortOrder(Enum):
 
 class ResultSorter:
     def __init__(
-            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
+            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
     ):
         self.pheval_results = pheval_results
-        self.ranking_method = ranking_method
+        self.sort_order = sort_order
 
     def _sort_by_decreasing_score(self):
         """Sort results in descending order."""
@@ -88,7 +88,7 @@ class ResultSorter:
         """Sort results with best score first."""
         return (
             self._sort_by_increasing_score()
-            if self.ranking_method.lower() == "pvalue"
+            if self.sort_order == SortOrder.ASCENDING
             else self._sort_by_decreasing_score()
         )
 
@@ -121,12 +121,13 @@ class ScoreRanker:
         return self.rank
 
 
-def _rank_pheval_result(
+def rank_pheval_result(
         pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
+        sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
-    score_ranker = ScoreRanker()
+    score_ranker = ScoreRanker(sort_order)
     ranked_result = []
     for result in pheval_result:
         ranked_result.append(
@@ -142,11 +143,11 @@ def _rank_pheval_result(
 
 
 def create_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
+        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
-    sorted_pheval_result = ResultSorter(pheval_result, ranking_method).sort_pheval_results()
-    return _rank_pheval_result(sorted_pheval_result)
+    sorted_pheval_result = ResultSorter(pheval_result, sort_order).sort_pheval_results()
+    return rank_pheval_result(sorted_pheval_result, sort_order)
 
 
 def write_pheval_gene_result(

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -76,15 +76,15 @@ class ResultSorter:
         self.pheval_results = pheval_results
         self.sort_order = sort_order
 
-    def _sort_by_decreasing_score(self):
+    def _sort_by_decreasing_score(self) -> [PhEvalGeneResult] or [PhEvalVariantResult]:
         """Sort results in descending order."""
         return sorted(self.pheval_results, key=operator.attrgetter("score"), reverse=True)
 
-    def _sort_by_increasing_score(self):
+    def _sort_by_increasing_score(self) -> [PhEvalGeneResult] or [PhEvalVariantResult]:
         """Sort results in ascending order."""
         return sorted(self.pheval_results, key=operator.attrgetter("score"), reverse=False)
 
-    def sort_pheval_results(self):
+    def sort_pheval_results(self) -> [PhEvalGeneResult] or [PhEvalVariantResult]:
         """Sort results with best score first."""
         return (
             self._sort_by_increasing_score()

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -71,7 +71,7 @@ class SortOrder(Enum):
 
 class ResultSorter:
     def __init__(
-            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+        self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
     ):
         self.pheval_results = pheval_results
         self.sort_order = sort_order
@@ -104,11 +104,11 @@ class ScoreRanker:
     def _check_rank_order(self, round_score: float) -> None:
         """Check the results are correctly ordered."""
         if self.sort_order == SortOrder.ASCENDING and round_score < self.current_score != float(
-                "inf"
+            "inf"
         ):
             raise ValueError("Results are not correctly sorted!")
         elif self.sort_order == SortOrder.DESCENDING and round_score > self.current_score != float(
-                "inf"
+            "inf"
         ):
             raise ValueError("Results are not correctly sorted!")
 
@@ -124,7 +124,7 @@ class ScoreRanker:
 
 
 def rank_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
@@ -143,7 +143,7 @@ def rank_pheval_result(
     return ranked_result
 
 
-def return_sort_order(sort_order_str: str) -> SortOrder:
+def _return_sort_order(sort_order_str: str) -> SortOrder:
     """Return the SortOrder Enum from string derived from config."""
     try:
         return SortOrder[sort_order_str.upper()]
@@ -152,16 +152,16 @@ def return_sort_order(sort_order_str: str) -> SortOrder:
 
 
 def create_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
-    sort_order = return_sort_order(sort_order_str)
+    sort_order = _return_sort_order(sort_order_str)
     sorted_pheval_result = ResultSorter(pheval_result, sort_order).sort_pheval_results()
     return rank_pheval_result(sorted_pheval_result, sort_order)
 
 
 def write_pheval_gene_result(
-        ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
+    ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval gene result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
@@ -176,13 +176,13 @@ def write_pheval_gene_result(
 
 
 def write_pheval_variant_result(
-        ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
+    ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval variant result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
     pheval_variant_output = ranked_result.loc[
-                            :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
-                            ]
+        :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
+    ]
     pheval_variant_output.to_csv(
         output_dir.joinpath(
             "pheval_variant_results/" + tool_result_path.stem + "-pheval_variant_result.tsv"

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -71,7 +71,7 @@ class SortOrder(Enum):
 
 class ResultSorter:
     def __init__(
-            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+        self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
     ):
         self.pheval_results = pheval_results
         self.sort_order = sort_order
@@ -122,8 +122,7 @@ class ScoreRanker:
 
 
 def rank_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
-        sort_order: SortOrder
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
@@ -143,7 +142,7 @@ def rank_pheval_result(
 
 
 def create_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
     sorted_pheval_result = ResultSorter(pheval_result, sort_order).sort_pheval_results()
@@ -151,7 +150,7 @@ def create_pheval_result(
 
 
 def write_pheval_gene_result(
-        ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
+    ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval gene result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
@@ -166,13 +165,13 @@ def write_pheval_gene_result(
 
 
 def write_pheval_variant_result(
-        ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
+    ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval variant result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
     pheval_variant_output = ranked_result.loc[
-                            :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
-                            ]
+        :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
+    ]
     pheval_variant_output.to_csv(
         output_dir.joinpath(
             "pheval_variant_results/" + tool_result_path.stem + "-pheval_variant_result.tsv"

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -65,7 +65,7 @@ class RankedPhEvalVariantResult:
 
 class ResultSorter:
     def __init__(
-            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
+        self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
     ):
         self.pheval_results = pheval_results
         self.ranking_method = ranking_method
@@ -104,7 +104,7 @@ class ScoreRanker:
 
 
 def rank_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
@@ -124,7 +124,7 @@ def rank_pheval_result(
 
 
 def create_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], ranking_method: str
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
     sorted_pheval_result = ResultSorter(pheval_result, ranking_method).sort_pheval_results()
@@ -132,7 +132,7 @@ def create_pheval_result(
 
 
 def write_pheval_gene_result(
-        ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
+    ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval gene result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
@@ -147,13 +147,13 @@ def write_pheval_gene_result(
 
 
 def write_pheval_variant_result(
-        ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
+    ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval variant result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
     pheval_variant_output = ranked_result.loc[
-                            :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
-                            ]
+        :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
+    ]
     pheval_variant_output.to_csv(
         output_dir.joinpath(
             "pheval_variant_results/" + tool_result_path.stem + "-pheval_variant_result.tsv"

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -102,6 +102,7 @@ class ScoreRanker:
         self.sort_order = sort_order
 
     def _check_rank_order(self, round_score: float) -> None:
+        """Check the results are correctly ordered."""
         if self.sort_order == SortOrder.ASCENDING and round_score < self.current_score != float(
                 "inf"
         ):

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -71,7 +71,7 @@ class SortOrder(Enum):
 
 class ResultSorter:
     def __init__(
-        self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
     ):
         self.pheval_results = pheval_results
         self.sort_order = sort_order
@@ -103,20 +103,13 @@ class ScoreRanker:
 
     def _check_rank_order(self, round_score: float):
         if self.sort_order == SortOrder.ASCENDING and round_score < self.current_score != float(
-            "inf"
+                "inf"
         ):
             raise ValueError("Results are not correctly sorted!")
         elif self.sort_order == SortOrder.DESCENDING and round_score > self.current_score != float(
-            "inf"
+                "inf"
         ):
             raise ValueError("Results are not correctly sorted!")
-        # match self.sort_order:
-        #     case SortOrder.ASCENDING:
-        #         if round_score < self.current_score != float("inf"):
-        #             raise ValueError("Results are not correctly sorted!")
-        #     case SortOrder.DESCENDING:
-        #         if round_score > self.current_score != float("inf"):
-        #             raise ValueError("Results are not correctly sorted!")
 
     def rank_scores(self, round_score: float):
         """Add ranks to a result, equal scores are given the same rank e.g., 1,1,3."""
@@ -130,7 +123,7 @@ class ScoreRanker:
 
 
 def rank_pheval_result(
-    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
@@ -149,16 +142,24 @@ def rank_pheval_result(
     return ranked_result
 
 
+def return_sort_order(sort_order_str: str) -> SortOrder:
+    try:
+        return SortOrder[sort_order_str.upper()]
+    except KeyError:
+        raise ValueError("Incompatible ordering method specified.")
+
+
 def create_pheval_result(
-    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
+    sort_order = return_sort_order(sort_order_str)
     sorted_pheval_result = ResultSorter(pheval_result, sort_order).sort_pheval_results()
     return rank_pheval_result(sorted_pheval_result, sort_order)
 
 
 def write_pheval_gene_result(
-    ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
+        ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval gene result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
@@ -173,13 +174,13 @@ def write_pheval_gene_result(
 
 
 def write_pheval_variant_result(
-    ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
+        ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval variant result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
     pheval_variant_output = ranked_result.loc[
-        :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
-    ]
+                            :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
+                            ]
     pheval_variant_output.to_csv(
         output_dir.joinpath(
             "pheval_variant_results/" + tool_result_path.stem + "-pheval_variant_result.tsv"

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -470,8 +470,9 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
             [
                 {
                     "variant": {
-                        "chrom": "3",
-                        "pos": 126730873,
+                        "chromosome": "3",
+                        "start": 126730873,
+                        "end": 126730873,
                         "ref": "G",
                         "alt": "A",
                         "gene": "PLXNA1",
@@ -481,8 +482,9 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
                 },
                 {
                     "variant": {
-                        "chrom": "3",
-                        "pos": 126730873,
+                        "chromosome": "3",
+                        "start": 126730873,
+                        "end": 126730873,
                         "ref": "G",
                         "alt": "A",
                         "gene": "PLXNA1",
@@ -492,8 +494,9 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
                 },
                 {
                     "variant": {
-                        "chrom": "3",
-                        "pos": 126741108,
+                        "chromosome": "3",
+                        "start": 126741108,
+                        "end": 126741108,
                         "ref": "G",
                         "alt": "A",
                         "gene": "PLXNA1",
@@ -537,8 +540,9 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
             self.assess_variant_prioritisation.record_variant_prioritisation_match(
                 result_entry=pd.Series(
                     {
-                        "chrom": "3",
-                        "pos": 126741108,
+                        "chromosome": "3",
+                        "start": 126741108,
+                        "end": 126741108,
                         "ref": "G",
                         "alt": "A",
                         "gene": "PLXNA1",
@@ -562,8 +566,9 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
             assess_with_threshold.assess_variant_with_pvalue_threshold(
                 result_entry=pd.Series(
                     {
-                        "chrom": "3",
-                        "pos": 126741108,
+                        "chromosome": "3",
+                        "start": 126741108,
+                        "end": 126741108,
                         "ref": "G",
                         "alt": "A",
                         "gene": "PLXNA1",
@@ -587,8 +592,9 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
             assess_with_threshold.assess_variant_with_pvalue_threshold(
                 result_entry=pd.Series(
                     {
-                        "chrom": "3",
-                        "pos": 126741108,
+                        "chromosome": "3",
+                        "start": 126741108,
+                        "end": 126741108,
                         "ref": "G",
                         "alt": "A",
                         "gene": "PLXNA1",
@@ -616,8 +622,9 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
             assess_with_threshold.assess_variant_with_threshold(
                 result_entry=pd.Series(
                     {
-                        "chrom": "3",
-                        "pos": 126741108,
+                        "chromosome": "3",
+                        "start": 126741108,
+                        "end": 126741108,
                         "ref": "G",
                         "alt": "A",
                         "gene": "PLXNA1",
@@ -641,8 +648,9 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
             assess_with_threshold.assess_variant_with_threshold(
                 result_entry=pd.Series(
                     {
-                        "chrom": "3",
-                        "pos": 126741108,
+                        "chromosome": "3",
+                        "start": 126741108,
+                        "end": 126741108,
                         "ref": "G",
                         "alt": "A",
                         "gene": "PLXNA1",

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -9,7 +9,8 @@ from pheval.post_processing.post_processing import (
     ScoreRanker,
     SortOrder,
     create_pheval_result,
-    rank_pheval_result, return_sort_order,
+    rank_pheval_result,
+    _return_sort_order,
 )
 
 pheval_gene_result = [
@@ -397,11 +398,9 @@ class TestCreatePhEvalResult(unittest.TestCase):
 
 class TestReturnSortOrder(unittest.TestCase):
     def test_return_sort_order(self):
-        self.assertEqual(return_sort_order("ascending"), SortOrder.ASCENDING)
-        self.assertEqual(return_sort_order("descending"), SortOrder.DESCENDING)
+        self.assertEqual(_return_sort_order("ascending"), SortOrder.ASCENDING)
+        self.assertEqual(_return_sort_order("descending"), SortOrder.DESCENDING)
 
     def test_return_sort_order_incompatible(self):
         with self.assertRaises(ValueError):
-            return_sort_order("null")
-
-
+            _return_sort_order("null")

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -7,7 +7,7 @@ from pheval.post_processing.post_processing import (
     RankedPhEvalVariantResult,
     ResultSorter,
     ScoreRanker,
-    rank_pheval_results,
+    rank_pheval_results, create_pheval_result,
 )
 
 pheval_gene_result = [
@@ -258,3 +258,41 @@ class TestRankPhEvalResults(unittest.TestCase):
                 ),
             ],
         )
+
+
+class TestCreatePhEvalResult(unittest.TestCase):
+
+    def test_create_pheval_result_gene(self):
+        self.assertEqual(create_pheval_result(pheval_gene_result, "combinedScore"),
+                         [RankedPhEvalGeneResult(
+                             pheval_gene_result=PhEvalGeneResult(gene_symbol='MAP3K14',
+                                                                 gene_identifier='ENSG00000006062',
+                                                                 score=0.9234), rank=1), RankedPhEvalGeneResult(
+                             pheval_gene_result=PhEvalGeneResult(gene_symbol='A4GNT', gene_identifier='ENSG00000118017',
+                                                                 score=0.6529), rank=2), RankedPhEvalGeneResult(
+                             pheval_gene_result=PhEvalGeneResult(gene_symbol='OR14J1',
+                                                                 gene_identifier='ENSG00000204695',
+                                                                 score=0.6529), rank=2), RankedPhEvalGeneResult(
+                             pheval_gene_result=PhEvalGeneResult(gene_symbol='PAGE1', gene_identifier='ENSG00000068985',
+                                                                 score=0.5235), rank=4)]
+                         )
+
+    def test_create_pheval_result_variant(self):
+        self.assertEqual(create_pheval_result(pheval_variant_result, "pValue"),
+                         [RankedPhEvalVariantResult(
+                             pheval_variant_result=PhEvalVariantResult(chromosome='X', start=93473023, end=93473024,
+                                                                       ref='A',
+                                                                       alt='G', score=0.1245), rank=1),
+                             RankedPhEvalVariantResult(
+                                 pheval_variant_result=PhEvalVariantResult(chromosome='8', start=532356, end=532357,
+                                                                           ref='A', alt='C',
+                                                                           score=0.4578), rank=2),
+                             RankedPhEvalVariantResult(
+                                 pheval_variant_result=PhEvalVariantResult(chromosome='5', start=23457444233,
+                                                                           end=23457444234, ref='A',
+                                                                           alt='C', score=0.9348), rank=3),
+                             RankedPhEvalVariantResult(
+                                 pheval_variant_result=PhEvalVariantResult(chromosome='12', start=12754332,
+                                                                           end=12754333, ref='T',
+                                                                           alt='G', score=0.9999), rank=4)]
+                         )

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -37,31 +37,48 @@ pheval_variant_result = [
 
 
 class TestRankedPhEvalGeneResult(unittest.TestCase):
-
     def setUp(self) -> None:
         self.pheval_gene_result = RankedPhEvalGeneResult(
-            pheval_gene_result=PhEvalGeneResult(gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529),
-            rank=1)
+            pheval_gene_result=PhEvalGeneResult(
+                gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
+            ),
+            rank=1,
+        )
 
     def test_as_dict(self):
-        self.assertEqual(self.pheval_gene_result.as_dict(),
-                         {'gene_symbol': 'A4GNT', 'gene_identifier': 'ENSG00000118017', 'score': 0.6529, 'rank': 1}
-                         )
+        self.assertEqual(
+            self.pheval_gene_result.as_dict(),
+            {
+                "gene_symbol": "A4GNT",
+                "gene_identifier": "ENSG00000118017",
+                "score": 0.6529,
+                "rank": 1,
+            },
+        )
 
 
 class TestRankedPhEvalVariantResult(unittest.TestCase):
-
     def setUp(self) -> None:
-        self.pheval_variant_result = RankedPhEvalVariantResult(pheval_variant_result=PhEvalVariantResult(
-            chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
-        ), rank=3)
+        self.pheval_variant_result = RankedPhEvalVariantResult(
+            pheval_variant_result=PhEvalVariantResult(
+                chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
+            ),
+            rank=3,
+        )
 
     def test_as_dict(self):
-        self.assertEqual(self.pheval_variant_result.as_dict(),
-                         {'chromosome': '12', 'start': 12754332, 'end': 12754333, 'ref': 'T', 'alt': 'G',
-                          'score': 0.9999,
-                          'rank': 3}
-                         )
+        self.assertEqual(
+            self.pheval_variant_result.as_dict(),
+            {
+                "chromosome": "12",
+                "start": 12754332,
+                "end": 12754333,
+                "ref": "T",
+                "alt": "G",
+                "score": 0.9999,
+                "rank": 3,
+            },
+        )
 
 
 class TestResultSorter(unittest.TestCase):

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -7,8 +7,9 @@ from pheval.post_processing.post_processing import (
     RankedPhEvalVariantResult,
     ResultSorter,
     ScoreRanker,
+    SortOrder,
     create_pheval_result,
-    rank_pheval_result, SortOrder,
+    rank_pheval_result,
 )
 
 pheval_gene_result = [

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -183,25 +183,38 @@ class TestResultSorter(unittest.TestCase):
 
 class TestScoreRanker(unittest.TestCase):
     def setUp(self) -> None:
-        self.score_ranker = ScoreRanker(SortOrder.DESCENDING)
+        self.score_ranker_descending = ScoreRanker(SortOrder.DESCENDING)
+        self.score_ranker_ascending = ScoreRanker(SortOrder.ASCENDING)
+
+    def test_check_rank_order_descending(self):
+        self.score_ranker_descending.rank_scores(0.9)
+        self.score_ranker_descending.rank_scores(0.8)
+        with self.assertRaises(ValueError):
+            self.score_ranker_descending.rank_scores(0.9)
+
+    def test_check_rank_order_ascending(self):
+        self.score_ranker_ascending.rank_scores(0.1)
+        self.score_ranker_ascending.rank_scores(0.2)
+        with self.assertRaises(ValueError):
+            self.score_ranker_ascending.rank_scores(0.1)
 
     def test_rank_scores_first_rank(self):
-        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.7342), 1)
 
     def test_rank_scores_increase_rank(self):
-        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.3452), 2)
 
     def test_rank_scores_same_rank(self):
-        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.3452), 2)
 
     def test_rank_scores_count_increase(self):
-        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker.rank_scores(0.1234), 4)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker_descending.rank_scores(0.1234), 4)
 
 
 class TestRankPhEvalResults(unittest.TestCase):

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -137,7 +137,7 @@ class TestResultSorter(unittest.TestCase):
 
     def test_sort_pheval_results_not_pvalue(self):
         self.assertEqual(
-            self.gene_results._sort_pheval_results(),
+            self.gene_results.sort_pheval_results(),
             [
                 PhEvalGeneResult(
                     gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
@@ -156,7 +156,7 @@ class TestResultSorter(unittest.TestCase):
 
     def test_sort_pheval_results_pvalue(self):
         self.assertEqual(
-            self.variant_results._sort_pheval_results(),
+            self.variant_results.sort_pheval_results(),
             [
                 PhEvalVariantResult(
                     chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
@@ -184,22 +184,22 @@ class TestScoreRanker(unittest.TestCase):
         self.score_ranker = ScoreRanker()
 
     def test_rank_scores_first_rank(self):
-        self.assertEqual(self.score_ranker._rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
 
     def test_rank_scores_increase_rank(self):
-        self.assertEqual(self.score_ranker._rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
 
     def test_rank_scores_same_rank(self):
-        self.assertEqual(self.score_ranker._rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
 
     def test_rank_scores_count_increase(self):
-        self.assertEqual(self.score_ranker._rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker._rank_scores(0.1234), 4)
+        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker.rank_scores(0.1234), 4)
 
 
 class TestRankPhEvalResults(unittest.TestCase):

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -1,0 +1,36 @@
+import unittest
+
+from pheval.post_processing.post_processing import ResultSorter, PhEvalGeneResult, PhEvalVariantResult
+
+
+class TestResultSorter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gene_results = ResultSorter(pheval_results=[
+            PhEvalGeneResult(gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529),
+            PhEvalGeneResult(gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234),
+            PhEvalGeneResult(gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529),
+            PhEvalGeneResult(gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235)
+
+        ], ranking_method="combinedScore")
+        self.variant_results = ResultSorter(pheval_results=[PhEvalVariantResult(chromosome="5", start=23457444233,
+                                                                                end=23457444234, ref="A", alt="C",
+                                                                                score=0.9348),
+                                                            PhEvalVariantResult(chromosome="12", start=12754332,
+                                                                                end=12754333, ref="T", alt="G",
+                                                                                score=0.9999),
+                                                            PhEvalVariantResult(chromosome="X", start=93473023,
+                                                                                end=93473024, ref="A", alt="G",
+                                                                                score=0.1245),
+                                                            PhEvalVariantResult(chromosome="8", start=532356,
+                                                                                end=532357, ref="A", alt="C",
+                                                                                score=0.4578)
+                                                            ], ranking_method="pValue")
+
+    def test_sort_by_decreasing_score(self):
+        assert False
+
+    def test_sort_by_increasing_score(self):
+        assert False
+
+    def test_sort_pheval_results(self):
+        assert False

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -311,7 +311,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 class TestCreatePhEvalResult(unittest.TestCase):
     def test_create_pheval_result_gene(self):
         self.assertEqual(
-            create_pheval_result(pheval_gene_result, SortOrder.DESCENDING),
+            create_pheval_result(pheval_gene_result, "descending"),
             [
                 RankedPhEvalGeneResult(
                     pheval_gene_result=PhEvalGeneResult(
@@ -342,7 +342,7 @@ class TestCreatePhEvalResult(unittest.TestCase):
 
     def test_create_pheval_result_variant(self):
         self.assertEqual(
-            create_pheval_result(pheval_variant_result, SortOrder.ASCENDING),
+            create_pheval_result(pheval_variant_result, "ascending"),
             [
                 RankedPhEvalVariantResult(
                     pheval_variant_result=PhEvalVariantResult(

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -7,7 +7,8 @@ from pheval.post_processing.post_processing import (
     RankedPhEvalVariantResult,
     ResultSorter,
     ScoreRanker,
-    rank_pheval_results, create_pheval_result,
+    create_pheval_result,
+    rank_pheval_results,
 )
 
 pheval_gene_result = [
@@ -261,38 +262,74 @@ class TestRankPhEvalResults(unittest.TestCase):
 
 
 class TestCreatePhEvalResult(unittest.TestCase):
-
     def test_create_pheval_result_gene(self):
-        self.assertEqual(create_pheval_result(pheval_gene_result, "combinedScore"),
-                         [RankedPhEvalGeneResult(
-                             pheval_gene_result=PhEvalGeneResult(gene_symbol='MAP3K14',
-                                                                 gene_identifier='ENSG00000006062',
-                                                                 score=0.9234), rank=1), RankedPhEvalGeneResult(
-                             pheval_gene_result=PhEvalGeneResult(gene_symbol='A4GNT', gene_identifier='ENSG00000118017',
-                                                                 score=0.6529), rank=2), RankedPhEvalGeneResult(
-                             pheval_gene_result=PhEvalGeneResult(gene_symbol='OR14J1',
-                                                                 gene_identifier='ENSG00000204695',
-                                                                 score=0.6529), rank=2), RankedPhEvalGeneResult(
-                             pheval_gene_result=PhEvalGeneResult(gene_symbol='PAGE1', gene_identifier='ENSG00000068985',
-                                                                 score=0.5235), rank=4)]
-                         )
+        self.assertEqual(
+            create_pheval_result(pheval_gene_result, "combinedScore"),
+            [
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
+                    ),
+                    rank=1,
+                ),
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
+                    ),
+                    rank=2,
+                ),
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529
+                    ),
+                    rank=2,
+                ),
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235
+                    ),
+                    rank=4,
+                ),
+            ],
+        )
 
     def test_create_pheval_result_variant(self):
-        self.assertEqual(create_pheval_result(pheval_variant_result, "pValue"),
-                         [RankedPhEvalVariantResult(
-                             pheval_variant_result=PhEvalVariantResult(chromosome='X', start=93473023, end=93473024,
-                                                                       ref='A',
-                                                                       alt='G', score=0.1245), rank=1),
-                             RankedPhEvalVariantResult(
-                                 pheval_variant_result=PhEvalVariantResult(chromosome='8', start=532356, end=532357,
-                                                                           ref='A', alt='C',
-                                                                           score=0.4578), rank=2),
-                             RankedPhEvalVariantResult(
-                                 pheval_variant_result=PhEvalVariantResult(chromosome='5', start=23457444233,
-                                                                           end=23457444234, ref='A',
-                                                                           alt='C', score=0.9348), rank=3),
-                             RankedPhEvalVariantResult(
-                                 pheval_variant_result=PhEvalVariantResult(chromosome='12', start=12754332,
-                                                                           end=12754333, ref='T',
-                                                                           alt='G', score=0.9999), rank=4)]
-                         )
+        self.assertEqual(
+            create_pheval_result(pheval_variant_result, "pValue"),
+            [
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
+                    ),
+                    rank=1,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
+                    ),
+                    rank=2,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="5",
+                        start=23457444233,
+                        end=23457444234,
+                        ref="A",
+                        alt="C",
+                        score=0.9348,
+                    ),
+                    rank=3,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="12",
+                        start=12754332,
+                        end=12754333,
+                        ref="T",
+                        alt="G",
+                        score=0.9999,
+                    ),
+                    rank=4,
+                ),
+            ],
+        )

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -8,7 +8,7 @@ from pheval.post_processing.post_processing import (
     ResultSorter,
     ScoreRanker,
     create_pheval_result,
-    rank_pheval_results,
+    rank_pheval_result,
 )
 
 pheval_gene_result = [
@@ -34,6 +34,34 @@ pheval_variant_result = [
     ),
     PhEvalVariantResult(chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578),
 ]
+
+
+class TestRankedPhEvalGeneResult(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.pheval_gene_result = RankedPhEvalGeneResult(
+            pheval_gene_result=PhEvalGeneResult(gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529),
+            rank=1)
+
+    def test_as_dict(self):
+        self.assertEqual(self.pheval_gene_result.as_dict(),
+                         {'gene_symbol': 'A4GNT', 'gene_identifier': 'ENSG00000118017', 'score': 0.6529, 'rank': 1}
+                         )
+
+
+class TestRankedPhEvalVariantResult(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.pheval_variant_result = RankedPhEvalVariantResult(pheval_variant_result=PhEvalVariantResult(
+            chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
+        ), rank=3)
+
+    def test_as_dict(self):
+        self.assertEqual(self.pheval_variant_result.as_dict(),
+                         {'chromosome': '12', 'start': 12754332, 'end': 12754333, 'ref': 'T', 'alt': 'G',
+                          'score': 0.9999,
+                          'rank': 3}
+                         )
 
 
 class TestResultSorter(unittest.TestCase):
@@ -190,7 +218,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 
     def test_rank_pheval_results_gene(self):
         self.assertTrue(
-            rank_pheval_results(self.sorted_gene_result),
+            rank_pheval_result(self.sorted_gene_result),
             [
                 RankedPhEvalGeneResult(
                     pheval_gene_result=PhEvalGeneResult(
@@ -221,7 +249,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 
     def test_rank_pheval_results_variant(self):
         self.assertEqual(
-            rank_pheval_results(self.sorted_variant_result),
+            rank_pheval_result(self.sorted_variant_result),
             [
                 RankedPhEvalVariantResult(
                     pheval_variant_result=PhEvalVariantResult(

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -8,9 +8,9 @@ from pheval.post_processing.post_processing import (
     ResultSorter,
     ScoreRanker,
     SortOrder,
+    _return_sort_order,
     create_pheval_result,
     rank_pheval_result,
-    _return_sort_order,
 )
 
 pheval_gene_result = [

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -6,46 +6,49 @@ from pheval.post_processing.post_processing import (
     ResultSorter,
 )
 
+pheval_gene_result = [
+    PhEvalGeneResult(
+        gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
+    ),
+    PhEvalGeneResult(
+        gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
+    ),
+    PhEvalGeneResult(
+        gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529
+    ),
+    PhEvalGeneResult(
+        gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235
+    ),
+]
+pheval_variant_result = [
+    PhEvalVariantResult(
+        chromosome="5",
+        start=23457444233,
+        end=23457444234,
+        ref="A",
+        alt="C",
+        score=0.9348,
+    ),
+    PhEvalVariantResult(
+        chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
+    ),
+    PhEvalVariantResult(
+        chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
+    ),
+    PhEvalVariantResult(
+        chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
+    ),
+]
+
 
 class TestResultSorter(unittest.TestCase):
     def setUp(self) -> None:
         self.gene_results = ResultSorter(
-            pheval_results=[
-                PhEvalGeneResult(
-                    gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
-                ),
-                PhEvalGeneResult(
-                    gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
-                ),
-                PhEvalGeneResult(
-                    gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529
-                ),
-                PhEvalGeneResult(
-                    gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235
-                ),
-            ],
+            pheval_results=pheval_gene_result,
             ranking_method="combinedScore",
         )
         self.variant_results = ResultSorter(
-            pheval_results=[
-                PhEvalVariantResult(
-                    chromosome="5",
-                    start=23457444233,
-                    end=23457444234,
-                    ref="A",
-                    alt="C",
-                    score=0.9348,
-                ),
-                PhEvalVariantResult(
-                    chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
-                ),
-                PhEvalVariantResult(
-                    chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
-                ),
-                PhEvalVariantResult(
-                    chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
-                ),
-            ],
+            pheval_results=pheval_variant_result,
             ranking_method="pValue",
         )
 
@@ -134,3 +137,8 @@ class TestResultSorter(unittest.TestCase):
                 ),
             ],
         )
+
+
+class TestScoreRanker(unittest.TestCase):
+    def test_rank_scores(self):
+        assert False

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -8,7 +8,7 @@ from pheval.post_processing.post_processing import (
     ResultSorter,
     ScoreRanker,
     create_pheval_result,
-    rank_pheval_result,
+    _rank_pheval_result,
 )
 
 pheval_gene_result = [
@@ -94,7 +94,7 @@ class TestResultSorter(unittest.TestCase):
 
     def test_sort_by_decreasing_score(self):
         self.assertEqual(
-            self.gene_results.sort_by_decreasing_score(),
+            self.gene_results._sort_by_decreasing_score(),
             [
                 PhEvalGeneResult(
                     gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
@@ -113,7 +113,7 @@ class TestResultSorter(unittest.TestCase):
 
     def test_sort_by_increasing_score(self):
         self.assertEqual(
-            self.variant_results.sort_by_increasing_score(),
+            self.variant_results._sort_by_increasing_score(),
             [
                 PhEvalVariantResult(
                     chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
@@ -137,7 +137,7 @@ class TestResultSorter(unittest.TestCase):
 
     def test_sort_pheval_results_not_pvalue(self):
         self.assertEqual(
-            self.gene_results.sort_pheval_results(),
+            self.gene_results._sort_pheval_results(),
             [
                 PhEvalGeneResult(
                     gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
@@ -156,7 +156,7 @@ class TestResultSorter(unittest.TestCase):
 
     def test_sort_pheval_results_pvalue(self):
         self.assertEqual(
-            self.variant_results.sort_pheval_results(),
+            self.variant_results._sort_pheval_results(),
             [
                 PhEvalVariantResult(
                     chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
@@ -184,22 +184,22 @@ class TestScoreRanker(unittest.TestCase):
         self.score_ranker = ScoreRanker()
 
     def test_rank_scores_first_rank(self):
-        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker._rank_scores(0.7342), 1)
 
     def test_rank_scores_increase_rank(self):
-        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker._rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
 
     def test_rank_scores_same_rank(self):
-        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker._rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
 
     def test_rank_scores_count_increase(self):
-        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
-        self.assertEqual(self.score_ranker.rank_scores(0.1234), 4)
+        self.assertEqual(self.score_ranker._rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker._rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker._rank_scores(0.1234), 4)
 
 
 class TestRankPhEvalResults(unittest.TestCase):
@@ -235,7 +235,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 
     def test_rank_pheval_results_gene(self):
         self.assertTrue(
-            rank_pheval_result(self.sorted_gene_result),
+            _rank_pheval_result(self.sorted_gene_result),
             [
                 RankedPhEvalGeneResult(
                     pheval_gene_result=PhEvalGeneResult(
@@ -266,7 +266,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 
     def test_rank_pheval_results_variant(self):
         self.assertEqual(
-            rank_pheval_result(self.sorted_variant_result),
+            _rank_pheval_result(self.sorted_variant_result),
             [
                 RankedPhEvalVariantResult(
                     pheval_variant_result=PhEvalVariantResult(

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -3,8 +3,11 @@ import unittest
 from pheval.post_processing.post_processing import (
     PhEvalGeneResult,
     PhEvalVariantResult,
+    RankedPhEvalGeneResult,
+    RankedPhEvalVariantResult,
     ResultSorter,
     ScoreRanker,
+    rank_pheval_results,
 )
 
 pheval_gene_result = [
@@ -151,3 +154,107 @@ class TestScoreRanker(unittest.TestCase):
         self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
         self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
         self.assertEqual(self.score_ranker.rank_scores(0.1234), 4)
+
+
+class TestRankPhEvalResults(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.sorted_gene_result = [
+            PhEvalGeneResult(
+                gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
+            ),
+            PhEvalGeneResult(gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529),
+            PhEvalGeneResult(gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529),
+            PhEvalGeneResult(gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235),
+        ]
+        cls.sorted_variant_result = [
+            PhEvalVariantResult(
+                chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
+            ),
+            PhEvalVariantResult(
+                chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
+            ),
+            PhEvalVariantResult(
+                chromosome="5",
+                start=23457444233,
+                end=23457444234,
+                ref="A",
+                alt="C",
+                score=0.9348,
+            ),
+            PhEvalVariantResult(
+                chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
+            ),
+        ]
+
+    def test_rank_pheval_results_gene(self):
+        self.assertTrue(
+            rank_pheval_results(self.sorted_gene_result),
+            [
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
+                    ),
+                    rank=1,
+                ),
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
+                    ),
+                    rank=2,
+                ),
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529
+                    ),
+                    rank=2,
+                ),
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235
+                    ),
+                    rank=4,
+                ),
+            ],
+        )
+
+    def test_rank_pheval_results_variant(self):
+        self.assertEqual(
+            rank_pheval_results(self.sorted_variant_result),
+            [
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
+                    ),
+                    rank=1,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
+                    ),
+                    rank=2,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="5",
+                        start=23457444233,
+                        end=23457444234,
+                        ref="A",
+                        alt="C",
+                        score=0.9348,
+                    ),
+                    rank=3,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="12",
+                        start=12754332,
+                        end=12754333,
+                        ref="T",
+                        alt="G",
+                        score=0.9999,
+                    ),
+                    rank=4,
+                ),
+            ],
+        )

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -9,7 +9,7 @@ from pheval.post_processing.post_processing import (
     ScoreRanker,
     SortOrder,
     create_pheval_result,
-    rank_pheval_result,
+    rank_pheval_result, return_sort_order,
 )
 
 pheval_gene_result = [
@@ -393,3 +393,15 @@ class TestCreatePhEvalResult(unittest.TestCase):
                 ),
             ],
         )
+
+
+class TestReturnSortOrder(unittest.TestCase):
+    def test_return_sort_order(self):
+        self.assertEqual(return_sort_order("ascending"), SortOrder.ASCENDING)
+        self.assertEqual(return_sort_order("descending"), SortOrder.DESCENDING)
+
+    def test_return_sort_order_incompatible(self):
+        with self.assertRaises(ValueError):
+            return_sort_order("null")
+
+

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -94,7 +94,7 @@ class TestResultSorter(unittest.TestCase):
 
     def test_sort_pheval_results_not_pvalue(self):
         self.assertEqual(
-            self.gene_results.sort_by_decreasing_score(),
+            self.gene_results.sort_pheval_results(),
             [
                 PhEvalGeneResult(
                     gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
@@ -113,7 +113,7 @@ class TestResultSorter(unittest.TestCase):
 
     def test_sort_pheval_results_pvalue(self):
         self.assertEqual(
-            self.variant_results.sort_by_increasing_score(),
+            self.variant_results.sort_pheval_results(),
             [
                 PhEvalVariantResult(
                     chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -1,36 +1,136 @@
 import unittest
 
-from pheval.post_processing.post_processing import ResultSorter, PhEvalGeneResult, PhEvalVariantResult
+from pheval.post_processing.post_processing import (
+    PhEvalGeneResult,
+    PhEvalVariantResult,
+    ResultSorter,
+)
 
 
 class TestResultSorter(unittest.TestCase):
     def setUp(self) -> None:
-        self.gene_results = ResultSorter(pheval_results=[
-            PhEvalGeneResult(gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529),
-            PhEvalGeneResult(gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234),
-            PhEvalGeneResult(gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529),
-            PhEvalGeneResult(gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235)
-
-        ], ranking_method="combinedScore")
-        self.variant_results = ResultSorter(pheval_results=[PhEvalVariantResult(chromosome="5", start=23457444233,
-                                                                                end=23457444234, ref="A", alt="C",
-                                                                                score=0.9348),
-                                                            PhEvalVariantResult(chromosome="12", start=12754332,
-                                                                                end=12754333, ref="T", alt="G",
-                                                                                score=0.9999),
-                                                            PhEvalVariantResult(chromosome="X", start=93473023,
-                                                                                end=93473024, ref="A", alt="G",
-                                                                                score=0.1245),
-                                                            PhEvalVariantResult(chromosome="8", start=532356,
-                                                                                end=532357, ref="A", alt="C",
-                                                                                score=0.4578)
-                                                            ], ranking_method="pValue")
+        self.gene_results = ResultSorter(
+            pheval_results=[
+                PhEvalGeneResult(
+                    gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235
+                ),
+            ],
+            ranking_method="combinedScore",
+        )
+        self.variant_results = ResultSorter(
+            pheval_results=[
+                PhEvalVariantResult(
+                    chromosome="5",
+                    start=23457444233,
+                    end=23457444234,
+                    ref="A",
+                    alt="C",
+                    score=0.9348,
+                ),
+                PhEvalVariantResult(
+                    chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
+                ),
+                PhEvalVariantResult(
+                    chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
+                ),
+                PhEvalVariantResult(
+                    chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
+                ),
+            ],
+            ranking_method="pValue",
+        )
 
     def test_sort_by_decreasing_score(self):
-        assert False
+        self.assertEqual(
+            self.gene_results.sort_by_decreasing_score(),
+            [
+                PhEvalGeneResult(
+                    gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235
+                ),
+            ],
+        )
 
     def test_sort_by_increasing_score(self):
-        assert False
+        self.assertEqual(
+            self.variant_results.sort_by_increasing_score(),
+            [
+                PhEvalVariantResult(
+                    chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
+                ),
+                PhEvalVariantResult(
+                    chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
+                ),
+                PhEvalVariantResult(
+                    chromosome="5",
+                    start=23457444233,
+                    end=23457444234,
+                    ref="A",
+                    alt="C",
+                    score=0.9348,
+                ),
+                PhEvalVariantResult(
+                    chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
+                ),
+            ],
+        )
 
-    def test_sort_pheval_results(self):
-        assert False
+    def test_sort_pheval_results_not_pvalue(self):
+        self.assertEqual(
+            self.gene_results.sort_by_decreasing_score(),
+            [
+                PhEvalGeneResult(
+                    gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529
+                ),
+                PhEvalGeneResult(
+                    gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235
+                ),
+            ],
+        )
+
+    def test_sort_pheval_results_pvalue(self):
+        self.assertEqual(
+            self.variant_results.sort_by_increasing_score(),
+            [
+                PhEvalVariantResult(
+                    chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
+                ),
+                PhEvalVariantResult(
+                    chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
+                ),
+                PhEvalVariantResult(
+                    chromosome="5",
+                    start=23457444233,
+                    end=23457444234,
+                    ref="A",
+                    alt="C",
+                    score=0.9348,
+                ),
+                PhEvalVariantResult(
+                    chromosome="12", start=12754332, end=12754333, ref="T", alt="G", score=0.9999
+                ),
+            ],
+        )

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -8,7 +8,7 @@ from pheval.post_processing.post_processing import (
     ResultSorter,
     ScoreRanker,
     create_pheval_result,
-    _rank_pheval_result,
+    rank_pheval_result, SortOrder,
 )
 
 pheval_gene_result = [
@@ -85,11 +85,11 @@ class TestResultSorter(unittest.TestCase):
     def setUp(self) -> None:
         self.gene_results = ResultSorter(
             pheval_results=pheval_gene_result,
-            ranking_method="combinedScore",
+            sort_order=SortOrder.DESCENDING,
         )
         self.variant_results = ResultSorter(
             pheval_results=pheval_variant_result,
-            ranking_method="pValue",
+            sort_order=SortOrder.ASCENDING,
         )
 
     def test_sort_by_decreasing_score(self):
@@ -136,6 +136,7 @@ class TestResultSorter(unittest.TestCase):
         )
 
     def test_sort_pheval_results_not_pvalue(self):
+        print(self.gene_results.sort_order)
         self.assertEqual(
             self.gene_results.sort_pheval_results(),
             [
@@ -181,7 +182,7 @@ class TestResultSorter(unittest.TestCase):
 
 class TestScoreRanker(unittest.TestCase):
     def setUp(self) -> None:
-        self.score_ranker = ScoreRanker()
+        self.score_ranker = ScoreRanker(SortOrder.DESCENDING)
 
     def test_rank_scores_first_rank(self):
         self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
@@ -235,7 +236,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 
     def test_rank_pheval_results_gene(self):
         self.assertTrue(
-            _rank_pheval_result(self.sorted_gene_result),
+            rank_pheval_result(self.sorted_gene_result, SortOrder.DESCENDING),
             [
                 RankedPhEvalGeneResult(
                     pheval_gene_result=PhEvalGeneResult(
@@ -266,7 +267,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 
     def test_rank_pheval_results_variant(self):
         self.assertEqual(
-            _rank_pheval_result(self.sorted_variant_result),
+            rank_pheval_result(self.sorted_variant_result, SortOrder.ASCENDING),
             [
                 RankedPhEvalVariantResult(
                     pheval_variant_result=PhEvalVariantResult(
@@ -309,7 +310,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 class TestCreatePhEvalResult(unittest.TestCase):
     def test_create_pheval_result_gene(self):
         self.assertEqual(
-            create_pheval_result(pheval_gene_result, "combinedScore"),
+            create_pheval_result(pheval_gene_result, SortOrder.DESCENDING),
             [
                 RankedPhEvalGeneResult(
                     pheval_gene_result=PhEvalGeneResult(
@@ -340,7 +341,7 @@ class TestCreatePhEvalResult(unittest.TestCase):
 
     def test_create_pheval_result_variant(self):
         self.assertEqual(
-            create_pheval_result(pheval_variant_result, "pValue"),
+            create_pheval_result(pheval_variant_result, SortOrder.ASCENDING),
             [
                 RankedPhEvalVariantResult(
                     pheval_variant_result=PhEvalVariantResult(

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -3,7 +3,7 @@ import unittest
 from pheval.post_processing.post_processing import (
     PhEvalGeneResult,
     PhEvalVariantResult,
-    ResultSorter,
+    ResultSorter, ScoreRanker,
 )
 
 pheval_gene_result = [
@@ -140,5 +140,23 @@ class TestResultSorter(unittest.TestCase):
 
 
 class TestScoreRanker(unittest.TestCase):
-    def test_rank_scores(self):
-        assert False
+    def setUp(self) -> None:
+        self.score_ranker = ScoreRanker()
+
+    def test_rank_scores_first_rank(self):
+        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+
+    def test_rank_scores_increase_rank(self):
+        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+
+    def test_rank_scores_same_rank(self):
+        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+
+    def test_rank_scores_count_increase(self):
+        self.assertEqual(self.score_ranker.rank_scores(0.7342), 1)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker.rank_scores(0.3452), 2)
+        self.assertEqual(self.score_ranker.rank_scores(0.1234), 4)

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -3,22 +3,15 @@ import unittest
 from pheval.post_processing.post_processing import (
     PhEvalGeneResult,
     PhEvalVariantResult,
-    ResultSorter, ScoreRanker,
+    ResultSorter,
+    ScoreRanker,
 )
 
 pheval_gene_result = [
-    PhEvalGeneResult(
-        gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529
-    ),
-    PhEvalGeneResult(
-        gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234
-    ),
-    PhEvalGeneResult(
-        gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529
-    ),
-    PhEvalGeneResult(
-        gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235
-    ),
+    PhEvalGeneResult(gene_symbol="A4GNT", gene_identifier="ENSG00000118017", score=0.6529),
+    PhEvalGeneResult(gene_symbol="MAP3K14", gene_identifier="ENSG00000006062", score=0.9234),
+    PhEvalGeneResult(gene_symbol="OR14J1", gene_identifier="ENSG00000204695", score=0.6529),
+    PhEvalGeneResult(gene_symbol="PAGE1", gene_identifier="ENSG00000068985", score=0.5235),
 ]
 pheval_variant_result = [
     PhEvalVariantResult(
@@ -35,9 +28,7 @@ pheval_variant_result = [
     PhEvalVariantResult(
         chromosome="X", start=93473023, end=93473024, ref="A", alt="G", score=0.1245
     ),
-    PhEvalVariantResult(
-        chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578
-    ),
+    PhEvalVariantResult(chromosome="8", start=532356, end=532357, ref="A", alt="C", score=0.4578),
 ]
 
 


### PR DESCRIPTION
These methods include sorting tool-specific output that has been post-processed to the PhEval gene/variant dataclasses in descending order with "best" scores first and assigning ranks to these results.