### PR TITLE
82 calculate end pos for variant from start and ref allele

### DIFF
--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -6,6 +6,11 @@ from pathlib import Path
 import pandas as pd
 
 
+def calculate_end_pos(variant_start: int, variant_ref: str) -> int:
+    """Calculate the end position for a variant."""
+    return variant_start + len(variant_ref) - 1
+
+
 @dataclass
 class PhEvalGeneResult:
     """Minimal data required from tool-specific output for gene prioritisation."""

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -9,6 +9,7 @@ from pheval.post_processing.post_processing import (
     ScoreRanker,
     SortOrder,
     _return_sort_order,
+    calculate_end_pos,
     create_pheval_result,
     rank_pheval_result,
 )
@@ -404,3 +405,11 @@ class TestReturnSortOrder(unittest.TestCase):
     def test_return_sort_order_incompatible(self):
         with self.assertRaises(ValueError):
             _return_sort_order("null")
+
+
+class TestCalculateEndPos(unittest.TestCase):
+    def test_calculate_end_pos_single_ref_length(self):
+        self.assertEqual(calculate_end_pos(variant_start=13007113, variant_ref="G"), 13007113)
+
+    def test_calculate_end_pos(self):
+        self.assertEqual(calculate_end_pos(variant_start=114269997, variant_ref="ACAG"), 114270000)


### PR DESCRIPTION
Added method to the `post_processing.py` to calculate the end position for a variant given the start position and the reference allele. This is needed as some VP tools do not return the end position of a variant, this method will need to be called by the implementor so that the results can be standardised to the pheval variant format. Also added tests for its functionality. No CLI changes