### PR TITLE
removing files object from phenopackets

### DIFF
--- a/testdata/phenopackets/lirical/Abdul_Wahab-2016-GCDH-Patient_5.json
+++ b/testdata/phenopackets/lirical/Abdul_Wahab-2016-GCDH-Patient_5.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Abdul_Wahab-2016-GCDH-Patient_5.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ajmal-2013-BBS1-IV-5_family_A.json
+++ b/testdata/phenopackets/lirical/Ajmal-2013-BBS1-IV-5_family_A.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ajmal-2013-BBS1-IV-5_family_A.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Al-Dosari-2010-TFAP2A-10-year-old_girl.json
+++ b/testdata/phenopackets/lirical/Al-Dosari-2010-TFAP2A-10-year-old_girl.json
@@ -295,15 +295,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Al-Dosari-2010-TFAP2A-10-year-old_girl.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.12-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Al-Hashmi-2018-SNX14-IV-1.json
+++ b/testdata/phenopackets/lirical/Al-Hashmi-2018-SNX14-IV-1.json
@@ -388,15 +388,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Al-Hashmi-2018-SNX14-IV-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Al-Qattan-2018-SCARF2-proband.json
+++ b/testdata/phenopackets/lirical/Al-Qattan-2018-SCARF2-proband.json
@@ -366,15 +366,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Al-Qattan-2018-SCARF2-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Al-Semari-2013-FGD1-II-1.json
+++ b/testdata/phenopackets/lirical/Al-Semari-2013-FGD1-II-1.json
@@ -240,15 +240,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Al-Semari-2013-FGD1-II-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/AlSubhi-2016-ALG9-IV_5.json
+++ b/testdata/phenopackets/lirical/AlSubhi-2016-ALG9-IV_5.json
@@ -347,15 +347,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "AlSubhi-2016-ALG9-IV_5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Alazami-2016-ATP6V1E1-Family_5_-_IV_2.json
+++ b/testdata/phenopackets/lirical/Alazami-2016-ATP6V1E1-Family_5_-_IV_2.json
@@ -127,15 +127,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Alazami-2016-ATP6V1E1-Family_5_-_IV_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ali-2017-MYH3-proband.json
+++ b/testdata/phenopackets/lirical/Ali-2017-MYH3-proband.json
@@ -293,15 +293,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ali-2017-MYH3-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Alzahrani-2018-EPG5-18-month_son.json
+++ b/testdata/phenopackets/lirical/Alzahrani-2018-EPG5-18-month_son.json
@@ -329,15 +329,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Alzahrani-2018-EPG5-18-month_son.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Anazi-2017-NKX6-2-Patient_36-16DG1123.json
+++ b/testdata/phenopackets/lirical/Anazi-2017-NKX6-2-Patient_36-16DG1123.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Anazi-2017-NKX6-2-Patient_36-16DG1123.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_1.json
+++ b/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_1.json
@@ -232,15 +232,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Arno-2017-ARHGEF18-Individual_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_2.json
+++ b/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_2.json
@@ -232,15 +232,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Arno-2017-ARHGEF18-Individual_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Arora-2019-COG8-proband.json
+++ b/testdata/phenopackets/lirical/Arora-2019-COG8-proband.json
@@ -549,15 +549,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Arora-2019-COG8-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Asgharzade-2018-GIPC3-Ahv-14_23.json
+++ b/testdata/phenopackets/lirical/Asgharzade-2018-GIPC3-Ahv-14_23.json
@@ -77,15 +77,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Asgharzade-2018-GIPC3-Ahv-14_23.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Avgeris-2017-TSC1-patient_6.json
+++ b/testdata/phenopackets/lirical/Avgeris-2017-TSC1-patient_6.json
@@ -186,15 +186,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Avgeris-2017-TSC1-patient_6.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Avrahami-2008-ST14-patient.json
+++ b/testdata/phenopackets/lirical/Avrahami-2008-ST14-patient.json
@@ -186,15 +186,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Avrahami-2008-ST14-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Badin-2017-RUNX1-Pedigree_I,_V_2.json
+++ b/testdata/phenopackets/lirical/Badin-2017-RUNX1-Pedigree_I,_V_2.json
@@ -113,15 +113,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Badin-2017-RUNX1-Pedigree_I,_V_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Baldi-2018-NKX6-2-F6,II-2.json
+++ b/testdata/phenopackets/lirical/Baldi-2018-NKX6-2-F6,II-2.json
@@ -492,15 +492,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Baldi-2018-NKX6-2-F6,II-2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bao-2019-COL6A1-II.1.json
+++ b/testdata/phenopackets/lirical/Bao-2019-COL6A1-II.1.json
@@ -445,15 +445,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bao-2019-COL6A1-II.1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Bastaki-2017-CTCF-proband.json
+++ b/testdata/phenopackets/lirical/Bastaki-2017-CTCF-proband.json
@@ -563,15 +563,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bastaki-2017-CTCF-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bee-2015-BBS2-II_2.json
+++ b/testdata/phenopackets/lirical/Bee-2015-BBS2-II_2.json
@@ -250,15 +250,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bee-2015-BBS2-II_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Ben_Ammar-2013-MUSK-patient.json
+++ b/testdata/phenopackets/lirical/Ben_Ammar-2013-MUSK-patient.json
@@ -369,15 +369,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ben_Ammar-2013-MUSK-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhatia-2018-PRPF31-IV_3.json
+++ b/testdata/phenopackets/lirical/Bhatia-2018-PRPF31-IV_3.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhatia-2018-PRPF31-IV_3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-1.json
@@ -421,15 +421,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-1-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-2.json
@@ -195,15 +195,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-1-2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-2-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-2-1.json
@@ -305,15 +305,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-2-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-3-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-3-1.json
@@ -331,15 +331,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-3-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-1.json
@@ -271,15 +271,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-4-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-2.json
@@ -160,15 +160,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-4-2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-5-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-5-1.json
@@ -383,15 +383,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-5-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-1.json
@@ -294,15 +294,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-6-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-2.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-6-2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-8-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-8-1.json
@@ -312,15 +312,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bhoj-2016-TBCK-8-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bicknell-2007-FLNB-19.json
+++ b/testdata/phenopackets/lirical/Bicknell-2007-FLNB-19.json
@@ -275,15 +275,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bicknell-2007-FLNB-19.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.12-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Blanco-Kelly-2017-CDH3-Patient.json
+++ b/testdata/phenopackets/lirical/Blanco-Kelly-2017-CDH3-Patient.json
@@ -343,15 +343,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Blanco-Kelly-2017-CDH3-Patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB049.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB049.json
@@ -190,15 +190,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bluteau-2018-SAMD9L-UB049.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB081.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB081.json
@@ -188,15 +188,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bluteau-2018-SAMD9L-UB081.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB085.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB085.json
@@ -277,15 +277,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bluteau-2018-SAMD9L-UB085.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB612.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB612.json
@@ -113,15 +113,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bluteau-2018-SAMD9L-UB612.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Boddrich-1997-NF1-0548.json
+++ b/testdata/phenopackets/lirical/Boddrich-1997-NF1-0548.json
@@ -195,15 +195,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "B\u00f6ddrich-1997-NF1-0548.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Bordbar-2017-PRF1-8-year-old_boy.json
+++ b/testdata/phenopackets/lirical/Bordbar-2017-PRF1-8-year-old_boy.json
@@ -168,15 +168,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bordbar-2017-PRF1-8-year-old_boy.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Bulut-2017-SETBP1-proposita.json
+++ b/testdata/phenopackets/lirical/Bulut-2017-SETBP1-proposita.json
@@ -528,15 +528,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Bulut-2017-SETBP1-proposita.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Calado-2005-UMOD-proband.json
+++ b/testdata/phenopackets/lirical/Calado-2005-UMOD-proband.json
@@ -167,15 +167,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Calado-2005-UMOD-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Canosa-2018-SOD1-patient.json
+++ b/testdata/phenopackets/lirical/Canosa-2018-SOD1-patient.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Canosa-2018-SOD1-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_1.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Cao-2018-FBN1-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_2.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_2.json
@@ -257,15 +257,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Cao-2018-FBN1-Patient_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_3.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_3.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Cao-2018-FBN1-Patient_3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Cao-2018-TGFBR2-Patient_4.json
+++ b/testdata/phenopackets/lirical/Cao-2018-TGFBR2-Patient_4.json
@@ -329,15 +329,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Cao-2018-TGFBR2-Patient_4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Caputo-2014-SMAD4-patient.json
+++ b/testdata/phenopackets/lirical/Caputo-2014-SMAD4-patient.json
@@ -386,15 +386,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Caputo-2014-SMAD4-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Caro-Contreras-2019-ERF-proband.json
+++ b/testdata/phenopackets/lirical/Caro-Contreras-2019-ERF-proband.json
@@ -366,15 +366,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Caro-Contreras-2019-ERF-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Carre-2014-FOXE1-patient.json
+++ b/testdata/phenopackets/lirical/Carre-2014-FOXE1-patient.json
@@ -184,15 +184,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Carr\u00e9-2014-FOXE1-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chabas-2005-GBA-_boy_weighing_1690_g.json
+++ b/testdata/phenopackets/lirical/Chabas-2005-GBA-_boy_weighing_1690_g.json
@@ -178,15 +178,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chab\u00e1s-2005-GBA-_boy_weighing_1690_g.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC6-Patient_B.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC6-Patient_B.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chebly-2018-ERCC6-Patient_B.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_A.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_A.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chebly-2018-ERCC8-Patient_A.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_C.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_C.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chebly-2018-ERCC8-Patient_C.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-III-1.json
+++ b/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-III-1.json
@@ -403,15 +403,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chelban-2017-NKX6-2-III-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-IV-6.json
+++ b/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-IV-6.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chelban-2017-NKX6-2-IV-6.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chen-2014-RUNX2-III_3.json
+++ b/testdata/phenopackets/lirical/Chen-2014-RUNX2-III_3.json
@@ -239,15 +239,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chen-2014-RUNX2-III_3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chen-2016-SAMD9L-II-4.json
+++ b/testdata/phenopackets/lirical/Chen-2016-SAMD9L-II-4.json
@@ -167,15 +167,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chen-2016-SAMD9L-II-4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chen-2016-SAMD9L-IV-1.json
+++ b/testdata/phenopackets/lirical/Chen-2016-SAMD9L-IV-1.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chen-2016-SAMD9L-IV-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Cheng-2018-FBN1-Family_1,_Patient_1.json
+++ b/testdata/phenopackets/lirical/Cheng-2018-FBN1-Family_1,_Patient_1.json
@@ -313,15 +313,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Cheng-2018-FBN1-Family_1,_Patient_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-A-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-A-II-1.json
@@ -563,15 +563,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chong-2016-TBCK-A-II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-4.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-4.json
@@ -491,15 +491,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chong-2016-TBCK-B-IV-4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-6.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-6.json
@@ -347,15 +347,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chong-2016-TBCK-B-IV-6.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-C-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-C-II-1.json
@@ -532,15 +532,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chong-2016-TBCK-C-II-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-D-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-D-II-1.json
@@ -547,15 +547,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Chong-2016-TBCK-D-II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Claverie-Martin-2019-LMX1B-index.json
+++ b/testdata/phenopackets/lirical/Claverie-Martin-2019-LMX1B-index.json
@@ -167,15 +167,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Claverie-Martin-2019-LMX1B-index.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Cuchanski-2018-KIF5A-proband.json
+++ b/testdata/phenopackets/lirical/Cuchanski-2018-KIF5A-proband.json
@@ -278,15 +278,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Cuchanski-2018-KIF5A-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Curtis-1978-FLCN-253.json
+++ b/testdata/phenopackets/lirical/Curtis-1978-FLCN-253.json
@@ -94,15 +94,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Curtis-1978-FLCN-253.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Dastsooz-2017-PANK2-Family_I_patient_I.json
+++ b/testdata/phenopackets/lirical/Dastsooz-2017-PANK2-Family_I_patient_I.json
@@ -188,15 +188,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dastsooz-2017-PANK2-Family_I_patient_I.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Dastsooz-2017-PLA2G6-family_II_patient_II.json
+++ b/testdata/phenopackets/lirical/Dastsooz-2017-PLA2G6-family_II_patient_II.json
@@ -205,15 +205,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dastsooz-2017-PLA2G6-family_II_patient_II.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Dauber-2014-SLC35C1-Proband_1.json
+++ b/testdata/phenopackets/lirical/Dauber-2014-SLC35C1-Proband_1.json
@@ -455,15 +455,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dauber-2014-SLC35C1-Proband_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Delahaye-2007-CHD7-B_III-3.json
+++ b/testdata/phenopackets/lirical/Delahaye-2007-CHD7-B_III-3.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Delahaye-2007-CHD7-B_III-3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Delahaye-2007-CHD7-Patient_A_III-2.json
+++ b/testdata/phenopackets/lirical/Delahaye-2007-CHD7-Patient_A_III-2.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Delahaye-2007-CHD7-Patient_A_III-2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Devalla-2016-TECRL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Devalla-2016-TECRL-Patient_1.json
@@ -204,15 +204,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Devalla-2016-TECRL-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:lccarmody",

