### PR TITLE
56 merge multi input and single input commands

### DIFF
--- a/src/pheval/cli.py
+++ b/src/pheval/cli.py
@@ -7,12 +7,12 @@ from pheval.analyse.analysis import benchmark, benchmark_comparison
 
 from .cli_pheval import run
 from .cli_pheval_utils import (
+    create_spiked_vcfs_command,
     scramble_phenopackets_command,
     scramble_semsim,
     semsim_comparison,
     update_phenopackets_command,
 )
-from .prepare.create_spiked_vcf import create_spiked_vcf_command, create_spiked_vcfs_command
 
 info_log = logging.getLogger("info")
 
@@ -55,7 +55,6 @@ pheval_utils.add_command(semsim_comparison)
 pheval_utils.add_command(scramble_phenopackets_command)
 pheval_utils.add_command(update_phenopackets_command)
 pheval_utils.add_command(create_spiked_vcfs_command)
-pheval_utils.add_command(create_spiked_vcf_command)
 pheval_utils.add_command(benchmark)
 pheval_utils.add_command(benchmark_comparison)
 

--- a/src/pheval/cli.py
+++ b/src/pheval/cli.py
@@ -4,13 +4,14 @@ import logging
 import click
 
 from pheval.analyse.analysis import benchmark, benchmark_comparison
-from pheval.prepare.update_phenopacket import (
-    update_phenopacket_command,
-    update_phenopackets_command,
-)
 
 from .cli_pheval import run
-from .cli_pheval_utils import scramble_phenopackets_command, scramble_semsim, semsim_comparison
+from .cli_pheval_utils import (
+    scramble_phenopackets_command,
+    scramble_semsim,
+    semsim_comparison,
+    update_phenopackets_command,
+)
 from .prepare.create_spiked_vcf import create_spiked_vcf_command, create_spiked_vcfs_command
 
 info_log = logging.getLogger("info")
@@ -52,7 +53,6 @@ def pheval_utils():
 pheval_utils.add_command(scramble_semsim)
 pheval_utils.add_command(semsim_comparison)
 pheval_utils.add_command(scramble_phenopackets_command)
-pheval_utils.add_command(update_phenopacket_command)
 pheval_utils.add_command(update_phenopackets_command)
 pheval_utils.add_command(create_spiked_vcfs_command)
 pheval_utils.add_command(create_spiked_vcf_command)

--- a/src/pheval/cli.py
+++ b/src/pheval/cli.py
@@ -10,11 +10,7 @@ from pheval.prepare.update_phenopacket import (
 )
 
 from .cli_pheval import run
-from .cli_pheval_utils import scramble_semsim, semsim_comparison
-from .prepare.create_noisy_phenopackets import (
-    scramble_phenopacket_command,
-    scramble_phenopackets_command,
-)
+from .cli_pheval_utils import scramble_phenopackets_command, scramble_semsim, semsim_comparison
 from .prepare.create_spiked_vcf import create_spiked_vcf_command, create_spiked_vcfs_command
 
 info_log = logging.getLogger("info")
@@ -56,7 +52,6 @@ def pheval_utils():
 pheval_utils.add_command(scramble_semsim)
 pheval_utils.add_command(semsim_comparison)
 pheval_utils.add_command(scramble_phenopackets_command)
-pheval_utils.add_command(scramble_phenopacket_command)
 pheval_utils.add_command(update_phenopacket_command)
 pheval_utils.add_command(update_phenopackets_command)
 pheval_utils.add_command(create_spiked_vcfs_command)

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -6,6 +6,7 @@ import click
 
 from pheval.prepare.create_noisy_phenopackets import scramble_phenopackets
 from pheval.prepare.custom_exceptions import InputError, MutuallyExclusiveOptionError
+from pheval.prepare.update_phenopacket import update_phenopackets
 from pheval.utils.semsim_utils import percentage_diff, semsim_heatmap_plot
 
 
