### PR TITLE
91 retrieving genes from interpretations in a phenopacket

### DIFF
--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -174,7 +174,7 @@ class PhenopacketUtil:
         compatible_genome_assembly = ["GRCh37", "hg19", "GRCh38", "hg38"]
         vcf_data = [file for file in self.files() if file.file_attributes["fileFormat"] == "VCF"][0]
         if not Path(vcf_data.uri).name.endswith(".vcf") and not Path(vcf_data.uri).name.endswith(
-                ".vcf.gz"
+            ".vcf.gz"
         ):
             raise IncorrectFileFormatError(Path(vcf_data.uri), ".vcf or .vcf.gz file")
         if vcf_data.file_attributes["genomeAssembly"] not in compatible_genome_assembly:
@@ -195,8 +195,10 @@ class PhenopacketUtil:
             )
 
         else:
-            return ProbandCausativeGene(gene_symbol=genomic_interpretation.gene.symbol,
-                                        gene_identifier=genomic_interpretation.gene.value_id)
+            return ProbandCausativeGene(
+                gene_symbol=genomic_interpretation.gene.symbol,
+                gene_identifier=genomic_interpretation.gene.value_id,
+            )
 
     def diagnosed_genes(self) -> list[ProbandCausativeGene]:
         """Returns a unique list of all causative genes and the corresponding gene identifiers from a phenopacket."""
@@ -323,7 +325,7 @@ class GeneIdentifierUpdater:
                         ]
 
     def update_genomic_interpretations_gene_identifier(
-            self, interpretations: list[Interpretation]
+        self, interpretations: list[Interpretation]
     ) -> list[Interpretation]:
         """Updates the genomic interpretations of a phenopacket."""
         updated_interpretations = copy(list(interpretations))

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -9,7 +9,14 @@ from pathlib import Path
 
 import pandas as pd
 from google.protobuf.json_format import MessageToJson, Parse
-from phenopackets import Family, File, Interpretation, Phenopacket, PhenotypicFeature
+from phenopackets import (
+    Family,
+    File,
+    GenomicInterpretation,
+    Interpretation,
+    Phenopacket,
+    PhenotypicFeature,
+)
 
 from pheval.prepare.custom_exceptions import IncorrectFileFormatError
 
@@ -185,7 +192,9 @@ class PhenopacketUtil:
         return vcf_data
 
     @staticmethod
-    def _extract_diagnosed_gene(genomic_interpretation):
+    def _extract_diagnosed_gene(
+        genomic_interpretation: GenomicInterpretation,
+    ) -> ProbandCausativeGene:
         """Returns the disease causative gene from the variant descriptor field if not empty,
         otherwise, returns from the gene descriptor from a phenopacket."""
         if genomic_interpretation.variant_interpretation.ByteSize() != 0:

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -186,7 +186,7 @@ class PhenopacketUtil:
 
     @staticmethod
     def _extract_diagnosed_gene(genomic_interpretation):