--- a/testdata/phenopackets/lirical/Di_Nottia-2017-PARK7-proband.json
+++ b/testdata/phenopackets/lirical/Di_Nottia-2017-PARK7-proband.json
@@ -295,15 +295,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Di_Nottia-2017-PARK7-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Dias-2013-TRPS1-girl.json
+++ b/testdata/phenopackets/lirical/Dias-2013-TRPS1-girl.json
@@ -161,15 +161,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dias-2013-TRPS1-girl.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Dikoglu-2015-LONP1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Dikoglu-2015-LONP1-Patient_1.json
@@ -233,15 +233,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dikoglu-2015-LONP1-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Dinani-2017-AAGAB-family_1_proband.json
+++ b/testdata/phenopackets/lirical/Dinani-2017-AAGAB-family_1_proband.json
@@ -134,15 +134,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dinani-2017-AAGAB-family_1_proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Djamshidian-2009-VCP-II-3.json
+++ b/testdata/phenopackets/lirical/Djamshidian-2009-VCP-II-3.json
@@ -259,15 +259,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Djamshidian-2009-VCP-II-3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Dobbs-2008-FLNB-patient.json
+++ b/testdata/phenopackets/lirical/Dobbs-2008-FLNB-patient.json
@@ -277,15 +277,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dobbs-2008-FLNB-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_1_II-1.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_1_II-1.json
@@ -293,15 +293,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dorboz-2017-NKX6-2-Patient_1_II-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_3_II-3.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_3_II-3.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dorboz-2017-NKX6-2-Patient_3_II-3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_4_II-1.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_4_II-1.json
@@ -268,15 +268,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dorboz-2017-NKX6-2-Patient_4_II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Dougherty-2016-NPC1-The_proband.json
+++ b/testdata/phenopackets/lirical/Dougherty-2016-NPC1-The_proband.json
@@ -340,15 +340,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Dougherty-2016-NPC1-The_proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Du-2018-TINF2-proband.json
+++ b/testdata/phenopackets/lirical/Du-2018-TINF2-proband.json
@@ -279,15 +279,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Du-2018-TINF2-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ekvall-2015-NRAS-case_1.json
+++ b/testdata/phenopackets/lirical/Ekvall-2015-NRAS-case_1.json
@@ -329,15 +329,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ekvall-2015-NRAS-case_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/El-Harith-2009-MPL-FT2_VI_3.json
+++ b/testdata/phenopackets/lirical/El-Harith-2009-MPL-FT2_VI_3.json
@@ -77,15 +77,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "El-Harith-2009-MPL-FT2_VI_3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/El-Jaick-2007-TGIF1-male_proband.json
+++ b/testdata/phenopackets/lirical/El-Jaick-2007-TGIF1-male_proband.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "El-Jaick-2007-TGIF1-male_proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Elsaadany-2016-WWOX-Patient_1.json
+++ b/testdata/phenopackets/lirical/Elsaadany-2016-WWOX-Patient_1.json
@@ -385,15 +385,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Elsaadany-2016-WWOX-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Elsaid-2017-NT5C2-II.3.json
+++ b/testdata/phenopackets/lirical/Elsaid-2017-NT5C2-II.3.json
@@ -294,15 +294,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Elsaid-2017-NT5C2-II.3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Falik_Zaccai-2014-INSR-ISR1.json
+++ b/testdata/phenopackets/lirical/Falik_Zaccai-2014-INSR-ISR1.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Falik_Zaccai-2014-INSR-ISR1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Falik_Zaccai-2017-PLAA-A-VI3.json
+++ b/testdata/phenopackets/lirical/Falik_Zaccai-2017-PLAA-A-VI3.json
@@ -367,15 +367,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Falik_Zaccai-2017-PLAA-A-VI3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fiscaletti-2018-SP7-II_5.json
+++ b/testdata/phenopackets/lirical/Fiscaletti-2018-SP7-II_5.json
@@ -348,15 +348,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fiscaletti-2018-SP7-II_5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_1.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_1.json
@@ -1706,15 +1706,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_10.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_10.json
@@ -167,15 +167,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_10.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_2.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_2.json
@@ -1637,15 +1637,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_3.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_3.json
@@ -1842,15 +1842,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_4.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_4.json
@@ -1689,15 +1689,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_5.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_5.json
@@ -1778,15 +1778,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_6.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_6.json
@@ -1521,15 +1521,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_6.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_7.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_7.json
@@ -1715,15 +1715,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_7.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_8.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_8.json
@@ -1806,15 +1806,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_8.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_9.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_9.json
@@ -1639,15 +1639,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fregeau-2016-RERE-Subject_9.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Fusco-2017-PMP22-Proband.json
+++ b/testdata/phenopackets/lirical/Fusco-2017-PMP22-Proband.json
@@ -188,15 +188,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Fusco-2017-PMP22-Proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_A-V_2.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_A-V_2.json
@@ -203,15 +203,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gan-Or-2016-CAPN1-Family_A-V_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_B-IV_1.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_B-IV_1.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gan-Or-2016-CAPN1-Family_B-IV_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_C-IV_13.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_C-IV_13.json
@@ -142,15 +142,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gan-Or-2016-CAPN1-Family_C-IV_13.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ge-2019-TJP2-proband.json
+++ b/testdata/phenopackets/lirical/Ge-2019-TJP2-proband.json
@@ -399,15 +399,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ge-2019-TJP2-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gebbia-1997-ZIC3-III-1.json
+++ b/testdata/phenopackets/lirical/Gebbia-1997-ZIC3-III-1.json
@@ -264,15 +264,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gebbia-1997-ZIC3-III-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Geiger-2017-TUBB2B-proband.json
+++ b/testdata/phenopackets/lirical/Geiger-2017-TUBB2B-proband.json
@@ -386,15 +386,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Geiger-2017-TUBB2B-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gerding-2009-LITAF-Proband.json
+++ b/testdata/phenopackets/lirical/Gerding-2009-LITAF-Proband.json
@@ -315,15 +315,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gerding-2009-LITAF-Proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Giau-2018-PSEN2-proband.json
+++ b/testdata/phenopackets/lirical/Giau-2018-PSEN2-proband.json
@@ -113,15 +113,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Giau-2018-PSEN2-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gong-2015-CBS-III_3.json
+++ b/testdata/phenopackets/lirical/Gong-2015-CBS-III_3.json
@@ -304,15 +304,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gong-2015-CBS-III_3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Gonzalez-Perez-2009-CAV3-I1.json
+++ b/testdata/phenopackets/lirical/Gonzalez-Perez-2009-CAV3-I1.json
@@ -354,15 +354,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gonz\u00e1lez-P\u00e9rez-2009-CAV3-I1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:lccarmody",

