### PR TITLE
80 obtain negated phenotypic features from a phenopacket

### DIFF
--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -109,7 +109,7 @@ class PhenopacketUtil:
             phenotypic_features.append(p)
         return phenotypic_features
 
-    def obtain_negated_phenotypes(self) -> [PhenotypicFeature] or None:
+    def negated_phenotypic_features(self) -> [PhenotypicFeature] or None:
         """Retrieve negated phenotypic features."""
         negated_phenotypic_features = []
         all_phenotypic_features = self.phenotypic_features()

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -109,14 +109,14 @@ class PhenopacketUtil:
             phenotypic_features.append(p)
         return phenotypic_features
 
-    def negated_phenotypic_features(self) -> [PhenotypicFeature] or None:
+    def negated_phenotypic_features(self) -> [PhenotypicFeature]:
         """Retrieve negated phenotypic features."""
         negated_phenotypic_features = []
         all_phenotypic_features = self.phenotypic_features()
         for p in all_phenotypic_features:
             if p.excluded:
                 negated_phenotypic_features.append(p)
-        return negated_phenotypic_features if negated_phenotypic_features != [] else None
+        return negated_phenotypic_features
 
     def interpretations(self) -> list[Interpretation]:
         """Returns all interpretations of a phenopacket."""

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -109,6 +109,15 @@ class PhenopacketUtil:
             phenotypic_features.append(p)
         return phenotypic_features
 
+    def obtain_negated_phenotypes(self) -> [PhenotypicFeature] or None:
+        """Retrieve negated phenotypic features."""
+        negated_phenotypic_features = []
+        all_phenotypic_features = self.phenotypic_features()
+        for p in all_phenotypic_features:
+            if p.excluded:
+                negated_phenotypic_features.append(p)
+        return negated_phenotypic_features if negated_phenotypic_features != [] else None
+
     def interpretations(self) -> list[Interpretation]:
         """Returns all interpretations of a phenopacket."""
         if hasattr(self.phenopacket_contents, "proband"):

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -345,27 +345,7 @@ class TestPhenopacketUtil(unittest.TestCase):
     def test_negated_phenotypic_features_all_excluded(self):
         self.assertEqual(
             self.phenopacket_excluded_pf.negated_phenotypic_features(),
-            [
-                PhenotypicFeature(
-                    type=OntologyClass(id="HP:0000256", label="Macrocephaly"), excluded=True
-                ),
-                PhenotypicFeature(
-                    type=OntologyClass(id="HP:0002059", label="Cerebral atrophy"), excluded=True
-                ),
-                PhenotypicFeature(
-                    type=OntologyClass(id="HP:0100309", label="Subdural hemorrhage"), excluded=True
-                ),
-                PhenotypicFeature(
-                    type=OntologyClass(id="HP:0003150", label="Glutaric aciduria"), excluded=True
-                ),
-                PhenotypicFeature(
-                    type=OntologyClass(id="HP:0001332", label="Dystonia"), excluded=True
-                ),
-                PhenotypicFeature(
-                    type=OntologyClass(id="HP:0008494", label="Inferior lens subluxation"),
-                    excluded=True,
-                ),
-            ],
+            phenotypic_features_all_excluded,
         )
 
     def test_negated_phenotypic_features_some_excluded(self):
@@ -380,7 +360,7 @@ class TestPhenopacketUtil(unittest.TestCase):
         )
 
     def test_negated_phenotypic_features_none_excluded(self):
-        self.assertEqual(self.family.negated_phenotypic_features(), None)
+        self.assertEqual(self.family.negated_phenotypic_features(), [])
 
     def test_interpretations_phenopacket(self):
         self.assertEqual(list(self.phenopacket.interpretations()), interpretations)

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -342,6 +342,46 @@ class TestPhenopacketUtil(unittest.TestCase):
             list(self.phenopacket.observed_phenotypic_features()), phenotypic_features_none_excluded
         )
 
+    def test_negated_phenotypic_features_all_excluded(self):
+        self.assertEqual(
+            self.phenopacket_excluded_pf.negated_phenotypic_features(),
+            [
+                PhenotypicFeature(
+                    type=OntologyClass(id="HP:0000256", label="Macrocephaly"), excluded=True
+                ),
+                PhenotypicFeature(
+                    type=OntologyClass(id="HP:0002059", label="Cerebral atrophy"), excluded=True
+                ),
+                PhenotypicFeature(
+                    type=OntologyClass(id="HP:0100309", label="Subdural hemorrhage"), excluded=True
+                ),
+                PhenotypicFeature(
+                    type=OntologyClass(id="HP:0003150", label="Glutaric aciduria"), excluded=True
+                ),
+                PhenotypicFeature(
+                    type=OntologyClass(id="HP:0001332", label="Dystonia"), excluded=True
+                ),
+                PhenotypicFeature(
+                    type=OntologyClass(id="HP:0008494", label="Inferior lens subluxation"),
+                    excluded=True,
+                ),
+            ],
+        )
+
+    def test_negated_phenotypic_features_some_excluded(self):
+        self.assertEqual(
+            self.phenopacket.negated_phenotypic_features(),
+            [
+                PhenotypicFeature(
+                    type=OntologyClass(id="HP:0008494", label="Inferior lens subluxation"),
+                    excluded=True,
+                )
+            ],
+        )
+
+    def test_negated_phenotypic_features_none_excluded(self):
+        self.assertEqual(self.family.negated_phenotypic_features(), None)
+
     def test_interpretations_phenopacket(self):
         self.assertEqual(list(self.phenopacket.interpretations()), interpretations)
 


### PR DESCRIPTION
Added a method within the `PhenopacketUtil` class to obtain any phenotypic features marked as excluded. Also added tests to test its functionality. No CLI changes