-        """Returns the proband causative gene from the variant descriptor field if not empty,
+        """Returns the disease causative gene from the variant descriptor field if not empty,
         otherwise, returns from the gene descriptor from a phenopacket."""
         if genomic_interpretation.variant_interpretation.ByteSize() != 0:
             return ProbandCausativeGene(

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -157,7 +157,47 @@ updated_interpretations = [
         ),
     )
 ]
-
+interpretations_no_variant_data = [
+    Interpretation(
+        id="test-subject-1-int",
+        progress_status="SOLVED",
+        diagnosis=Diagnosis(
+            genomic_interpretations=[
+                GenomicInterpretation(
+                    subject_or_biosample_id="test-subject-1",
+                    interpretation_status=4,
+                    variant_interpretation=VariantInterpretation(
+                        acmg_pathogenicity_classification="NOT_PROVIDED",
+                        therapeutic_actionability="UNKNOWN_ACTIONABILITY",
+                        variation_descriptor=VariationDescriptor(
+                            gene_context=GeneDescriptor(
+                                value_id="ENSG00000102302",
+                                symbol="FGD1",
+                                alternate_ids=[
+                                    "HGNC:3663",
+                                    "ncbigene:2245",
+                                    "ensembl:ENSG00000102302",
+                                    "symbol:FGD1",
+                                ],
+                            ),
+                            vcf_record=VcfRecord(
+                                genome_assembly="GRCh37",
+                                chrom="X",
+                                pos=54492285,
+                                ref="C",
+                                alt="T",
+                            ),
+                            allelic_state=OntologyClass(
+                                id="GENO:0000134",
+                                label="hemizygous",
+                            ),
+                        ),
+                    ),
+                ),
+            ]
+        ),
+    )
+]
 phenotypic_features_none_excluded = [
     PhenotypicFeature(type=OntologyClass(id="HP:0000256", label="Macrocephaly")),
     PhenotypicFeature(type=OntologyClass(id="HP:0002059", label="Cerebral atrophy")),
@@ -251,6 +291,14 @@ phenopacket = Phenopacket(
     files=phenopacket_files,
     meta_data=phenopacket_metadata,
 )
+phenopacket_no_variant_data = Phenopacket(
+    id="test-subject",
+    subject=Individual(id="test-subject-1", sex=1),
+    phenotypic_features=phenotypic_features_with_excluded,
+    interpretations=interpretations_no_variant_data,
+    files=phenopacket_files,
+    meta_data=phenopacket_metadata,
+)
 phenopacket_with_all_excluded_terms = Phenopacket(
     id="test-subject",
     subject=Individual(id="test-subject-1", sex=1),
@@ -320,6 +368,7 @@ class TestPhenopacketUtil(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.phenopacket = PhenopacketUtil(phenopacket)
+        cls.phenopacket_no_variants = PhenopacketUtil(phenopacket_no_variant_data)
         cls.phenopacket_excluded_pf = PhenopacketUtil(phenopacket_with_all_excluded_terms)
         cls.family = PhenopacketUtil(family)
         cls.family_incorrect_files = PhenopacketUtil(family_incorrect_files)
@@ -414,6 +463,14 @@ class TestPhenopacketUtil(unittest.TestCase):
                 ]
             ),
             self.phenopacket.diagnosed_genes(),
+        )
+
+    def test_diagnosed_genes_no_variants(self):
+        self.assertEqual(
+            (
+                [ProbandCausativeGene(gene_symbol='FGD1', gene_identifier='ENSG00000102302')]
+            ),
+            self.phenopacket_no_variants.diagnosed_genes(),
         )
 
     def test_diagnosed_variants(self):
@@ -551,3 +608,6 @@ class TestGeneIdentifierUpdater(unittest.TestCase):
             ),
             updated_interpretations,
         )
+
+
+

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -467,9 +467,7 @@ class TestPhenopacketUtil(unittest.TestCase):
 
     def test_diagnosed_genes_no_variants(self):
         self.assertEqual(
-            (
-                [ProbandCausativeGene(gene_symbol='FGD1', gene_identifier='ENSG00000102302')]
-            ),
+            ([ProbandCausativeGene(gene_symbol="FGD1", gene_identifier="ENSG00000102302")]),
             self.phenopacket_no_variants.diagnosed_genes(),
         )
 
@@ -608,6 +606,3 @@ class TestGeneIdentifierUpdater(unittest.TestCase):
             ),
             updated_interpretations,
         )
-
-
-


### PR DESCRIPTION
The `genomicInterpretations` field of a phenopacket can take either a `geneContext` or `variantInterpretation` field. In these cases, the location of where to locate and retrieve the disease causing genes differs.

The method within the`PhenopacketUtil` class that deals with retrieving the genes from a phenopacket has been updated to check if the `variantInterpretation` interpretation field is empty, if it is, retrieve the gene from the `geneContext` otherwise, retrieve from the `variantInterpretation`