--- a/testdata/phenopackets/lirical/Gowda-2017-MCOLN1-6_year_old_boy.json
+++ b/testdata/phenopackets/lirical/Gowda-2017-MCOLN1-6_year_old_boy.json
@@ -203,15 +203,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gowda-2017-MCOLN1-6_year_old_boy.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Gregor-2018-FBXO11-Individual_1.json
+++ b/testdata/phenopackets/lirical/Gregor-2018-FBXO11-Individual_1.json
@@ -530,15 +530,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gregor-2018-FBXO11-Individual_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Grumach-2015-CARD9-Patient.json
+++ b/testdata/phenopackets/lirical/Grumach-2015-CARD9-Patient.json
@@ -206,15 +206,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Grumach-2015-CARD9-Patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gu-2013-NOTCH2-proband.json
+++ b/testdata/phenopackets/lirical/Gu-2013-NOTCH2-proband.json
@@ -276,15 +276,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gu-2013-NOTCH2-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gueguen-2013-ACTN1-proband.json
+++ b/testdata/phenopackets/lirical/Gueguen-2013-ACTN1-proband.json
@@ -151,15 +151,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gu\u00e9guen-2013-ACTN1-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-3.json
+++ b/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-3.json
@@ -437,15 +437,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Guerreiro-2016-TBCK-II-3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-4.json
+++ b/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-4.json
@@ -331,15 +331,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Guerreiro-2016-TBCK-II-4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Gul-2006-CENPJ-IV-5.json
+++ b/testdata/phenopackets/lirical/Gul-2006-CENPJ-IV-5.json
@@ -188,15 +188,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Gul-2006-CENPJ-IV-5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.12-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Guo-2017-EXTL3-Patient_1.json
+++ b/testdata/phenopackets/lirical/Guo-2017-EXTL3-Patient_1.json
@@ -959,15 +959,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Guo-2017-EXTL3-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Guo-2018-KMT2D-3_month_old_boy.json
+++ b/testdata/phenopackets/lirical/Guo-2018-KMT2D-3_month_old_boy.json
@@ -420,15 +420,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Guo-2018-KMT2D-3_month_old_boy.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Habarou-2017-LIPT2-P1.json
+++ b/testdata/phenopackets/lirical/Habarou-2017-LIPT2-P1.json
@@ -376,15 +376,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Habarou-2017-LIPT2-P1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Haliloglu-2017-PIEZO2-Patient.json
+++ b/testdata/phenopackets/lirical/Haliloglu-2017-PIEZO2-Patient.json
@@ -275,15 +275,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Haliloglu-2017-PIEZO2-Patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_A-IV_6.json
+++ b/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_A-IV_6.json
@@ -455,15 +455,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hall-2017-PLAA-Family_A-IV_6.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_D-Case_VIII-1.json
+++ b/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_D-Case_VIII-1.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hall-2017-PLAA-Family_D-Case_VIII-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hamamy-2014-FYB1-IV_5.json
+++ b/testdata/phenopackets/lirical/Hamamy-2014-FYB1-IV_5.json
@@ -132,15 +132,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hamamy-2014-FYB1-IV_5.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hamzeh-2016-GPSM2-case_1.json
+++ b/testdata/phenopackets/lirical/Hamzeh-2016-GPSM2-case_1.json
@@ -293,15 +293,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hamzeh-2016-GPSM2-case_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Han-2015-CHRDL1-III-1.json
+++ b/testdata/phenopackets/lirical/Han-2015-CHRDL1-III-1.json
@@ -132,15 +132,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Han-2015-CHRDL1-III-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Hara-2019-TGFBR1-patient.json
+++ b/testdata/phenopackets/lirical/Hara-2019-TGFBR1-patient.json
@@ -383,15 +383,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hara-2019-TGFBR1-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Harlalka-2013-HERC2-Pedigree_1A,VIII_8.json
+++ b/testdata/phenopackets/lirical/Harlalka-2013-HERC2-Pedigree_1A,VIII_8.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Harlalka-2013-HERC2-Pedigree_1A,VIII_8.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hashemi-Gorji-2019-MED23-IV.8.json
+++ b/testdata/phenopackets/lirical/Hashemi-Gorji-2019-MED23-IV.8.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hashemi-Gorji-2019-MED23-IV.8.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hayette-1995-EPB42-proposita.json
+++ b/testdata/phenopackets/lirical/Hayette-1995-EPB42-proposita.json
@@ -144,15 +144,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hayette-1995-EPB42-proposita.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Helmi-2017-LYST-patient.json
+++ b/testdata/phenopackets/lirical/Helmi-2017-LYST-patient.json
@@ -318,15 +318,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Helmi-2017-LYST-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hernan-2004-STK11-20-year-old_woman_.json
+++ b/testdata/phenopackets/lirical/Hernan-2004-STK11-20-year-old_woman_.json
@@ -113,15 +113,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hernan-2004-STK11-20-year-old_woman_.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Higuchi-2017-COL2A1-proband.json
+++ b/testdata/phenopackets/lirical/Higuchi-2017-COL2A1-proband.json
@@ -404,15 +404,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Higuchi-2017-COL2A1-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hilgert-2008-TMC1-935-IV_1.json
+++ b/testdata/phenopackets/lirical/Hilgert-2008-TMC1-935-IV_1.json
@@ -96,15 +96,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hilgert-2008-TMC1-935-IV_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hirabayashi-2018-SPINT2-two-month-old_male.json
+++ b/testdata/phenopackets/lirical/Hirabayashi-2018-SPINT2-two-month-old_male.json
@@ -322,15 +322,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hirabayashi-2018-SPINT2-two-month-old_male.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hirschhorn-1991-ADA-Patient.json
+++ b/testdata/phenopackets/lirical/Hirschhorn-1991-ADA-Patient.json
@@ -167,15 +167,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hirschhorn-1991-ADA-Patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Ho-2018-GNPTAB-proband.json
+++ b/testdata/phenopackets/lirical/Ho-2018-GNPTAB-proband.json
@@ -340,15 +340,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ho-2018-GNPTAB-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Holmberg-1997-GP1BA-73_year_old_male.json
+++ b/testdata/phenopackets/lirical/Holmberg-1997-GP1BA-73_year_old_male.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Holmberg-1997-GP1BA-73_year_old_male.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Horvath-2014-GLRA1-proband.json
+++ b/testdata/phenopackets/lirical/Horvath-2014-GLRA1-proband.json
@@ -150,15 +150,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Horv\u00e1th-2014-GLRA1-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hsu-2017-SNAP29-The_patient.json
+++ b/testdata/phenopackets/lirical/Hsu-2017-SNAP29-The_patient.json
@@ -401,15 +401,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hsu-2017-SNAP29-The_patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Huang-2017-P3H1-proband.json
+++ b/testdata/phenopackets/lirical/Huang-2017-P3H1-proband.json
@@ -159,15 +159,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Huang-2017-P3H1-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Hyun-2018-TP53RK-II-1.json
+++ b/testdata/phenopackets/lirical/Hyun-2018-TP53RK-II-1.json
@@ -239,15 +239,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Hyun-2018-TP53RK-II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Imani-2019-BBS5-II_2.json
+++ b/testdata/phenopackets/lirical/Imani-2019-BBS5-II_2.json
@@ -168,15 +168,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Imani-2019-BBS5-II_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Infante-2017-SMC3-patient_1.json
+++ b/testdata/phenopackets/lirical/Infante-2017-SMC3-patient_1.json
@@ -474,15 +474,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Infante-2017-SMC3-patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Inlora-2017-APTX-V-3.json
+++ b/testdata/phenopackets/lirical/Inlora-2017-APTX-V-3.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Inlora-2017-APTX-V-3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Inui-2017-LONP1-Proband.json
+++ b/testdata/phenopackets/lirical/Inui-2017-LONP1-Proband.json
@@ -325,15 +325,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Inui-2017-LONP1-Proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Irfanullah-2015-NPR2-IV-2_family-A.json
+++ b/testdata/phenopackets/lirical/Irfanullah-2015-NPR2-IV-2_family-A.json
@@ -240,15 +240,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Irfanullah-2015-NPR2-IV-2_family-A.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ishii-2013-KCNT1-Patient-1.json
+++ b/testdata/phenopackets/lirical/Ishii-2013-KCNT1-Patient-1.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ishii-2013-KCNT1-Patient-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Itoh-Satoh-2002-TTN-JK109.json
+++ b/testdata/phenopackets/lirical/Itoh-Satoh-2002-TTN-JK109.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Itoh-Satoh-2002-TTN-JK109.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jagadisan-2017-PYGL-2-year_5-month_old_child.json
+++ b/testdata/phenopackets/lirical/Jagadisan-2017-PYGL-2-year_5-month_old_child.json
@@ -317,15 +317,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jagadisan-2017-PYGL-2-year_5-month_old_child.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Janecke-2015-SLC9A3-Patient_9.json
+++ b/testdata/phenopackets/lirical/Janecke-2015-SLC9A3-Patient_9.json
@@ -251,15 +251,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Janecke-2015-SLC9A3-Patient_9.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F1-II2.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F1-II2.json
@@ -257,15 +257,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jansen-2016-TMEM199-F1-II2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F2-II2.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F2-II2.json
@@ -397,15 +397,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jansen-2016-TMEM199-F2-II2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F3-II1.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F3-II1.json
@@ -263,15 +263,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jansen-2016-TMEM199-F3-II1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Janssen-2009-BSND-family-A-III3.json
+++ b/testdata/phenopackets/lirical/Janssen-2009-BSND-family-A-III3.json
@@ -222,15 +222,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "/data/WHRI-Phenogenomics/projects/pheval/LiricalPhenopacketSimulations/vcf/Janssen-2009-BSND-family-A.III3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Javadiyan-2017-MAF-patient_CSA108.01.json
+++ b/testdata/phenopackets/lirical/Javadiyan-2017-MAF-patient_CSA108.01.json
@@ -77,15 +77,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Javadiyan-2017-MAF-patient_CSA108.01.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jeon-2014-LAMC2-patient.json
+++ b/testdata/phenopackets/lirical/Jeon-2014-LAMC2-patient.json
@@ -178,15 +178,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jeon-2014-LAMC2-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ji-2017-ATRX-Proband.json
+++ b/testdata/phenopackets/lirical/Ji-2017-ATRX-Proband.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ji-2017-ATRX-Proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jiang-2017-PPIB-second_fetus.json
+++ b/testdata/phenopackets/lirical/Jiang-2017-PPIB-second_fetus.json
@@ -177,15 +177,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jiang-2017-PPIB-second_fetus.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Jin-2017-FBN1-patient.json
+++ b/testdata/phenopackets/lirical/Jin-2017-FBN1-patient.json
@@ -366,15 +366,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jin-2017-FBN1-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_2.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_2.json
@@ -466,15 +466,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jordan-2018-RERE-Subject_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_3.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_3.json
@@ -693,15 +693,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jordan-2018-RERE-Subject_3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_4.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_4.json
@@ -354,15 +354,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jordan-2018-RERE-Subject_4.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_5.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_5.json
@@ -623,15 +623,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jordan-2018-RERE-Subject_5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_6.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_6.json
@@ -322,15 +322,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jordan-2018-RERE-Subject_6.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_7.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_7.json
@@ -743,15 +743,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jordan-2018-RERE-Subject_7.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_8.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_8.json
@@ -732,15 +732,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jordan-2018-RERE-Subject_8.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_9.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_9.json
@@ -438,15 +438,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Jordan-2018-RERE-Subject_9.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kantaputra-2014-FBLN5-4-year-old_Burmese_girl_.json
+++ b/testdata/phenopackets/lirical/Kantaputra-2014-FBLN5-4-year-old_Burmese_girl_.json
@@ -277,15 +277,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kantaputra-2014-FBLN5-4-year-old_Burmese_girl_.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kato-2018-HNF1B-patient.json
+++ b/testdata/phenopackets/lirical/Kato-2018-HNF1B-patient.json
@@ -168,15 +168,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kato-2018-HNF1B-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Khan-2017-HOXC13-IV-1.json
+++ b/testdata/phenopackets/lirical/Khan-2017-HOXC13-IV-1.json
@@ -187,15 +187,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Khan-2017-HOXC13-IV-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Kim-2016-LAMB3-proband.json
+++ b/testdata/phenopackets/lirical/Kim-2016-LAMB3-proband.json
@@ -95,15 +95,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kim-2016-LAMB3-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kinnear-2017-TTC37-index.json
+++ b/testdata/phenopackets/lirical/Kinnear-2017-TTC37-index.json
@@ -368,15 +368,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kinnear-2017-TTC37-index.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kluijtmans-1996-CBS-patient.json
+++ b/testdata/phenopackets/lirical/Kluijtmans-1996-CBS-patient.json
@@ -132,15 +132,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kluijtmans-1996-CBS-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam1Pat1.json
+++ b/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam1Pat1.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kocoglu-2018-CAPN1-Fam1Pat1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam2Pat1.json
+++ b/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam2Pat1.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kocoglu-2018-CAPN1-Fam2Pat1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Konkolova-2017-GRHPR-patient.json
+++ b/testdata/phenopackets/lirical/Konkolova-2017-GRHPR-patient.json
@@ -260,15 +260,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Konko\u013eov\u00e1-2017-GRHPR-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kou-2018-ERCC6-index.json
+++ b/testdata/phenopackets/lirical/Kou-2018-ERCC6-index.json
@@ -383,15 +383,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kou-2018-ERCC6-index.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kremer-2016-TANGO2-F1_II.2.json
+++ b/testdata/phenopackets/lirical/Kremer-2016-TANGO2-F1_II.2.json
@@ -473,15 +473,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kremer-2016-TANGO2-F1_II.2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Kretz-2011-PYCR1-Patient_4.json
+++ b/testdata/phenopackets/lirical/Kretz-2011-PYCR1-Patient_4.json
@@ -349,15 +349,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kretz-2011-PYCR1-Patient_4.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.12-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kruszka-2016-FGFR3-Proband_27.json
+++ b/testdata/phenopackets/lirical/Kruszka-2016-FGFR3-Proband_27.json
@@ -150,15 +150,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kruszka-2016-FGFR3-Proband_27.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Kuptanon-2018-WNT1-proband.json
+++ b/testdata/phenopackets/lirical/Kuptanon-2018-WNT1-proband.json
@@ -260,15 +260,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Kuptanon-2018-WNT1-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_1.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_1.json
@@ -671,15 +671,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "K\u00fcry-2017-PSMD12-Subject_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_2.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_2.json
@@ -601,15 +601,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "K\u00fcry-2017-PSMD12-Subject_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_3.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_3.json
@@ -279,15 +279,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "K\u00fcry-2017-PSMD12-Subject_3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_4.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_4.json
@@ -437,15 +437,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "K\u00fcry-2017-PSMD12-Subject_4.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_2.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_2.json
@@ -654,15 +654,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lalani-2016-TANGO2-Subject_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_4.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_4.json
@@ -347,15 +347,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lalani-2016-TANGO2-Subject_4.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_5.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_5.json
@@ -437,15 +437,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lalani-2016-TANGO2-Subject_5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_6.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_6.json
@@ -368,15 +368,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lalani-2016-TANGO2-Subject_6.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Suject_1.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Suject_1.json
@@ -420,15 +420,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lalani-2016-TANGO2-Suject_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lambe-2018-CAPN1-II-4.json
+++ b/testdata/phenopackets/lirical/Lambe-2018-CAPN1-II-4.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lambe-2018-CAPN1-II-4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_A,_V-2.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_A,_V-2.json
@@ -386,15 +386,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lesage-2016-VPS13C-Family_A,_V-2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_B,_II-1.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_B,_II-1.json
@@ -178,15 +178,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lesage-2016-VPS13C-Family_B,_II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_C,_II-1.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_C,_II-1.json
@@ -161,15 +161,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lesage-2016-VPS13C-Family_C,_II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Li-2014-BBS4-4-year-old_female_patient.json
+++ b/testdata/phenopackets/lirical/Li-2014-BBS4-4-year-old_female_patient.json
@@ -239,15 +239,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Li-2014-BBS4-4-year-old_female_patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Li-2018-STXBP1-P1.json
+++ b/testdata/phenopackets/lirical/Li-2018-STXBP1-P1.json
@@ -166,15 +166,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Li-2018-STXBP1-P1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Liberalesso-2017-SALL1-VMFS.json
+++ b/testdata/phenopackets/lirical/Liberalesso-2017-SALL1-VMFS.json
@@ -476,15 +476,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Liberalesso-2017-SALL1-VMFS.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ling-2019-NHS-III_1.json
+++ b/testdata/phenopackets/lirical/Ling-2019-NHS-III_1.json
@@ -214,15 +214,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ling-2019-NHS-III_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Lopez-2018-EP300-11.json
+++ b/testdata/phenopackets/lirical/Lopez-2018-EP300-11.json
@@ -537,15 +537,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "L\u00f3pez-2018-EP300-11.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Lopez-2018-EP300-38.json
+++ b/testdata/phenopackets/lirical/Lopez-2018-EP300-38.json
@@ -534,15 +534,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "L\u00f3pez-2018-EP300-38.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Luco-2016-DYRK1A-Patient_2.json
+++ b/testdata/phenopackets/lirical/Luco-2016-DYRK1A-Patient_2.json
@@ -401,15 +401,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Luco-2016-DYRK1A-Patient_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Luo-2016-COMP-II-1.json
+++ b/testdata/phenopackets/lirical/Luo-2016-COMP-II-1.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Luo-2016-COMP-II-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Lv-2016-TMEM38B-family2-patient2.json
+++ b/testdata/phenopackets/lirical/Lv-2016-TMEM38B-family2-patient2.json
@@ -223,15 +223,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Lv-2016-TMEM38B-family2-patient2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ma-2018-SPTA1-proband.json
+++ b/testdata/phenopackets/lirical/Ma-2018-SPTA1-proband.json
@@ -271,15 +271,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ma-2018-SPTA1-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mackenroth-2016-ADAMTSL2-patient.json
+++ b/testdata/phenopackets/lirical/Mackenroth-2016-ADAMTSL2-patient.json
@@ -377,15 +377,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mackenroth-2016-ADAMTSL2-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Magerus-Chatinet-2013-FASLG-patient.json
+++ b/testdata/phenopackets/lirical/Magerus-Chatinet-2013-FASLG-patient.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Magerus-Chatinet-2013-FASLG-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Maghami-2018-FKBP10-proband.json
+++ b/testdata/phenopackets/lirical/Maghami-2018-FKBP10-proband.json
@@ -227,15 +227,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Maghami-2018-FKBP10-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mattioli-2017-BRPF1-Individual_11_Family_F.json
+++ b/testdata/phenopackets/lirical/Mattioli-2017-BRPF1-Individual_11_Family_F.json
@@ -258,15 +258,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mattioli-2017-BRPF1-Individual_11_Family_F.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mazzucchelli-2011-LAMA3-Proband.json
+++ b/testdata/phenopackets/lirical/Mazzucchelli-2011-LAMA3-Proband.json
@@ -95,15 +95,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mazzucchelli-2011-LAMA3-Proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_1.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mei-2015-NIPBL-Patient_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_2.json
+++ b/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_2.json
@@ -239,15 +239,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mei-2015-NIPBL-Patient_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_1.json
+++ b/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_1.json
@@ -413,15 +413,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Metodiev-2016-TRMT10C-Subject_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_2.json
+++ b/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_2.json
@@ -329,15 +329,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Metodiev-2016-TRMT10C-Subject_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Miao-2018-CLCN1-man.json
+++ b/testdata/phenopackets/lirical/Miao-2018-CLCN1-man.json
@@ -187,15 +187,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Miao-2018-CLCN1-man.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Michalska-2018-GTF2H5-male_infant.json
+++ b/testdata/phenopackets/lirical/Michalska-2018-GTF2H5-male_infant.json
@@ -574,15 +574,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Michalska-2018-GTF2H5-male_infant.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mokbel-2013-TPM2-1A.json
+++ b/testdata/phenopackets/lirical/Mokbel-2013-TPM2-1A.json
@@ -144,15 +144,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mokbel-2013-TPM2-1A.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Montgomery-2015-AMN-III_1.json
+++ b/testdata/phenopackets/lirical/Montgomery-2015-AMN-III_1.json
@@ -142,15 +142,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Montgomery-2015-AMN-III_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Moosa-1799-MTOR-index.json
+++ b/testdata/phenopackets/lirical/Moosa-1799-MTOR-index.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Moosa-1799-MTOR-index.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Moreau-Le_Lan-2018-ACTA1-Patient_5.json
+++ b/testdata/phenopackets/lirical/Moreau-Le_Lan-2018-ACTA1-Patient_5.json
@@ -245,15 +245,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Moreau-Le_Lan-2018-ACTA1-Patient_5.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_1.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mundhofir-2013-FGFR2-Patient_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_2.json
+++ b/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_2.json
@@ -347,15 +347,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mundhofir-2013-FGFR2-Patient_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Mwasamwaja-2018-TGFB1-patient.json
+++ b/testdata/phenopackets/lirical/Mwasamwaja-2018-TGFB1-patient.json
@@ -296,15 +296,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Mwasamwaja-2018-TGFB1-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Nakajima-2013-B3GALT6-P7_F6.json
+++ b/testdata/phenopackets/lirical/Nakajima-2013-B3GALT6-P7_F6.json
@@ -622,15 +622,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Nakajima-2013-B3GALT6-P7_F6.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:lccarmody",

