### PR TITLE
74 provide provisional output for existing runners

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -155,6 +155,14 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "casefy"
+version = "0.1.7"
+description = "Utilities for string case conversion."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "certifi"
 version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -844,7 +852,7 @@ python-versions = ">=3.7"
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1227,6 +1235,27 @@ description = "Persistent/Functional/Immutable data structures"
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "pyserde"
+version = "0.9.8"
+description = "Yet another serialization library on top of dataclasses"
+category = "main"
+optional = false
+python-versions = ">=3.7.0,<4.0.0"
+
+[package.dependencies]
+casefy = "*"
+jinja2 = "*"
+typing_inspect = ">=0.4.0"
+
+[package.extras]
+all = ["msgpack", "numpy (>1.21.0)", "numpy (>1.21.0)", "numpy (>1.21.0)", "numpy (>1.22.0)", "orjson", "pyyaml", "tomli", "tomli-w"]
+msgpack = ["msgpack"]
+numpy = ["numpy (>1.21.0)", "numpy (>1.21.0)", "numpy (>1.21.0)", "numpy (>1.22.0)"]
+orjson = ["orjson"]
+toml = ["tomli", "tomli-w"]
+yaml = ["pyyaml"]
 
 [[package]]
 name = "pyshex"
@@ -1876,6 +1905,18 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "typing-inspect"
+version = "0.8.0"
+description = "Runtime inspection utilities for typing module."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "uri-template"
 version = "1.2.0"
 description = "RFC 6570 URI Template Processor"
