### PR TITLE
100 merge post processing methods

### DIFF
--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -76,7 +76,7 @@ class SortOrder(Enum):
 
 class ResultSorter:
     def __init__(
-        self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
     ):
         self.pheval_results = pheval_results
         self.sort_order = sort_order
@@ -109,11 +109,11 @@ class ScoreRanker:
     def _check_rank_order(self, round_score: float) -> None:
         """Check the results are correctly ordered."""
         if self.sort_order == SortOrder.ASCENDING and round_score < self.current_score != float(
-            "inf"
+                "inf"
         ):
             raise ValueError("Results are not correctly sorted!")
         elif self.sort_order == SortOrder.DESCENDING and round_score > self.current_score != float(
-            "inf"
+                "inf"
         ):
             raise ValueError("Results are not correctly sorted!")
 
@@ -129,7 +129,7 @@ class ScoreRanker:
 
 
 def rank_pheval_result(
-    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
@@ -157,7 +157,7 @@ def _return_sort_order(sort_order_str: str) -> SortOrder:
 
 
 def create_pheval_result(
-    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str
+        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
     sort_order = _return_sort_order(sort_order_str)
@@ -166,7 +166,7 @@ def create_pheval_result(
 
 
 def write_pheval_gene_result(
-    ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
+        ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval gene result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
@@ -181,13 +181,13 @@ def write_pheval_gene_result(
 
 
 def write_pheval_variant_result(
-    ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
+        ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval variant result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
     pheval_variant_output = ranked_result.loc[
-        :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
-    ]
+                            :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
+                            ]
     pheval_variant_output.to_csv(
         output_dir.joinpath(
             "pheval_variant_results/" + tool_result_path.stem + "-pheval_variant_result.tsv"
@@ -195,3 +195,11 @@ def write_pheval_variant_result(
         sep="\t",
         index=False,
     )
+
+
+def generate_pheval_result(pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str,
+                           output_dir: Path, tool_result_path: Path):
+    """Generate either a PhEval variant or PhEval gene tsv result."""
+    ranked_pheval_result = create_pheval_result(pheval_result, sort_order_str)
+    write_pheval_variant_result(ranked_pheval_result, output_dir, tool_result_path) if type(ranked_pheval_result) == [
+        PhEvalVariantResult] else write_pheval_gene_result(ranked_pheval_result, output_dir, tool_result_path)

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -76,7 +76,7 @@ class SortOrder(Enum):
 
 class ResultSorter:
     def __init__(
-            self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+        self, pheval_results: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
     ):
         self.pheval_results = pheval_results
         self.sort_order = sort_order
@@ -109,11 +109,11 @@ class ScoreRanker:
     def _check_rank_order(self, round_score: float) -> None:
         """Check the results are correctly ordered."""
         if self.sort_order == SortOrder.ASCENDING and round_score < self.current_score != float(
-                "inf"
+            "inf"
         ):
             raise ValueError("Results are not correctly sorted!")
         elif self.sort_order == SortOrder.DESCENDING and round_score > self.current_score != float(
-                "inf"
+            "inf"
         ):
             raise ValueError("Results are not correctly sorted!")
 
@@ -129,7 +129,7 @@ class ScoreRanker:
 
 
 def _rank_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
     Deals with ex aequo scores"""
@@ -157,7 +157,7 @@ def _return_sort_order(sort_order_str: str) -> SortOrder:
 
 
 def _create_pheval_result(
-        pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
     sort_order = _return_sort_order(sort_order_str)
@@ -166,7 +166,7 @@ def _create_pheval_result(
 
 
 def _write_pheval_gene_result(
-        ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
+    ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval gene result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
@@ -181,13 +181,13 @@ def _write_pheval_gene_result(
 
 
 def _write_pheval_variant_result(
-        ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
+    ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval variant result to tsv."""
     ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
     pheval_variant_output = ranked_result.loc[
-                            :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
-                            ]
+        :, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]
+    ]
     pheval_variant_output.to_csv(
         output_dir.joinpath(
             "pheval_variant_results/" + tool_result_path.stem + "-pheval_variant_result.tsv"
@@ -197,9 +197,16 @@ def _write_pheval_variant_result(
     )
 
 
-def generate_pheval_result(pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str,
-                           output_dir: Path, tool_result_path: Path):
+def generate_pheval_result(
+    pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult],
+    sort_order_str: str,
+    output_dir: Path,
+    tool_result_path: Path,
+):
     """Generate either a PhEval variant or PhEval gene tsv result."""
     ranked_pheval_result = _create_pheval_result(pheval_result, sort_order_str)
-    _write_pheval_variant_result(ranked_pheval_result, output_dir, tool_result_path) if type(ranked_pheval_result) == [
-        PhEvalVariantResult] else _write_pheval_gene_result(ranked_pheval_result, output_dir, tool_result_path)
+    _write_pheval_variant_result(ranked_pheval_result, output_dir, tool_result_path) if type(
+        ranked_pheval_result
+    ) == [PhEvalVariantResult] else _write_pheval_gene_result(
+        ranked_pheval_result, output_dir, tool_result_path
+    )

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -128,7 +128,7 @@ class ScoreRanker:
         return self.rank
 
 
-def rank_pheval_result(
+def _rank_pheval_result(
         pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order: SortOrder
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Ranks either a PhEval gene or variant result post-processed from a tool specific output.
@@ -156,16 +156,16 @@ def _return_sort_order(sort_order_str: str) -> SortOrder:
         raise ValueError("Incompatible ordering method specified.")
 
 
-def create_pheval_result(
+def _create_pheval_result(
         pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str
 ) -> [RankedPhEvalGeneResult] or [RankedPhEvalVariantResult]:
     """Create PhEval gene/variant result with corresponding ranks."""
     sort_order = _return_sort_order(sort_order_str)
     sorted_pheval_result = ResultSorter(pheval_result, sort_order).sort_pheval_results()
-    return rank_pheval_result(sorted_pheval_result, sort_order)
+    return _rank_pheval_result(sorted_pheval_result, sort_order)
 
 
-def write_pheval_gene_result(
+def _write_pheval_gene_result(
         ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval gene result to tsv."""
@@ -180,7 +180,7 @@ def write_pheval_gene_result(
     )
 
 
-def write_pheval_variant_result(
+def _write_pheval_variant_result(
         ranked_pheval_result: [RankedPhEvalVariantResult], output_dir: Path, tool_result_path: Path
 ) -> None:
     """Write ranked PhEval variant result to tsv."""
@@ -200,6 +200,6 @@ def write_pheval_variant_result(
 def generate_pheval_result(pheval_result: [PhEvalGeneResult] or [PhEvalVariantResult], sort_order_str: str,
                            output_dir: Path, tool_result_path: Path):
     """Generate either a PhEval variant or PhEval gene tsv result."""
-    ranked_pheval_result = create_pheval_result(pheval_result, sort_order_str)
-    write_pheval_variant_result(ranked_pheval_result, output_dir, tool_result_path) if type(ranked_pheval_result) == [
-        PhEvalVariantResult] else write_pheval_gene_result(ranked_pheval_result, output_dir, tool_result_path)
+    ranked_pheval_result = _create_pheval_result(pheval_result, sort_order_str)
+    _write_pheval_variant_result(ranked_pheval_result, output_dir, tool_result_path) if type(ranked_pheval_result) == [
+        PhEvalVariantResult] else _write_pheval_gene_result(ranked_pheval_result, output_dir, tool_result_path)

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -8,10 +8,10 @@ from pheval.post_processing.post_processing import (
     ResultSorter,
     ScoreRanker,
     SortOrder,
-    _return_sort_order,
-    calculate_end_pos,
     _create_pheval_result,
     _rank_pheval_result,
+    _return_sort_order,
+    calculate_end_pos,
 )
 
 pheval_gene_result = [

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -10,8 +10,8 @@ from pheval.post_processing.post_processing import (
     SortOrder,
     _return_sort_order,
     calculate_end_pos,
-    create_pheval_result,
-    rank_pheval_result,
+    _create_pheval_result,
+    _rank_pheval_result,
 )
 
 pheval_gene_result = [
@@ -252,7 +252,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 
     def test_rank_pheval_results_gene(self):
         self.assertTrue(
-            rank_pheval_result(self.sorted_gene_result, SortOrder.DESCENDING),
+            _rank_pheval_result(self.sorted_gene_result, SortOrder.DESCENDING),
             [
                 RankedPhEvalGeneResult(
                     pheval_gene_result=PhEvalGeneResult(
@@ -283,7 +283,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 
     def test_rank_pheval_results_variant(self):
         self.assertEqual(
-            rank_pheval_result(self.sorted_variant_result, SortOrder.ASCENDING),
+            _rank_pheval_result(self.sorted_variant_result, SortOrder.ASCENDING),
             [
                 RankedPhEvalVariantResult(
                     pheval_variant_result=PhEvalVariantResult(
@@ -326,7 +326,7 @@ class TestRankPhEvalResults(unittest.TestCase):
 class TestCreatePhEvalResult(unittest.TestCase):
     def test_create_pheval_result_gene(self):
         self.assertEqual(
-            create_pheval_result(pheval_gene_result, "descending"),
+            _create_pheval_result(pheval_gene_result, "descending"),
             [
                 RankedPhEvalGeneResult(
                     pheval_gene_result=PhEvalGeneResult(
@@ -357,7 +357,7 @@ class TestCreatePhEvalResult(unittest.TestCase):
 
     def test_create_pheval_result_variant(self):
         self.assertEqual(
-            create_pheval_result(pheval_variant_result, "ascending"),
+            _create_pheval_result(pheval_variant_result, "ascending"),
             [
                 RankedPhEvalVariantResult(
                     pheval_variant_result=PhEvalVariantResult(


### PR DESCRIPTION
Added an additional method `generate_pheval_result()` to be called by the implementor for the final post-processing steps. This method will rank the results and format them into the tsv results depending on whether the implementor provides it with a list of variant or gene results.

Changed public methods to private methods (in the pythonic way) to hopefully document that these should not be called in a runner implementation.