--- a/testdata/phenopackets/lirical/Naz_Villalba-2016-NLRP3-proband.json
+++ b/testdata/phenopackets/lirical/Naz_Villalba-2016-NLRP3-proband.json
@@ -223,15 +223,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Naz_Villalba-2016-NLRP3-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Nellist-2009-TSC1-II_3_Family_2.json
+++ b/testdata/phenopackets/lirical/Nellist-2009-TSC1-II_3_Family_2.json
@@ -213,15 +213,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Nellist-2009-TSC1-II_3_Family_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:lccarmody",

--- a/testdata/phenopackets/lirical/Nevidomskyte-2017-SMAD3-54-year_old_woman.json
+++ b/testdata/phenopackets/lirical/Nevidomskyte-2017-SMAD3-54-year_old_woman.json
@@ -95,15 +95,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Nevidomskyte-2017-SMAD3-54-year_old_woman.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Nguyen-2017-NPHS1-patient_1.json
+++ b/testdata/phenopackets/lirical/Nguyen-2017-NPHS1-patient_1.json
@@ -279,15 +279,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Nguyen-2017-NPHS1-patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Nicole-2014-AGRN-Patient_3_Kinship_2.json
+++ b/testdata/phenopackets/lirical/Nicole-2014-AGRN-Patient_3_Kinship_2.json
@@ -359,15 +359,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Nicole-2014-AGRN-Patient_3_Kinship_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:lccarmody",