@@ -1984,7 +2025,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "e0320e30dd6da697754d6c06392ad8e955d7ef05ae51dd63ea43056f382e9f80"
+content-hash = "2152ae871d0e653b39eb734b15fa668228196e30f74d5b7d924fea1daff8ecf1"
 
 [metadata.files]
 aiohttp = [
@@ -2063,6 +2104,10 @@ black = [
     {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
     {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
     {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+]
+casefy = [
+    {file = "casefy-0.1.7-py3-none-any.whl", hash = "sha256:ab05ff1c67f2a8e62d9f8986fa9a849416d61ac5413ec57d1f827b4f36589cf6"},
+    {file = "casefy-0.1.7.tar.gz", hash = "sha256:6accce985a64b9edb2a610a29ac489d78fac80e52ff8f2d137e294f2f92b8027"},
 ]
 certifi = [
     {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
@@ -2896,6 +2941,10 @@ pyrsistent = [
     {file = "pyrsistent-0.19.3-py3-none-any.whl", hash = "sha256:ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64"},
     {file = "pyrsistent-0.19.3.tar.gz", hash = "sha256:1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440"},
 ]
+pyserde = [
+    {file = "pyserde-0.9.8-py3-none-any.whl", hash = "sha256:daf51935129301af0f639d2bcf016022acb4ce4c473667c23b8cbbd1a1a15bb9"},
+    {file = "pyserde-0.9.8.tar.gz", hash = "sha256:9d695aed4d5d0f98674ae371d8b25e60e1f4fa67a01a72b4f24618e4f0a0ceb6"},
+]
 pyshex = [
     {file = "PyShEx-0.8.1-py3-none-any.whl", hash = "sha256:6da1b10123e191abf8dcb6bf3e54aa3e1fcf771df5d1a0ed453217c8900c8e6a"},
     {file = "PyShEx-0.8.1.tar.gz", hash = "sha256:3c5c4d45fe27faaadae803cb008c41acf8ee784da7868b04fd84967e75be70d0"},
@@ -3203,6 +3252,10 @@ tqdm = [
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
     {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+typing-inspect = [
+    {file = "typing_inspect-0.8.0-py3-none-any.whl", hash = "sha256:5fbf9c1e65d4fa01e701fe12a5bca6c6e08a4ffd5bc60bfac028253a447c5188"},
+    {file = "typing_inspect-0.8.0.tar.gz", hash = "sha256:8b1ff0c400943b6145df8119c41c244ca8207f1f10c9c057aeed1560e4806e3d"},
 ]
 uri-template = [
     {file = "uri_template-1.2.0-py3-none-any.whl", hash = "sha256:f1699c77b73b925cf4937eae31ab282a86dc885c333f2e942513f08f691fc7db"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ oaklib = "^0.1.55"
 google = "^3.0.0"
 pyaml = "^21.10.1"
 plotly = "^5.13.0"
+pyserde = "^0.9.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/src/pheval/cli_pheval.py
+++ b/src/pheval/cli_pheval.py
@@ -1,11 +1,13 @@
 """
 Monarch Initiative
 """
+
 from pathlib import Path
 
 import click
 
 from pheval.implementations import get_implementation_resolver
+from pheval.utils.file_utils import write_metadata
 
 
 @click.command()
@@ -15,7 +17,6 @@ from pheval.implementations import get_implementation_resolver
     metavar="INPUTDIR",
     required=True,
     help="The input directory (relative path: e.g exomiser-13.11)",
-    type=Path,
 )
 @click.option(
     "--testdata-dir",
@@ -23,7 +24,6 @@ from pheval.implementations import get_implementation_resolver
     metavar="TESTDATA",
     required=True,
     help="The input directory (relative path: e.g ./data)",
-    type=Path,
 )
 @click.option(
     "--runner",
@@ -38,7 +38,6 @@ from pheval.implementations import get_implementation_resolver
     metavar="TMPDIR",
     required=False,
     help="The path of the temporary directory (optional)",
-    type=Path,
 )
 @click.option(
     "--output-dir",
@@ -46,7 +45,6 @@ from pheval.implementations import get_implementation_resolver
     metavar="OUTPUTDIR",
     required=True,
     help="The path of the output directory",
-    type=Path,
 )
 @click.option(
     "--config",
@@ -74,16 +72,17 @@ def run(
     """PhEval Runner Command Line Interface
 
     Args:
-        input_dir (Path): The input directory (relative path: e.g exomiser-13.11)
-        testdata_dir (Path): The input directory (relative path: e.g ./data
+        input_dir (Click.Path): The input directory (relative path: e.g exomiser-13.11)
+        testdata_dir (Click.Path): The input directory (relative path: e.g ./data
         runner (str): Runner implementation (e.g exomiser-13.11)
-        tmp_dir (Path): The path of the temporary directory (optional)
-        output_dir (Path): The path of the output directory
-        config (Path): The path of the configuration file (optional e.g., config.yaml)
-        version (str): The version of the tool implementation
+        tmp_dir (Click.Path): The path of the temporary directory (optional)
+        output_dir (Click.Path): The path of the output directory
+        config (Click.Path): The path of the configuration file (optional e.g config.yaml)
     """
     runner_class = get_implementation_resolver().lookup(runner)
     runner_instance = runner_class(input_dir, testdata_dir, tmp_dir, output_dir, config, version)
+    runner_instance.build_output_directory_structure()
     runner_instance.prepare()
     runner_instance.run()
     runner_instance.post_process()
+    write_metadata(runner_instance.create_metadata())

--- a/src/pheval/config_parser.py
+++ b/src/pheval/config_parser.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from serde import serde
+from serde.yaml import from_yaml
+
+from pheval.utils.constants import INPUT_DIR_CONFIG
+
+
+@serde
+@dataclass
+class InputDirConfig:
+    """
+    Class for defining the fields within the input directory config.
+
+    Args:
+        tool (str): Name of the tool implementation (e.g. exomiser/phen2gene)
+        software_directory (Path or None): Path to the software directory
+        software_config (Path or None): Path to the software configuration file
+        input_directory (Path): Path to the tool input data
+        phenotype_only (bool): Whether the tool is run with HPO terms only (True) or with variant data (False)
+
+    """
+
+    tool: str
+    software_directory: Path or None
+    software_config: Path or None
+    input_directory: Path
+    phenotype_only: bool
+
+
+def parse_input_dir_config(input_dir: Path) -> InputDirConfig:
+    """Reads the config file."""
+    with open(Path(input_dir).joinpath(INPUT_DIR_CONFIG), "r") as config_file:
+        config = yaml.safe_load(config_file)
+    config_file.close()
+    return from_yaml(InputDirConfig, yaml.dump(config))

--- a/src/pheval/construct_metadata.py
+++ b/src/pheval/construct_metadata.py
@@ -45,7 +45,7 @@ def create_run_metadata(
     corpus: Path,
     corpus_variant_path: Path,
 ):
-    """Create the basic metadata for a single PhEval run."""
+    """Create the basic metadata record for a single PhEval run."""
     return MetaDataRecord(
         run_metadata=BasicOutputRunMetaData(
             tool=input_dir_config.tool,

--- a/src/pheval/construct_metadata.py
+++ b/src/pheval/construct_metadata.py
@@ -1,0 +1,58 @@
+import timeit
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from serde import serde
+
+from pheval.config_parser import InputDirConfig
+from pheval.utils.constants import INPUT_DIR_CONFIG, RUN_METADATA_FILE
+
+
+@serde
+@dataclass
+class BasicOutputRunMetaData:
+    """Class for defining variables for the run metadata.
+    Args:
+        tool (str): Name of the tool implementation
+        tool_version (str): Version of the tool implementation
+        config (Path): Path to the config file located in the input directory
+        run_timestamp (int): Time taken for run to complete
+        corpus (Path): Path to corpus used in pheval run
+        tool_specific_configuration_options (Any): Special field that can be overwritten by tool implementations to
+                                                   contain any extra tool specific configurations used in the run
+    """
+
+    tool: str
+    tool_version: str
+    config: Path
+    run_timestamp: int
+    corpus: Path
+    tool_specific_configuration_options: Any = None
+
+
+@dataclass
+class MetaDataRecord:
+    run_metadata: BasicOutputRunMetaData
+    run_metadata_filepath: Path
+
+
+def create_run_metadata(
+    input_dir_config: InputDirConfig,
+    tool_version: str,
+    input_dir: Path,
+    start_time: int,
+    corpus: Path,
+    corpus_variant_path: Path,
+):
+    """Create the basic metadata for a single PhEval run."""
+    return MetaDataRecord(
+        run_metadata=BasicOutputRunMetaData(
+            tool=input_dir_config.tool,
+            tool_version=tool_version,
+            config=str(Path(input_dir).joinpath(INPUT_DIR_CONFIG)),
+            run_timestamp=int(timeit.default_timer() - start_time),
+            corpus=corpus,
+        ),
+        run_metadata_filepath=Path(corpus_variant_path).joinpath(RUN_METADATA_FILE),
+    )

--- a/src/pheval/construct_metadata.py
+++ b/src/pheval/construct_metadata.py
@@ -6,7 +6,7 @@ from typing import Any
 from serde import serde
 
 from pheval.config_parser import InputDirConfig
-from pheval.utils.constants import INPUT_DIR_CONFIG, RUN_METADATA_FILE
+from pheval.utils.constants import RUN_METADATA_FILE
 
 
 @serde
@@ -50,9 +50,9 @@ def create_run_metadata(
         run_metadata=BasicOutputRunMetaData(
             tool=input_dir_config.tool,
             tool_version=tool_version,
-            config=str(Path(input_dir).joinpath(INPUT_DIR_CONFIG)),
+            config=f"{Path(input_dir).parent.name}-{Path(input_dir).name}",
             run_timestamp=int(timeit.default_timer() - start_time),
-            corpus=corpus,
+            corpus=f"{Path(corpus).parent.name}-{Path(corpus).name}",
         ),
         run_metadata_filepath=Path(corpus_variant_path).joinpath(RUN_METADATA_FILE),
     )

--- a/src/pheval/construct_metadata.py
+++ b/src/pheval/construct_metadata.py
@@ -50,9 +50,9 @@ def create_run_metadata(
         run_metadata=BasicOutputRunMetaData(
             tool=input_dir_config.tool,
             tool_version=tool_version,
-            config=f"{Path(input_dir).parent.name}-{Path(input_dir).name}",
+            config=f"{Path(input_dir).parent.name}/{Path(input_dir).name}",
             run_timestamp=int(timeit.default_timer() - start_time),
-            corpus=f"{Path(corpus).parent.name}-{Path(corpus).name}",
+            corpus=f"{Path(corpus).parent.name}/{Path(corpus).name}",
         ),
         run_metadata_filepath=Path(corpus_variant_path).joinpath(RUN_METADATA_FILE),
     )

--- a/src/pheval/runners/runner.py
+++ b/src/pheval/runners/runner.py
@@ -1,7 +1,17 @@
 """Runners Module"""
+import timeit
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
+
+from pheval.config_parser import parse_input_dir_config
+from pheval.utils.constants import (
+    PHEVAL_GENE_RESULTS_DIR,
+    PHEVAL_VARIANT_RESULTS_DIR,
+    RUNNER_INPUT_COMMANDS_DIR,
+    TOOL_RESULTS_DIR,
+)
+from pheval.construct_metadata import create_run_metadata
 
 
 @dataclass
@@ -14,6 +24,96 @@ class PhEvalRunner(ABC):
     output_dir: Path
     config_file: Path
     version: str
+    directory_path = None
+    input_dir_config = None
+    start_time = timeit.default_timer()
+
+    def __post_init__(self):
+        self.input_dir_config = parse_input_dir_config(self.input_dir)
+
+    def _get_tool(self):
+        return self.input_dir_config.tool
+
+    def _get_phenotype_only(self):
+        return self.input_dir_config.phenotype_only
+
+    @property
+    def runner_version_dir(self):
+        return Path(self.output_dir).joinpath(f"{self._get_tool()}-{self.version}")
+
+    @runner_version_dir.setter
+    def runner_version_dir(self, directory_path):
+        self.directory_path = Path(directory_path)
+
+    @property
+    def runner_input_commands_dir(self):
+        return Path(self.output_dir).joinpath(
+            f"{self._get_tool()}-{self.version}/{RUNNER_INPUT_COMMANDS_DIR}"
+        )
+
+    @runner_input_commands_dir.setter
+    def runner_input_commands_dir(self, directory_path):
+        self.directory_path = Path(directory_path)
+
+    @property
+    def corpus_variant_dir(self):
+        return Path(self.output_dir).joinpath(
+            f"{self._get_tool()}-{self.version}/{Path(self.input_dir).name}-"
+            f"{Path(self.testdata_dir).parent.name}-"
+            f"{Path(self.testdata_dir).name}"
+        )
+
+    @corpus_variant_dir.setter
+    def corpus_variant_dir(self, directory_path):
+        self.directory_path = Path(directory_path)
+
+    @property
+    def runner_results_dir(self):
+        return Path(self.output_dir).joinpath(
+            f"{self._get_tool()}-{self.version}/{Path(self.input_dir).name}-"
+            f"{Path(self.testdata_dir).parent.name}-"
+            f"{Path(self.testdata_dir).name}/{TOOL_RESULTS_DIR}"
+        )
+
+    @runner_results_dir.setter
+    def runner_results_dir(self, directory_path):
+        self.directory_path = Path(directory_path)
+
+    @property
+    def pheval_gene_results_dir(self):
+        return Path(self.output_dir).joinpath(
+            f"{self._get_tool()}-{self.version}/{Path(self.input_dir).name}-"
+            f"{Path(self.testdata_dir).parent.name}-"
+            f"{Path(self.testdata_dir).name}/"
+            f"{PHEVAL_GENE_RESULTS_DIR}"
+        )
+
+    @pheval_gene_results_dir.setter
+    def pheval_gene_results_dir(self, directory_path):
+        self.directory_path = Path(directory_path)
+
+    @property
+    def pheval_variant_results_dir(self):
+        return Path(self.output_dir).joinpath(
+            f"{self._get_tool()}-{self.version}/{Path(self.input_dir).name}-"
+            f"{Path(self.testdata_dir).parent.name}-"
+            f"{Path(self.testdata_dir).name}/"
+            f"{PHEVAL_VARIANT_RESULTS_DIR}"
+        )
+
+    @pheval_variant_results_dir.setter
+    def pheval_variant_results_dir(self, directory_path):
+        self.directory_path = Path(directory_path)
+
+    def build_output_directory_structure(self):
+        """build output directory structure"""
+        self.runner_version_dir.mkdir(exist_ok=True, parents=True)
+        self.runner_input_commands_dir.mkdir(exist_ok=True, parents=True)
+        self.corpus_variant_dir.mkdir(parents=True, exist_ok=True)
+        self.runner_results_dir.mkdir(parents=True, exist_ok=True)
+        self.pheval_gene_results_dir.mkdir(parents=True, exist_ok=True)
+        if not self._get_phenotype_only():
+            self.pheval_variant_results_dir.mkdir(parents=True, exist_ok=True)
 
     @abstractmethod
     def prepare(self) -> str:
@@ -26,6 +126,17 @@ class PhEvalRunner(ABC):
     @abstractmethod
     def post_process(self):
         """post_process"""
+
+    def create_metadata(self):
+        """create metadata for run"""
+        return create_run_metadata(
+            input_dir_config=self.input_dir_config,
+            input_dir=self.input_dir,
+            tool_version=self.version,
+            corpus=self.testdata_dir,
+            start_time=self.start_time,
+            corpus_variant_path=self.corpus_variant_dir,
+        )
 
 
 class DefaultPhEvalRunner(PhEvalRunner):

--- a/src/pheval/runners/runner.py
+++ b/src/pheval/runners/runner.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pheval.config_parser import parse_input_dir_config
+from pheval.construct_metadata import create_run_metadata
 from pheval.utils.constants import (
     PHEVAL_GENE_RESULTS_DIR,
     PHEVAL_VARIANT_RESULTS_DIR,
     RUNNER_INPUT_COMMANDS_DIR,
     TOOL_RESULTS_DIR,
 )
-from pheval.construct_metadata import create_run_metadata
 
 
 @dataclass

--- a/src/pheval/utils/constants.py
+++ b/src/pheval/utils/constants.py
@@ -1,0 +1,6 @@
+PHEVAL_GENE_RESULTS_DIR = "pheval_gene_results/"
+PHEVAL_VARIANT_RESULTS_DIR = "pheval_variant_results/"
+TOOL_RESULTS_DIR = "results/"
+RUNNER_INPUT_COMMANDS_DIR = "runner_input_commands/"
+INPUT_DIR_CONFIG = "config.yaml"
+RUN_METADATA_FILE = "results.yml"

--- a/src/pheval/utils/file_utils.py
+++ b/src/pheval/utils/file_utils.py
@@ -8,7 +8,7 @@ import pandas as pd
 import yaml
 from serde import to_dict
 
-from pheval.utils.metadata import MetaDataRecord
+from pheval.construct_metadata import MetaDataRecord
 
 
 def files_with_suffix(directory: Path, suffix: str):

--- a/src/pheval/utils/file_utils.py
+++ b/src/pheval/utils/file_utils.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from typing import List
 
 import pandas as pd
+import yaml
+from serde import to_dict
+
+from pheval.utils.metadata import MetaDataRecord
 
 
 def files_with_suffix(directory: Path, suffix: str):
@@ -74,3 +78,10 @@ def ensure_columns_exists(cols: list, dataframes: List[pd.DataFrame], err_messag
     for dataframe in dataframes:
         if not all(x in dataframe.columns for x in flat_cols):
             raise ValueError(err_msg)
+
+
+def write_metadata(meta_data: MetaDataRecord) -> None:
+    """Write the metadata for a run."""
+    with open(meta_data.run_metadata_filepath, "w") as metadata_file:
+        yaml.dump(to_dict(meta_data.run_metadata), metadata_file, sort_keys=False, default_style="")
+    metadata_file.close()

--- a/tests/input_dir/configs/default/config.yaml
+++ b/tests/input_dir/configs/default/config.yaml
@@ -1,0 +1,5 @@
+tool: defaultrunner
+software_directory: /configurations/default_runner-1.0.0/default/default-runner-cli-1.0.0
+software_config: /configurations/default_runner-1.0.0/default/software-config.yml
+input_directory: /configurations/default_runner-1.0.0/default/
+phenotype_only: False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
 """CLI Test """
 import logging
+import shutil
+import tempfile
 import unittest
+from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -16,17 +19,57 @@ class TestCommandLineInterface(unittest.TestCase):
     def setUp(self) -> None:
         runner = CliRunner(mix_stderr=False)
         self.runner = runner
+        self.test_dir = tempfile.mkdtemp()
 
-    def test_scramble_semsim(self):
-        """test_scramble_semsim"""
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_cli_runner(self):
+        """test_cli_runner"""
         result = self.runner.invoke(
-            run, ["-i", "./", "-t", "./", "-r", "defaultphevalrunner", "-o", "./"]
+            run,
+            [
+                "-i",
+                "./tests/input_dir/configs/default",
+                "-t",
+                "./testdata/phenopackets/lirical",
+                "-r",
+                "defaultphevalrunner",
+                "-o",
+                self.test_dir,
+                "-v",
+                "1.0.0",
+            ],
         )
         err = result.stderr
         self.assertEqual(None, result.exception)
         logging.info("ERR=%s", err)
         exit_code = result.exit_code
         self.assertEqual(0, exit_code)
+        self.assertTrue(Path(self.test_dir).joinpath("defaultrunner-1.0.0").exists())
+        self.assertTrue(
+            Path(self.test_dir)
+            .joinpath("defaultrunner-1.0.0/default-phenopackets-lirical")
+            .exists()
+        )
+        self.assertTrue(
+            Path(self.test_dir)
+            .joinpath("defaultrunner-1.0.0/default-phenopackets-lirical/pheval_gene_results")
+            .exists()
+        )
+        self.assertTrue(
+            Path(self.test_dir)
+            .joinpath("defaultrunner-1.0.0/default-phenopackets-lirical/pheval_variant_results")
+            .exists()
+        )
+        self.assertTrue(
+            Path(self.test_dir)
+            .joinpath("defaultrunner-1.0.0/default-phenopackets-lirical/results")
+            .exists()
+        )
+        self.assertTrue(
+            Path(self.test_dir).joinpath("defaultrunner-1.0.0/runner_input_commands").exists()
+        )
 
     def test_semsim_heatmap(self):
         """test_semsim_heatmap"""


### PR DESCRIPTION
Extended the PhEval Runner with a method to create the metadata for a run. By default, with no alteration by any runner implementations, the `results.yml` would output something like so:

```
tool: exomiser
tool_version: 13.2.0
config: exomiser-13.2.0-default
run_timestamp: 23
corpus: corpus1-default
tool_specific_configuration_options: Null
```

The tool specific configurations can be overwritten by the tool developer in the runner class like so:

```python
def create_metadata(self):
     metadata = super(ExomiserPhEvalRunner, self).create_metadata()
     metadata.run_metadata.tool_specific_configuration_options = ExomiserToolConfigurations(hg19_version='2209',
                                                                                            hg38_version='2209',
                                                                                            phenotype_version='2302')
     return metadata
```


Ideally, for this to work, the implementor would assign `tool_specific_configuration_options` a dataclass, which can be as nested/detailed as required and the field will be overwritten. The above command would return this:

```
tool: exomiser
tool_version: 13.2.0
config: exomiser-13.2.0-default
run_timestamp: 23
corpus: corpus1-default
tool_specific_configuration_options:
  hg19_version: '2209'
  hg38_version: '2209'
  phenotype_version: '2302'
```