### PR TITLE
81 obtain the sample id from a phenopacket

### DIFF
--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -92,6 +92,13 @@ class PhenopacketUtil:
     def __init__(self, phenopacket_contents: Phenopacket):
         self.phenopacket_contents = phenopacket_contents
 
+    def sample_id(self) -> str:
+        """Retrieve the sample ID."""
+        if hasattr(self.phenopacket_contents, "proband"):
+            return self.phenopacket_contents.proband.subject.id
+        else:
+            return self.phenopacket_contents.subject.id
+
     def phenotypic_features(self) -> list[PhenotypicFeature]:
         """Retrieves a list of all HPO terms."""
         if hasattr(self.phenopacket_contents, "proband"):

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -93,7 +93,7 @@ class PhenopacketUtil:
         self.phenopacket_contents = phenopacket_contents
 
     def sample_id(self) -> str:
-        """Retrieve the sample ID."""
+        """Retrieve the sample ID from a phenopacket or proband of a family."""
         if hasattr(self.phenopacket_contents, "proband"):
             return self.phenopacket_contents.proband.subject.id
         else:

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -324,6 +324,12 @@ class TestPhenopacketUtil(unittest.TestCase):
         cls.family_incorrect_files = PhenopacketUtil(family_incorrect_files)
         cls.family_incorrect_file_format = PhenopacketUtil(family_incorrect_file_format)
 
+    def test_sample_id_phenopacket(self):
+        self.assertEqual(self.phenopacket.sample_id(), "test-subject-1")
+
+    def test_sample_id_family(self):
+        self.assertEqual(self.family.sample_id(), "test-subject-1")
+
     def test_phenotypic_features_phenopacket(self):
         self.assertEqual(
             list(self.phenopacket.phenotypic_features()), phenotypic_features_with_excluded


### PR DESCRIPTION
Added method to the `PhenopacketUtil` class to retrieve the sample id for the proband. Also added tests for its functionality. No CLI changes