--- a/testdata/phenopackets/lirical/Niihori-2006-BRAF-CFC16.json
+++ b/testdata/phenopackets/lirical/Niihori-2006-BRAF-CFC16.json
@@ -349,15 +349,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Niihori-2006-BRAF-CFC16.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ning-2015-MEN1-III-3.json
+++ b/testdata/phenopackets/lirical/Ning-2015-MEN1-III-3.json
@@ -330,15 +330,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ning-2015-MEN1-III-3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Noch-2017-ATP13A2-Case_1.json
+++ b/testdata/phenopackets/lirical/Noch-2017-ATP13A2-Case_1.json
@@ -276,15 +276,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Noch-2017-ATP13A2-Case_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ockeloen-2012-CFL2-_Patient_1.json
+++ b/testdata/phenopackets/lirical/Ockeloen-2012-CFL2-_Patient_1.json
@@ -277,15 +277,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ockeloen-2012-CFL2-_Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Okamoto-2018-ASPM-patient.json
+++ b/testdata/phenopackets/lirical/Okamoto-2018-ASPM-patient.json
@@ -268,15 +268,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Okamoto-2018-ASPM-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-AII-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-AII-1.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Oud-2017-EXTL3-AII-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-BII-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-BII-1.json
@@ -527,15 +527,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Oud-2017-EXTL3-BII-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-B_II-2.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-B_II-2.json
@@ -535,15 +535,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Oud-2017-EXTL3-B_II-2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-C_II-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-C_II-1.json
@@ -275,15 +275,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Oud-2017-EXTL3-C_II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-D_IV-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-D_IV-1.json
@@ -473,15 +473,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Oud-2017-EXTL3-D_IV-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-E_II-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-E_II-1.json
@@ -419,15 +419,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Oud-2017-EXTL3-E_II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Papanastasiou-2010-STAT3-12_year_old_girl.json
+++ b/testdata/phenopackets/lirical/Papanastasiou-2010-STAT3-12_year_old_girl.json
@@ -278,15 +278,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Papanastasiou-2010-STAT3-12_year_old_girl.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Park-2014-DNM2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Park-2014-DNM2-Patient_1.json
@@ -277,15 +277,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Park-2014-DNM2-Patient_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:lccarmody",

