### PR TITLE
Alter spike vcfs methods to create a valid URI for the phenopacket

### DIFF
--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -297,7 +297,7 @@ def generate_spiked_vcf_file(
     )
     VcfWriter(spiked_vcf, spiked_vcf_path).write_vcf_file()
     return File(
-        uri=str(spiked_vcf_path.absolute()),
+        uri=f"file://{str(spiked_vcf_path)}",
         file_attributes={"fileFormat": "VCF", "genomeAssembly": vcf_assembly},
     )
 

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -297,7 +297,7 @@ def generate_spiked_vcf_file(
     )
     VcfWriter(spiked_vcf, spiked_vcf_path).write_vcf_file()
     return File(
-        uri=f"file://{str(spiked_vcf_path)}",
+        uri=spiked_vcf_path.as_uri(),
         file_attributes={"fileFormat": "VCF", "genomeAssembly": vcf_assembly},
     )
 

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -298,7 +298,7 @@ def generate_spiked_vcf_file(
     VcfWriter(spiked_vcf, spiked_vcf_path).write_vcf_file()
     return File(
         uri=spiked_vcf_path.as_uri(),
-        file_attributes={"fileFormat": "VCF", "genomeAssembly": vcf_assembly},
+        file_attributes={"fileFormat": "vcf", "genomeAssembly": vcf_assembly},
     )
 
 


### PR DESCRIPTION
When a VCF is spiked with the relevant proband variants the path to the spiked VCF path is added to the phenopacket `Files`. The phenopacket schema requires this to formatted like `file:///path/to/relavant_file` rather than an absolute path. I have just added the `file://` to be prepended to an absolute path. LIRICAL is quite stringent on this being formatted this way and will throw an error for an invalid URI. It is better to change this to be consistent with the phenopacket schema's requirements.

This won't impact any of the CLI or methods called later in the runners as I am ignoring the path provided in the phenopacket and providing the path in the CLI parameters for the tool from the testdata directory.