@@ -137,3 +138,49 @@ def semsim_comparison(
         return semsim_heatmap_plot(semsim_left, semsim_right, score_column)
     if analysis == "percentage_diff":
         percentage_diff(semsim_left, semsim_right, score_column, output)
+
+
+@click.command("update-phenopackets")
+@click.option(
+    "--phenopacket-path",
+    "-p",
+    metavar="PATH",
+    help="Path to phenopacket.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["phenopacket_dir"],
+)
+@click.option(
+    "--phenopacket-dir",
+    "-p",
+    metavar="PATH",
+    required=True,
+    help="Path to phenopacket directory for updating.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["phenopacket_path"],
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    metavar="PATH",
+    required=True,
+    help="Path to write phenopacket.",
+    type=Path,
+)
+@click.option(
+    "--gene-identifier",
+    "-g",
+    required=False,
+    default="ensembl_id",
+    show_default=True,
+    help="Gene identifier to add to phenopacket",
+    type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
+)
+def update_phenopackets_command(
+    phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
+):
+    """Update gene symbols and identifiers for phenopackets."""
+    if phenopacket_path is None and phenopacket_dir is None:
+        raise InputError("Either a phenopacket or phenopacket directory must be specified")
+    update_phenopackets(gene_identifier, phenopacket_path, phenopacket_dir, output_dir)

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -152,7 +152,7 @@ def semsim_comparison(
 )
 @click.option(
     "--phenopacket-dir",
-    "-p",
+    "-P",
     metavar="PATH",
     help="Path to phenopacket directory for updating.",
     type=Path,

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 
 from pheval.prepare.create_noisy_phenopackets import scramble_phenopackets
+from pheval.prepare.create_spiked_vcf import spike_vcfs
 from pheval.prepare.custom_exceptions import InputError, MutuallyExclusiveOptionError
 from pheval.prepare.update_phenopacket import update_phenopackets
 from pheval.utils.semsim_utils import percentage_diff, semsim_heatmap_plot
@@ -183,3 +184,63 @@ def update_phenopackets_command(
     if phenopacket_path is None and phenopacket_dir is None:
         raise InputError("Either a phenopacket or phenopacket directory must be specified")
     update_phenopackets(gene_identifier, phenopacket_path, phenopacket_dir, output_dir)
+
+
+@click.command("create-spiked-vcfs")
+@click.option(
+    "--phenopacket-path",
+    "-p",
+    metavar="PATH",
+    help="Path to phenopacket.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["phenopacket_dir"],
+)
+@click.option(
+    "--phenopacket-dir",
+    "-P",
+    metavar="PATH",
+    help="Path to phenopacket directory for updating.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["phenopacket_path"],
+)
+@click.option(
+    "--template-vcf-path",
+    "-t",
+    cls=MutuallyExclusiveOptionError,
+    metavar="PATH",
+    required=False,
+    help="Template VCF file",
+    mutually_exclusive=["vcf_dir"],
+    type=Path,
+)
+@click.option(
+    "--vcf-dir",
+    "-v",
+    cls=MutuallyExclusiveOptionError,
+    metavar="PATH",
+    help="Directory containing template VCF files",
+    mutually_exclusive=["template_vcf"],
+    type=Path,
+)
+@click.option(
+    "--output-dir",
+    "-O",
+    metavar="PATH",
+    required=True,
+    help="Path for creation of output directory",
+    default="vcf",
+    type=Path,
+)
+def create_spiked_vcfs_command(
+    phenopacket_path: Path,
+    phenopacket_dir: Path,
+    output_dir: Path,
+    template_vcf_path: Path = None,
+    vcf_dir: Path = None,
+):
+    """Spikes variants into a template VCF file for a directory of phenopackets."""
+    if phenopacket_path is None and phenopacket_dir is None:
+        raise InputError("Either a phenopacket or phenopacket directory must be specified")
+    spike_vcfs(output_dir, phenopacket_path, phenopacket_dir, template_vcf_path, vcf_dir)

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -154,7 +154,6 @@ def semsim_comparison(
     "--phenopacket-dir",
     "-p",
     metavar="PATH",
-    required=True,
     help="Path to phenopacket directory for updating.",
     type=Path,
     cls=MutuallyExclusiveOptionError,

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 
 from pheval.prepare.create_noisy_phenopackets import create_scrambled_phenopackets
+from pheval.prepare.custom_exceptions import MutuallyExclusiveOptionError
 from pheval.utils.semsim_utils import percentage_diff, semsim_heatmap_plot
 
 
@@ -27,7 +28,7 @@ def scramble_semsim(input: Path):
     "-P",
     metavar="PATH",
     required=True,
-    help="Path to phenopackets directory",
+    help="Path to phenopackets directory."
 )
 @click.option(
     "--scramble-factor",
@@ -40,13 +41,6 @@ def scramble_semsim(input: Path):
     type=float,
 )
 @click.option(
-    "--output-file-suffix",
-    "-o",
-    metavar="<str>",
-    required=True,
-    help="Suffix to append to output file",
-)
-@click.option(
     "--output-dir",
     "-O",
     metavar="PATH",
@@ -57,11 +51,10 @@ def scramble_semsim(input: Path):
 def scramble_phenopackets_command(
     phenopacket_dir: Path,
     scramble_factor: float,
-    output_file_suffix: str,
     output_dir: Path,
 ):
     """Generate noisy phenopackets from existing ones."""
-    create_scrambled_phenopackets(output_dir, output_file_suffix, phenopacket_dir, scramble_factor)
+    create_scrambled_phenopackets(output_dir, phenopacket_dir, scramble_factor)
 
 
 @click.command("semsim-comparison")

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import click
 
-from pheval.prepare.create_noisy_phenopackets import create_scrambled_phenopackets
-from pheval.prepare.custom_exceptions import MutuallyExclusiveOptionError
+from pheval.prepare.create_noisy_phenopackets import scramble_phenopackets
+from pheval.prepare.custom_exceptions import InputError, MutuallyExclusiveOptionError
 from pheval.utils.semsim_utils import percentage_diff, semsim_heatmap_plot
 
 
@@ -24,11 +24,22 @@ def scramble_semsim(input: Path):
 
 @click.command("scramble-phenopackets")
 @click.option(
+    "--phenopacket-path",
+    "-p",
+    metavar="PATH",
+    help="Path to phenopacket.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["phenopacket_dir"],
+)
+@click.option(
     "--phenopacket-dir",
     "-P",
     metavar="PATH",
-    required=True,
-    help="Path to phenopackets directory."
+    help="Path to phenopackets directory.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["phenopacket_path"],
 )
 @click.option(
     "--scramble-factor",
@@ -47,14 +58,19 @@ def scramble_semsim(input: Path):
     required=True,
     help="Path for creation of output directory",
     default="noisy_phenopackets",
+    type=Path,
 )
 def scramble_phenopackets_command(
+    phenopacket_path: Path,
     phenopacket_dir: Path,
     scramble_factor: float,
     output_dir: Path,
 ):
     """Generate noisy phenopackets from existing ones."""
-    create_scrambled_phenopackets(output_dir, phenopacket_dir, scramble_factor)
+    if phenopacket_path is None and phenopacket_dir is None:
+        raise InputError("Either a phenopacket or phenopacket directory must be specified")
+    else:
+        scramble_phenopackets(output_dir, phenopacket_path, phenopacket_dir, scramble_factor)
 
 
 @click.command("semsim-comparison")

--- a/src/pheval/prepare/create_noisy_phenopackets.py
+++ b/src/pheval/prepare/create_noisy_phenopackets.py
@@ -1,7 +1,6 @@
 import random
 from pathlib import Path
 
-import click
 from oaklib.implementations.pronto.pronto_implementation import ProntoImplementation
 from oaklib.resource import OntologyResource
 from phenopackets import Family, OntologyClass, Phenopacket, PhenotypicFeature
@@ -123,7 +122,7 @@ def add_noise_to_phenotypic_profile(
 
 def create_scrambled_phenopacket(
     output_dir: Path, phenopacket_path: Path, scramble_factor: float
-):
+) -> None:
     """Creates a scrambled phenopacket."""
     try:
         output_dir.mkdir()
@@ -138,15 +137,13 @@ def create_scrambled_phenopacket(
     )
     write_phenopacket(
         created_noisy_phenopacket,
-        output_dir.joinpath(
-            phenopacket_path.name
-        ),
+        output_dir.joinpath(phenopacket_path.name),
     )
 
 
 def create_scrambled_phenopackets(
     output_dir: Path, phenopacket_dir: Path, scramble_factor: float
-):
+) -> None:
     """Creates scrambled phenopackets."""
     try:
         output_dir.mkdir()
@@ -166,75 +163,11 @@ def create_scrambled_phenopackets(
         )
 
 
-@click.command("scramble-phenopacket")
-@click.option(
-    "--phenopacket-path",
-    "-P",
-    metavar="PATH",
-    required=True,
-    help="Path to phenopacket to be randomised",
-    type=Path,
-)
-@click.option(
-    "--scramble-factor",
-    "-s",
-    metavar=float,
-    required=True,
-    default=0.5,
-    show_default=True,
-    help="Scramble factor for randomising phenopacket phenotypic profiles.",
-    type=float,
-)
-@click.option(
-    "--output-dir",
-    "-O",
-    metavar="PATH",
-    required=True,
-    help="Path for creation of output directory",
-    default="noisy_phenopackets",
-    type=Path,
-)
-def scramble_phenopacket_command(
-    phenopacket_path: Path,
-    scramble_factor: float,
-    output_dir: Path,
-):
-    """Generate a noisy phenopacket from an existing one."""
-    create_scrambled_phenopacket(output_dir, phenopacket_path, scramble_factor)
-
-
-@click.command("scramble-phenopackets")
-@click.option(
-    "--phenopacket-dir",
-    "-P",
-    metavar="PATH",
-    required=True,
-    help="Path to phenopackets directory",
-    type=Path,
-)
-@click.option(
-    "--scramble-factor",
-    "-s",
-    metavar=float,
-    required=True,
-    default=0.5,
-    show_default=True,
-    help="Scramble factor for randomising phenopacket phenotypic profiles.",
-    type=float,
-)
-@click.option(
-    "--output-dir",
-    "-O",
-    metavar="PATH",
-    required=True,
-    help="Path for creation of output directory",
-    default="noisy_phenopackets",
-    type=Path,
-)
-def scramble_phenopackets_command(
-    phenopacket_dir: Path,
-    scramble_factor: float,
-    output_dir: Path,
-):
-    """Generate noisy phenopackets from existing ones."""
-    create_scrambled_phenopackets(output_dir, phenopacket_dir, scramble_factor)
+def scramble_phenopackets(
+    output_dir: Path, phenopacket_path: Path, phenopacket_dir: Path, scramble_factor: float
+) -> None:
+    """Create scrambled phenopackets from either a single phenopacket or directory of phenopackets."""
+    if phenopacket_path is not None:
+        create_scrambled_phenopacket(output_dir, phenopacket_path, scramble_factor)
+    elif phenopacket_dir is not None:
+        create_scrambled_phenopackets(output_dir, phenopacket_dir, scramble_factor)

--- a/src/pheval/prepare/create_noisy_phenopackets.py
+++ b/src/pheval/prepare/create_noisy_phenopackets.py
@@ -122,7 +122,7 @@ def add_noise_to_phenotypic_profile(
 
 
 def create_scrambled_phenopacket(
-    output_dir: Path, output_file_suffix: str, phenopacket_path: Path, scramble_factor: float
+    output_dir: Path, phenopacket_path: Path, scramble_factor: float
 ):
     """Creates a scrambled phenopacket."""
     try:
@@ -139,13 +139,13 @@ def create_scrambled_phenopacket(
     write_phenopacket(
         created_noisy_phenopacket,
         output_dir.joinpath(
-            phenopacket_path.stem + "-" + output_file_suffix + phenopacket_path.suffix
+            phenopacket_path.name
         ),
     )
 
 
 def create_scrambled_phenopackets(
-    output_dir: Path, output_file_suffix: str, phenopacket_dir: Path, scramble_factor: float
+    output_dir: Path, phenopacket_dir: Path, scramble_factor: float
 ):
     """Creates scrambled phenopackets."""
     try:
@@ -161,7 +161,7 @@ def create_scrambled_phenopackets(
         write_phenopacket(
             created_noisy_phenopacket,
             output_dir.joinpath(
-                phenopacket_path.stem + "-" + output_file_suffix + phenopacket_path.suffix,
+                phenopacket_path.name,
             ),
         )
 
@@ -186,13 +186,6 @@ def create_scrambled_phenopackets(
     type=float,
 )
 @click.option(
-    "--output-file-suffix",
-    "-o",
-    metavar="<str>",
-    required=True,
-    help="Suffix to append to output file",
-)
-@click.option(
     "--output-dir",
     "-O",
     metavar="PATH",
@@ -204,11 +197,10 @@ def create_scrambled_phenopackets(
 def scramble_phenopacket_command(
     phenopacket_path: Path,
     scramble_factor: float,
-    output_file_suffix: str,
     output_dir: Path,
 ):
     """Generate a noisy phenopacket from an existing one."""
-    create_scrambled_phenopacket(output_dir, output_file_suffix, phenopacket_path, scramble_factor)
+    create_scrambled_phenopacket(output_dir, phenopacket_path, scramble_factor)
 
 
 @click.command("scramble-phenopackets")
@@ -231,13 +223,6 @@ def scramble_phenopacket_command(
     type=float,
 )
 @click.option(
-    "--output-file-suffix",
-    "-o",
-    metavar="<str>",
-    required=True,
-    help="Suffix to append to output file",
-)
-@click.option(
     "--output-dir",
     "-O",
     metavar="PATH",
@@ -249,8 +234,7 @@ def scramble_phenopacket_command(
 def scramble_phenopackets_command(
     phenopacket_dir: Path,
     scramble_factor: float,
-    output_file_suffix: str,
     output_dir: Path,
 ):
     """Generate noisy phenopackets from existing ones."""
-    create_scrambled_phenopackets(output_dir, output_file_suffix, phenopacket_dir, scramble_factor)
+    create_scrambled_phenopackets(output_dir, phenopacket_dir, scramble_factor)

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -6,7 +6,6 @@ from copy import copy
 from dataclasses import dataclass
 from pathlib import Path
 
-import click
 from phenopackets import Family, File, Phenopacket
 
 from pheval.utils.phenopacket_utils import (
@@ -18,7 +17,7 @@ from pheval.utils.phenopacket_utils import (
     write_phenopacket,
 )
 
-from .custom_exceptions import InputError, MutuallyExclusiveOptionError
+from .custom_exceptions import InputError
 from ..utils.file_utils import all_files, files_with_suffix, is_gzipped
 
 info_log = logging.getLogger("info")
@@ -341,92 +340,15 @@ def create_spiked_vcfs(
     # ".json"]
 
 
-@click.command("create-spiked-vcf")
-@click.option(
-    "--phenopacket-path",
-    "-p",
-    metavar="FILE",
-    required=True,
-    help="Path to phenopacket file",
-    type=Path,
-)
-@click.option(
-    "--template-vcf-path",
-    "-t",
-    cls=MutuallyExclusiveOptionError,
-    metavar="FILE",
-    required=False,
-    help="Template VCF file",
-    mutually_exclusive=["vcf_dir"],
-    type=Path,
-)
-@click.option(
-    "--vcf-dir",
-    "-v",
-    cls=MutuallyExclusiveOptionError,
-    metavar="PATH",
-    help="Directory containing template VCF files",
-    mutually_exclusive=["template_vcf"],
-    type=Path,
-)
-@click.option(
-    "--output-dir",
-    "-O",
-    metavar="PATH",
-    required=True,
-    help="Path for creation of output directory",
-    default="vcf",
-    type=Path,
-)
-def create_spiked_vcf_command(
-    phenopacket_path: Path, output_dir: Path, template_vcf_path: Path = None, vcf_dir: Path = None
-):
-    """Spikes variants into a template VCF file for a single phenopacket."""
-    create_spiked_vcf(output_dir, phenopacket_path, template_vcf_path, vcf_dir)
-
-
-@click.command("create-spiked-vcfs")
-@click.option(
-    "--phenopacket-dir",
-    "-p",
-    metavar="PATH",
-    required=True,
-    help="Path to phenopackets directory",
-    type=Path,
-)
-@click.option(
-    "--template-vcf-path",
-    "-t",
-    cls=MutuallyExclusiveOptionError,
-    metavar="PATH",
-    required=False,
-    help="Template VCF file",
-    mutually_exclusive=["vcf_dir"],
-    type=Path,
-)
-@click.option(
-    "--vcf-dir",
-    "-v",
-    cls=MutuallyExclusiveOptionError,
-    metavar="PATH",
-    help="Directory containing template VCF files",
-    mutually_exclusive=["template_vcf"],
-    type=Path,
-)
-@click.option(
-    "--output-dir",
-    "-O",
-    metavar="PATH",
-    required=True,
-    help="Path for creation of output directory",
-    default="vcf",
-    type=Path,
-)
-def create_spiked_vcfs_command(
-    phenopacket_dir: Path,
+def spike_vcfs(
     output_dir: Path,
-    template_vcf_path: Path = None,
-    vcf_dir: Path = None,
+    phenopacket_path: Path,
+    phenopacket_dir: Path,
+    template_vcf_path: Path,
+    vcf_dir: Path,
 ):
-    """Spikes variants into a template VCF file for a directory of phenopackets."""
-    create_spiked_vcfs(output_dir, phenopacket_dir, template_vcf_path, vcf_dir)
+    """Create spiked VCF from either a phenopacket or a phenopacket directory."""
+    if phenopacket_path is not None:
+        create_spiked_vcf(output_dir, phenopacket_path, template_vcf_path, vcf_dir)
+    elif phenopacket_dir is not None:
+        create_spiked_vcfs(output_dir, phenopacket_dir, template_vcf_path, vcf_dir)

--- a/src/pheval/prepare/update_phenopacket.py
+++ b/src/pheval/prepare/update_phenopacket.py
@@ -1,8 +1,6 @@
 from collections import defaultdict
 from pathlib import Path
 
-import click
-
 from pheval.utils.file_utils import all_files
 from pheval.utils.phenopacket_utils import (
     GeneIdentifierUpdater,
@@ -27,14 +25,14 @@ def update_outdated_gene_context(
     return PhenopacketRebuilder(phenopacket).update_interpretations(updated_interpretations)
 
 
-def update_phenopacket(gene_identifier: str, phenopacket_path: Path, output_dir: Path):
+def create_updated_phenopacket(gene_identifier: str, phenopacket_path: Path, output_dir: Path):
     """Updates the gene context within the interpretations for a phenopacket."""
     hgnc_data = create_hgnc_dict()
     updated_phenopacket = update_outdated_gene_context(phenopacket_path, gene_identifier, hgnc_data)
     write_phenopacket(updated_phenopacket, output_dir.joinpath(phenopacket_path.name))
 
 
-def update_phenopackets(gene_identifier: str, phenopacket_dir: Path, output_dir: Path):
+def create_updated_phenopackets(gene_identifier: str, phenopacket_dir: Path, output_dir: Path):
     """Updates the gene context within the interpretations for phenopackets."""
     hgnc_data = create_hgnc_dict()
     for phenopacket_path in all_files(phenopacket_dir):
@@ -44,63 +42,11 @@ def update_phenopackets(gene_identifier: str, phenopacket_dir: Path, output_dir:
         write_phenopacket(updated_phenopacket, output_dir.joinpath(phenopacket_path.name))
 
 
-@click.command("update-phenopacket")
-@click.option(
-    "--phenopacket-path",
-    "-p",
-    metavar="FILE",
-    required=True,
-    help="Path to phenopacket for updating.",
-    type=Path,
-)
-@click.option(
-    "--output-dir",
-    "-o",
-    metavar="PATH",
-    required=True,
-    help="Path to write phenopacket.",
-    type=Path,
-)
-@click.option(
-    "--gene-identifier",
-    "-g",
-    required=False,
-    default="ensembl_id",
-    show_default=True,
-    help="Gene identifier to add to phenopacket",
-    type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
-)
-def update_phenopacket_command(phenopacket_path: Path, output_dir: Path, gene_identifier: str):
-    """Update gene symbols and identifiers for a phenopacket."""
-    update_phenopacket(gene_identifier, phenopacket_path, output_dir)
-
-
-@click.command("update-phenopackets")
-@click.option(
-    "--phenopacket-dir",
-    "-p",
-    metavar="PATH",
-    required=True,
-    help="Path to phenopacket directory for updating.",
-    type=Path,
-)
-@click.option(
-    "--output-dir",
-    "-o",
-    metavar="PATH",
-    required=True,
-    help="Path to write phenopacket.",
-    type=Path,
-)
-@click.option(
-    "--gene-identifier",
-    "-g",
-    required=False,
-    default="ensembl_id",
-    show_default=True,
-    help="Gene identifier to add to phenopacket",
-    type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
-)
-def update_phenopackets_command(phenopacket_dir: Path, output_dir: Path, gene_identifier: str):
-    """Update gene symbols and identifiers for phenopackets."""
-    update_phenopackets(gene_identifier, phenopacket_dir, output_dir)
+def update_phenopackets(
+    gene_identifier: str, phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path
+):
+    """Update the gene identifiers in either a single phenopacket or a directory of phenopackets."""
+    if phenopacket_path is not None:
+        create_updated_phenopacket(gene_identifier, phenopacket_path, output_dir)
+    elif phenopacket_dir is not None:
+        create_updated_phenopackets(gene_identifier, phenopacket_dir, output_dir)

--- a/src/pheval/prepare/update_phenopacket.py
+++ b/src/pheval/prepare/update_phenopacket.py
@@ -46,6 +46,7 @@ def update_phenopackets(
     gene_identifier: str, phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path
 ):
     """Update the gene identifiers in either a single phenopacket or a directory of phenopackets."""
+    output_dir.mkdir(exist_ok=True)
     if phenopacket_path is not None:
         create_updated_phenopacket(gene_identifier, phenopacket_path, output_dir)
     elif phenopacket_dir is not None:


### PR DESCRIPTION
Closes #56 

Merged multi-input and single-input commands into a single command for:
- Updating the gene identifiers and symbols in phenopackets
- Scrambling the phenotypic profiles in phenopackets
- Creating spiked vcfs

Also addressed some prior points of moving the click commands to the cli_pheval_utils.py and keeping it completely separate to the methods, as well as removing the "hacking" of file names in the scramble phenopackets command