--- a/testdata/phenopackets/lirical/Park-2016-GSN-III_5.json
+++ b/testdata/phenopackets/lirical/Park-2016-GSN-III_5.json
@@ -167,15 +167,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Park-2016-GSN-III_5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Pasic-2013-NBN-12-year-old_girl.json
+++ b/testdata/phenopackets/lirical/Pasic-2013-NBN-12-year-old_girl.json
@@ -383,15 +383,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Pasic-2013-NBN-12-year-old_girl.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P5.json
+++ b/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P5.json
@@ -95,15 +95,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Pastor-2018-SAMD9L-P5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P7.json
+++ b/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P7.json
@@ -95,15 +95,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Pastor-2018-SAMD9L-P7.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Patsi-2018-PNPLA6-18_year-old_female.json
+++ b/testdata/phenopackets/lirical/Patsi-2018-PNPLA6-18_year-old_female.json
@@ -365,15 +365,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Patsi-2018-PNPLA6-18_year-old_female.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Paun-2013-RET-DM_patient.json
+++ b/testdata/phenopackets/lirical/Paun-2013-RET-DM_patient.json
@@ -110,15 +110,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "P\u0103un-2013-RET-DM_patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Pipilas-2016-CALM1-Case_2.json
+++ b/testdata/phenopackets/lirical/Pipilas-2016-CALM1-Case_2.json
@@ -132,15 +132,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Pipilas-2016-CALM1-Case_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Pipilas-2016-CALM2-Case_1.json
+++ b/testdata/phenopackets/lirical/Pipilas-2016-CALM2-Case_1.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Pipilas-2016-CALM2-Case_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Prada-2014-CTSA-BAB3767.json
+++ b/testdata/phenopackets/lirical/Prada-2014-CTSA-BAB3767.json
@@ -328,15 +328,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Prada-2014-CTSA-BAB3767.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Qin-2017-NRL-II_2.json
+++ b/testdata/phenopackets/lirical/Qin-2017-NRL-II_2.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Qin-2017-NRL-II_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Rejeb-2017-VPS13B-proposita.json
+++ b/testdata/phenopackets/lirical/Rejeb-2017-VPS13B-proposita.json
@@ -414,15 +414,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Rejeb-2017-VPS13B-proposita.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Reyes-de_la_Rosa-2018-JAG1-Proband.json
+++ b/testdata/phenopackets/lirical/Reyes-de_la_Rosa-2018-JAG1-Proband.json
@@ -384,15 +384,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Reyes-de_la_Rosa-2018-JAG1-Proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Rincon-2019-WRN-48-year-old_male.json
+++ b/testdata/phenopackets/lirical/Rincon-2019-WRN-48-year-old_male.json
@@ -386,15 +386,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Rinc\u00f3n-2019-WRN-48-year-old_male.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ritelli-2013-COL5A1-AN_002501.json
+++ b/testdata/phenopackets/lirical/Ritelli-2013-COL5A1-AN_002501.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ritelli-2013-COL5A1-AN_002501.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ritelli-2014-TGFB2-proposita.json
+++ b/testdata/phenopackets/lirical/Ritelli-2014-TGFB2-proposita.json
@@ -330,15 +330,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ritelli-2014-TGFB2-proposita.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Ritelli-2019-AEBP1-AN_006205.json
+++ b/testdata/phenopackets/lirical/Ritelli-2019-AEBP1-AN_006205.json
@@ -474,15 +474,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ritelli-2019-AEBP1-AN_006205.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Rohanizadegan-2018-DHCR24-proband.json
+++ b/testdata/phenopackets/lirical/Rohanizadegan-2018-DHCR24-proband.json
@@ -672,15 +672,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Rohanizadegan-2018-DHCR24-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Romero-Quintana-2013-CTSC-Case_1P1.json
+++ b/testdata/phenopackets/lirical/Romero-Quintana-2013-CTSC-Case_1P1.json
@@ -167,15 +167,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Romero-Quintana-2013-CTSC-Case_1P1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Salas-Alanis-2016-ANTXR1-14_year_old_brother.json
+++ b/testdata/phenopackets/lirical/Salas-Alanis-2016-ANTXR1-14_year_old_brother.json
@@ -246,15 +246,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Salas-Alan\u00eds-2016-ANTXR1-14_year_old_brother.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Salpietro-2018-DDX59-Patient_1.json
+++ b/testdata/phenopackets/lirical/Salpietro-2018-DDX59-Patient_1.json
@@ -257,15 +257,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Salpietro-2018-DDX59-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Sandal-2018-CHST14-3-year_old_boy.json
+++ b/testdata/phenopackets/lirical/Sandal-2018-CHST14-3-year_old_boy.json
@@ -347,15 +347,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Sandal-2018-CHST14-3-year_old_boy.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Savage-2016-FANCI-NCI-309-1.json
+++ b/testdata/phenopackets/lirical/Savage-2016-FANCI-NCI-309-1.json
@@ -250,15 +250,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Savage-2016-FANCI-NCI-309-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Sawal-2018-ADGRG1-Family_A,_II_2.json
+++ b/testdata/phenopackets/lirical/Sawal-2018-ADGRG1-Family_A,_II_2.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Sawal-2018-ADGRG1-Family_A,_II_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Schaefer-2014-POLR1D-family_1_patient.json
+++ b/testdata/phenopackets/lirical/Schaefer-2014-POLR1D-family_1_patient.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Schaefer-2014-POLR1D-family_1_patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Schormair-2018-VPS13C-VPS13C_case.json
+++ b/testdata/phenopackets/lirical/Schormair-2018-VPS13C-VPS13C_case.json
@@ -286,15 +286,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Schormair-2018-VPS13C-VPS13C_case.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Schreckenbach-2014-TPM3-II.2.json
+++ b/testdata/phenopackets/lirical/Schreckenbach-2014-TPM3-II.2.json
@@ -428,15 +428,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Schreckenbach-2014-TPM3-II.2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Schussler-2018-ANTXR2-II-3_.json
+++ b/testdata/phenopackets/lirical/Schussler-2018-ANTXR2-II-3_.json
@@ -293,15 +293,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Schussler-2018-ANTXR2-II-3_.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Schweizer-2014-HCN4-family_A_II_1.json
+++ b/testdata/phenopackets/lirical/Schweizer-2014-HCN4-family_A_II_1.json
@@ -113,15 +113,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Schweizer-2014-HCN4-family_A_II_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Seidlmayer-2018-RYR2-proband.json
+++ b/testdata/phenopackets/lirical/Seidlmayer-2018-RYR2-proband.json
@@ -169,15 +169,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Seidlmayer-2018-RYR2-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Sekelska-2017-SPRED1-P62.json
+++ b/testdata/phenopackets/lirical/Sekelska-2017-SPRED1-P62.json
@@ -95,15 +95,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Sekelska-2017-SPRED1-P62.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Servian-Morilla-2016-POGLUT1-Patient_II.1.json
+++ b/testdata/phenopackets/lirical/Servian-Morilla-2016-POGLUT1-Patient_II.1.json
@@ -287,15 +287,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Servi\u00e1n-Morilla-2016-POGLUT1-Patient_II.1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:lccarmody",

--- a/testdata/phenopackets/lirical/Seven-2014-DYM-Patient_2.json
+++ b/testdata/phenopackets/lirical/Seven-2014-DYM-Patient_2.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Seven-2014-DYM-Patient_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Shahid-2019-FERMT3-index.json
+++ b/testdata/phenopackets/lirical/Shahid-2019-FERMT3-index.json
@@ -133,15 +133,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Shahid-2019-FERMT3-index.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Shalaby-2009-MYOT-patient.json
+++ b/testdata/phenopackets/lirical/Shalaby-2009-MYOT-patient.json
@@ -150,15 +150,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Shalaby-2009-MYOT-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Shen-2017-VPS13A-Patient-2.json
+++ b/testdata/phenopackets/lirical/Shen-2017-VPS13A-Patient-2.json
@@ -250,15 +250,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Shen-2017-VPS13A-Patient-2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Sher-2014-CHSY1-IV-1.json
+++ b/testdata/phenopackets/lirical/Sher-2014-CHSY1-IV-1.json
@@ -350,15 +350,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Sher-2014-CHSY1-IV-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Shervin_Badv-2019-ASAH1-patient.json
+++ b/testdata/phenopackets/lirical/Shervin_Badv-2019-ASAH1-patient.json
@@ -295,15 +295,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Shervin_Badv-2019-ASAH1-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Shlebak-2015-GP1BA-Patient_3.json
+++ b/testdata/phenopackets/lirical/Shlebak-2015-GP1BA-Patient_3.json
@@ -242,15 +242,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Shlebak-2015-GP1BA-Patient_3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Silva-2018-PREPL-proband.json
+++ b/testdata/phenopackets/lirical/Silva-2018-PREPL-proband.json
@@ -383,15 +383,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Silva-2018-PREPL-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Skraban-2017-WDR26-Individual_1,_PPMD01P,_GEA055P.json
+++ b/testdata/phenopackets/lirical/Skraban-2017-WDR26-Individual_1,_PPMD01P,_GEA055P.json
@@ -1025,15 +1025,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Skraban-2017-WDR26-Individual_1,_PPMD01P,_GEA055P.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Skrabl-Baumgartner-2017-ADA2-patient_1.json
+++ b/testdata/phenopackets/lirical/Skrabl-Baumgartner-2017-ADA2-patient_1.json
@@ -322,15 +322,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Skrabl-Baumgartner-2017-ADA2-patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Slavotinek-2017-TBL1XR1-seven_year_old_male.json
+++ b/testdata/phenopackets/lirical/Slavotinek-2017-TBL1XR1-seven_year_old_male.json
@@ -582,15 +582,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Slavotinek-2017-TBL1XR1-seven_year_old_male.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Smith-2000-MITF-family_815.json
+++ b/testdata/phenopackets/lirical/Smith-2000-MITF-family_815.json
@@ -167,15 +167,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Smith-2000-MITF-family_815.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Smith-2017-ACP4-Family_1-IV_3.json
+++ b/testdata/phenopackets/lirical/Smith-2017-ACP4-Family_1-IV_3.json
@@ -95,15 +95,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Smith-2017-ACP4-Family_1-IV_3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Snanoudj-2019-SERAC1-proband.json
+++ b/testdata/phenopackets/lirical/Snanoudj-2019-SERAC1-proband.json
@@ -504,15 +504,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Snanoudj-2019-SERAC1-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Soumittra-2014-SLC4A11-Patient_1.json
+++ b/testdata/phenopackets/lirical/Soumittra-2014-SLC4A11-Patient_1.json
@@ -94,15 +94,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Soumittra-2014-SLC4A11-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Steinkellner-2015-ADAMTS10-18-year-old_woman.json
+++ b/testdata/phenopackets/lirical/Steinkellner-2015-ADAMTS10-18-year-old_woman.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Steinkellner-2015-ADAMTS10-18-year-old_woman.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Stouffs-2018-RTTN-Patient_3.json
+++ b/testdata/phenopackets/lirical/Stouffs-2018-RTTN-Patient_3.json
@@ -239,15 +239,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Stouffs-2018-RTTN-Patient_3.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Straniero-2018-OTUD6B-proband.json
+++ b/testdata/phenopackets/lirical/Straniero-2018-OTUD6B-proband.json
@@ -340,15 +340,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Straniero-2018-OTUD6B-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Suarez-Artiles-2018-OCRL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Suarez-Artiles-2018-OCRL-Patient_1.json
@@ -204,15 +204,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Suarez-Artiles-2018-OCRL-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Suter-2016-USB1-patient.json
+++ b/testdata/phenopackets/lirical/Suter-2016-USB1-patient.json
@@ -184,15 +184,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Suter-2016-USB1-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Szczałuba-2018-GNB1-proband.json
+++ b/testdata/phenopackets/lirical/Szczałuba-2018-GNB1-proband.json
@@ -240,15 +240,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Szcza\u0142uba-2018-GNB1-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-1-II-1.json
+++ b/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-1-II-1.json
@@ -482,15 +482,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ta-Shma-2017-TMEM260-1-II-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-2-II-4.json
+++ b/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-2-II-4.json
@@ -407,15 +407,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Ta-Shma-2017-TMEM260-2-II-4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tadic-2017-CAPN1-Index.json
+++ b/testdata/phenopackets/lirical/Tadic-2017-CAPN1-Index.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tadic-2017-CAPN1-Index.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Taghizade_Mortezaee-2015-ITGB2-P1.json
+++ b/testdata/phenopackets/lirical/Taghizade_Mortezaee-2015-ITGB2-P1.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Taghizade_Mortezaee-2015-ITGB2-P1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Takagi-2006-WNK1-Patient.json
+++ b/testdata/phenopackets/lirical/Takagi-2006-WNK1-Patient.json
@@ -327,15 +327,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Takagi-2006-WNK1-Patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:lccarmody",

--- a/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_1.json
@@ -419,15 +419,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tamhankar-2014-ROR2-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_2.json
+++ b/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_2.json
@@ -401,15 +401,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tamhankar-2014-ROR2-Patient_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tamura-2017-DHCR7-patient.json
+++ b/testdata/phenopackets/lirical/Tamura-2017-DHCR7-patient.json
@@ -323,15 +323,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tamura-2017-DHCR7-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tan-2014-CDK5RAP2-patient.json
+++ b/testdata/phenopackets/lirical/Tan-2014-CDK5RAP2-patient.json
@@ -196,15 +196,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tan-2014-CDK5RAP2-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-II-4.json
+++ b/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-II-4.json
@@ -293,15 +293,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tesi-2017-SAMD9L-II-4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-III-1.json
+++ b/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-III-1.json
@@ -239,15 +239,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tesi-2017-SAMD9L-III-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tian-2018-ACVR1-patient.json
+++ b/testdata/phenopackets/lirical/Tian-2018-ACVR1-patient.json
@@ -243,15 +243,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tian-2018-ACVR1-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tiecke-2001-FBN1-B15.json
+++ b/testdata/phenopackets/lirical/Tiecke-2001-FBN1-B15.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tiecke-2001-FBN1-B15.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Tran-2015-GALT-FKT118.json
+++ b/testdata/phenopackets/lirical/Tran-2015-GALT-FKT118.json
@@ -214,15 +214,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Tran-2015-GALT-FKT118.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Travaglini-2017-CAPN1-index.json
+++ b/testdata/phenopackets/lirical/Travaglini-2017-CAPN1-index.json
@@ -160,15 +160,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Travaglini-2017-CAPN1-index.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS324.json
+++ b/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS324.json
@@ -509,15 +509,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Truong-2010-RAI1-SMS324.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS335.json
+++ b/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS335.json
@@ -329,15 +329,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Truong-2010-RAI1-SMS335.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Twigg-2013-EFNB1-3269.json
+++ b/testdata/phenopackets/lirical/Twigg-2013-EFNB1-3269.json
@@ -365,15 +365,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Twigg-2013-EFNB1-3269.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Unger-2008-CCNQ-Case_2.json
+++ b/testdata/phenopackets/lirical/Unger-2008-CCNQ-Case_2.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Unger-2008-CCNQ-Case_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Uysal-2017-KCNQ1-family_III-IV-5.json
+++ b/testdata/phenopackets/lirical/Uysal-2017-KCNQ1-family_III-IV-5.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "/data/WHRI-Phenogenomics/projects/pheval/LiricalPhenopacketSimulations/vcf/Uysal-2017-KCNQ1-family_III_IV-5.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_1.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_1.json
@@ -214,15 +214,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Vajro-2018-TMEM199-Patient_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_2.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_2.json
@@ -214,15 +214,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Vajro-2018-TMEM199-Patient_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_3.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_3.json
@@ -196,15 +196,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Vajro-2018-TMEM199-Patient_3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIII_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIII_1.json
@@ -316,15 +316,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Van_Damme-2017-ATP6V1A-PIII_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIV_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIV_1.json
@@ -405,15 +405,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Van_Damme-2017-ATP6V1A-PIV_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PV_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PV_1.json
@@ -261,15 +261,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Van_Damme-2017-ATP6V1A-PV_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PII_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PII_1.json
@@ -297,15 +297,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Van_Damme-2017-ATP6V1E1-PII_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PI_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PI_1.json
@@ -297,15 +297,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Van_Damme-2017-ATP6V1E1-PI_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Van_De_Weghe-2017-ARMC9-UW132-3.json
+++ b/testdata/phenopackets/lirical/Van_De_Weghe-2017-ARMC9-UW132-3.json
@@ -178,15 +178,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Van_De_Weghe-2017-ARMC9-UW132-3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Van_Zwieten-2013-SLC4A1-c.1432-2A_T.json
+++ b/testdata/phenopackets/lirical/Van_Zwieten-2013-SLC4A1-c.1432-2A_T.json
@@ -112,15 +112,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Van_Zwieten-2013-SLC4A1-c.1432-2A_T.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Vogiatzi-2018-COL11A1-proband.json
+++ b/testdata/phenopackets/lirical/Vogiatzi-2018-COL11A1-proband.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Vogiatzi-2018-COL11A1-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_1.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_1.json
@@ -239,15 +239,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Volpi-2017-EXTL3-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_2.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_2.json
@@ -203,15 +203,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Volpi-2017-EXTL3-Patient_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_3.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_3.json
@@ -563,15 +563,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Volpi-2017-EXTL3-Patient_3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Vrtel-1996-TSC2-III-1.json
+++ b/testdata/phenopackets/lirical/Vrtel-1996-TSC2-III-1.json
@@ -127,15 +127,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Vrtel-1996-TSC2-III-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Wakil-2018-RETREG1-F2_IV_1.json
+++ b/testdata/phenopackets/lirical/Wakil-2018-RETREG1-F2_IV_1.json
@@ -205,15 +205,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wakil-2018-RETREG1-F2_IV_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-R-III_1.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-R-III_1.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wang-2016-CAPN1-R-III_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-399-073.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-399-073.json
@@ -214,15 +214,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wang-2016-CAPN1-SAL-399-073.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-584-005.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-584-005.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wang-2016-CAPN1-SAL-584-005.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-Tun66275.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-Tun66275.json
@@ -113,15 +113,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wang-2016-CAPN1-Tun66275.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Wang-2017-OCA2-B.json
+++ b/testdata/phenopackets/lirical/Wang-2017-OCA2-B.json
@@ -160,15 +160,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wang-2017-OCA2-B.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Wang-2018-CRX-IV_5.json
+++ b/testdata/phenopackets/lirical/Wang-2018-CRX-IV_5.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wang-2018-CRX-IV_5.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Wang-2018-SLC6A8-proband.json
+++ b/testdata/phenopackets/lirical/Wang-2018-SLC6A8-proband.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wang-2018-SLC6A8-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Warnecke-2007-SPG7-II-3.json
+++ b/testdata/phenopackets/lirical/Warnecke-2007-SPG7-II-3.json
@@ -297,15 +297,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Warnecke-2007-SPG7-II-3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Watanabe-2016-COL5A2-patient.json
+++ b/testdata/phenopackets/lirical/Watanabe-2016-COL5A2-patient.json
@@ -204,15 +204,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Watanabe-2016-COL5A2-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Whittock-2004-DLL3-II.6.json
+++ b/testdata/phenopackets/lirical/Whittock-2004-DLL3-II.6.json
@@ -197,15 +197,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Whittock-2004-DLL3-II.6.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Wiltshire-2013-LMNA-II3.json
+++ b/testdata/phenopackets/lirical/Wiltshire-2013-LMNA-II3.json
@@ -275,15 +275,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wiltshire-2013-LMNA-II3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Windpassinger-2017-CDK10-F1-II_1.json
+++ b/testdata/phenopackets/lirical/Windpassinger-2017-CDK10-F1-II_1.json
@@ -419,15 +419,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Windpassinger-2017-CDK10-F1-II_1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Wollnik-2003-PAX3-proposita.json
+++ b/testdata/phenopackets/lirical/Wollnik-2003-PAX3-proposita.json
@@ -203,15 +203,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Wollnik-2003-PAX3-proposita.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Woo-2013-ASS1-5.json
+++ b/testdata/phenopackets/lirical/Woo-2013-ASS1-5.json
@@ -203,15 +203,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Woo-2013-ASS1-5.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Xie-2013-COMP-patient.json
+++ b/testdata/phenopackets/lirical/Xie-2013-COMP-patient.json
@@ -367,15 +367,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Xie-2013-COMP-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Xiong-2019-ZIC2-proband.json
+++ b/testdata/phenopackets/lirical/Xiong-2019-ZIC2-proband.json
@@ -113,15 +113,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Xiong-2019-ZIC2-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-1_II-3.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-1_II-3.json
@@ -275,15 +275,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Xu-2017-CWC27-1_II-3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-3_II-1.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-3_II-1.json
@@ -95,15 +95,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Xu-2017-CWC27-3_II-1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-4_II-3.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-4_II-3.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Xu-2017-CWC27-4_II-3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-II-4.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-II-4.json
@@ -257,15 +257,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Xu-2017-CWC27-II-4.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Yalcin-Cakmakli-2014-FBXO7-ANK-07.json
+++ b/testdata/phenopackets/lirical/Yalcin-Cakmakli-2014-FBXO7-ANK-07.json
@@ -186,15 +186,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Yalcin-Cakmakli-2014-FBXO7-ANK-07.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Yang-2016-MFN2-patient.json
+++ b/testdata/phenopackets/lirical/Yang-2016-MFN2-patient.json
@@ -261,15 +261,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Yang-2016-MFN2-patient.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Yao-2019-FGFR3-VI-5.json
+++ b/testdata/phenopackets/lirical/Yao-2019-FGFR3-VI-5.json
@@ -225,15 +225,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Yao-2019-FGFR3-VI-5.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Yoshida-1991-GLB1-KT.json
+++ b/testdata/phenopackets/lirical/Yoshida-1991-GLB1-KT.json
@@ -169,15 +169,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Yoshida-1991-GLB1-KT.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13",

--- a/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_1.json
+++ b/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_1.json
@@ -600,15 +600,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zapata-Aldana-2019-TBCK-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_2.json
@@ -347,15 +347,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zapata-Aldana-2019-TBCK-Patient_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.14-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zemojtel-2014-KMT2A-P1.json
+++ b/testdata/phenopackets/lirical/Zemojtel-2014-KMT2A-P1.json
@@ -347,15 +347,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zemojtel-2014-KMT2A-P1.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zenker-2007-KRAS-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zenker-2007-KRAS-Patient_2.json
@@ -311,15 +311,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zenker-2007-KRAS-Patient_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zerkaoui-2015-GALC-child.json
+++ b/testdata/phenopackets/lirical/Zerkaoui-2015-GALC-child.json
@@ -196,15 +196,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zerkaoui-2015-GALC-child.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhang-2009-EDA-proband.json
+++ b/testdata/phenopackets/lirical/Zhang-2009-EDA-proband.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhang-2009-EDA-proband.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhang-2011-TYRP1-patient_2.json
+++ b/testdata/phenopackets/lirical/Zhang-2011-TYRP1-patient_2.json
@@ -142,15 +142,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhang-2011-TYRP1-patient_2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhang-2016-RPS19-patient.json
+++ b/testdata/phenopackets/lirical/Zhang-2016-RPS19-patient.json
@@ -153,15 +153,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhang-2016-RPS19-patient.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_1.json
@@ -275,15 +275,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhang-2017-FOXG1-Patient_1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_2.json
@@ -257,15 +257,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhang-2017-FOXG1-Patient_2.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_3.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_3.json
@@ -221,15 +221,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhang-2017-FOXG1-Patient_3.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_4.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_4.json
@@ -222,15 +222,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhang-2017-FOXG1-Patient_4.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhao-2008-KRT9-III_4.json
+++ b/testdata/phenopackets/lirical/Zhao-2008-KRT9-III_4.json
@@ -113,15 +113,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhao-2008-KRT9-III_4.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Zheng-2018-PNPLA6-II.2.json
+++ b/testdata/phenopackets/lirical/Zheng-2018-PNPLA6-II.2.json
@@ -232,15 +232,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zheng-2018-PNPLA6-II.2.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/Zhong-2016-PRPF3-020001-II_4.json
+++ b/testdata/phenopackets/lirical/Zhong-2016-PRPF3-020001-II_4.json
@@ -131,15 +131,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhong-2016-PRPF3-020001-II_4.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhou-2018-FBN2-IV_7.json
+++ b/testdata/phenopackets/lirical/Zhou-2018-FBN2-IV_7.json
@@ -171,15 +171,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhou-2018-FBN2-IV_7.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/Zhu-2017-AIRE-V-1.json
+++ b/testdata/phenopackets/lirical/Zhu-2017-AIRE-V-1.json
@@ -239,15 +239,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "Zhu-2017-AIRE-V-1.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "submittedBy": "HPO:probinson",

--- a/testdata/phenopackets/lirical/de_Vries-2012-FANCC-proband.json
+++ b/testdata/phenopackets/lirical/de_Vries-2012-FANCC-proband.json
@@ -185,15 +185,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "de_Vries-2012-FANCC-proband.vcf",
-      "fileAttributes": {
-        "genomeAssembly": "GRCh37",
-        "fileFormat": "VCF"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",

--- a/testdata/phenopackets/lirical/van_Oorschot-2019-GFI1B-II_6.json
+++ b/testdata/phenopackets/lirical/van_Oorschot-2019-GFI1B-II_6.json
@@ -149,15 +149,6 @@
       }
     }
   ],
-  "files": [
-    {
-      "uri": "van_Oorschot-2019-GFI1B-II_6.vcf",
-      "fileAttributes": {
-        "fileFormat": "VCF",
-        "genomeAssembly": "GRCh37"
-      }
-    }
-  ],
   "metaData": {
     "created": "1970-01-01T00:00:00Z",
     "createdBy": "Hpo Case Annotator : 1.0.13-SNAPSHOT",


### PR DESCRIPTION
Instead of changing the paths to the VCF files in the phenopackets I have removed the `files` object entirely from the phenopackets that had them. 