### PR TITLE
106 formatting time at last encounter field

### DIFF
--- a/testdata/phenopackets/lirical/Abdul_Wahab-2016-GCDH-Patient_5.json
+++ b/testdata/phenopackets/lirical/Abdul_Wahab-2016-GCDH-Patient_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:27672653-Abdul_Wahab-2016-GCDH-Patient_5",
   "subject": {
     "id": "Patient 5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Ajmal-2013-BBS1-IV-5_family_A.json
+++ b/testdata/phenopackets/lirical/Ajmal-2013-BBS1-IV-5_family_A.json
@@ -2,7 +2,6 @@
   "id": "PMID:23559858-Ajmal-2013-BBS1-IV-5/family_A",
   "subject": {
     "id": "IV-5/family A",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P26Y"

--- a/testdata/phenopackets/lirical/Ajmal-2013-BBS1-IV-5_family_A.json
+++ b/testdata/phenopackets/lirical/Ajmal-2013-BBS1-IV-5_family_A.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "26Y"
+        "iso8601duration": "P26Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Al-Dosari-2010-TFAP2A-10-year-old_girl.json
+++ b/testdata/phenopackets/lirical/Al-Dosari-2010-TFAP2A-10-year-old_girl.json
@@ -2,7 +2,6 @@
   "id": "PMID:20461149-Al-Dosari-2010-TFAP2A-10-year-old_girl",
   "subject": {
     "id": "10-year-old girl",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Al-Hashmi-2018-SNX14-IV-1.json
+++ b/testdata/phenopackets/lirical/Al-Hashmi-2018-SNX14-IV-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30473892-Al-Hashmi-2018-SNX14-IV-1",
   "subject": {
     "id": "IV-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y9M"

--- a/testdata/phenopackets/lirical/Al-Qattan-2018-SCARF2-proband.json
+++ b/testdata/phenopackets/lirical/Al-Qattan-2018-SCARF2-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:29378527-Al-Qattan-2018-SCARF2-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Al-Semari-2013-FGD1-II-1.json
+++ b/testdata/phenopackets/lirical/Al-Semari-2013-FGD1-II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:23211637-Al-Semari-2013-FGD1-II-1",
   "subject": {
     "id": "II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P16Y"

--- a/testdata/phenopackets/lirical/AlSubhi-2016-ALG9-IV_5.json
+++ b/testdata/phenopackets/lirical/AlSubhi-2016-ALG9-IV_5.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "6Y"
+        "iso8601duration": "P6Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/AlSubhi-2016-ALG9-IV_5.json
+++ b/testdata/phenopackets/lirical/AlSubhi-2016-ALG9-IV_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:26453364-AlSubhi-2016-ALG9-IV:5",
   "subject": {
     "id": "IV:5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Alazami-2016-ATP6V1E1-Family_5_-_IV_2.json
+++ b/testdata/phenopackets/lirical/Alazami-2016-ATP6V1E1-Family_5_-_IV_2.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "Family 5 - IV:2",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Alazami-2016-ATP6V1E1-Family_5_-_IV_2.json
+++ b/testdata/phenopackets/lirical/Alazami-2016-ATP6V1E1-Family_5_-_IV_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:27023906-Alazami-2016-ATP6V1E1-Family_5_-_IV:2",
   "subject": {
     "id": "Family 5 - IV:2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Ali-2017-MYH3-proband.json
+++ b/testdata/phenopackets/lirical/Ali-2017-MYH3-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:28584669-Ali-2017-MYH3-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10D"

--- a/testdata/phenopackets/lirical/Alzahrani-2018-EPG5-18-month_son.json
+++ b/testdata/phenopackets/lirical/Alzahrani-2018-EPG5-18-month_son.json
@@ -2,7 +2,6 @@
   "id": "PMID:29983806-Alzahrani-2018-EPG5-18-month_son",
   "subject": {
     "id": "18-month son",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y6M"

--- a/testdata/phenopackets/lirical/Anazi-2017-NKX6-2-Patient_36-16DG1123.json
+++ b/testdata/phenopackets/lirical/Anazi-2017-NKX6-2-Patient_36-16DG1123.json
@@ -2,7 +2,6 @@
   "id": "PMID:28940097-Anazi-2017-NKX6-2-Patient_36-16DG1123",
   "subject": {
     "id": "Patient 36-16DG1123",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_1.json
+++ b/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132693-Arno-2017-ARHGEF18-Individual_1",
   "subject": {
     "id": "Individual 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P37Y"

--- a/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_2.json
+++ b/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132693-Arno-2017-ARHGEF18-Individual_2",
   "subject": {
     "id": "Individual 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P51Y"

--- a/testdata/phenopackets/lirical/Arora-2019-COG8-proband.json
+++ b/testdata/phenopackets/lirical/Arora-2019-COG8-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30690882-Arora-2019-COG8-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1D"

--- a/testdata/phenopackets/lirical/Asgharzade-2018-GIPC3-Ahv-14_23.json
+++ b/testdata/phenopackets/lirical/Asgharzade-2018-GIPC3-Ahv-14_23.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "Ahv-14:23",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "FEMALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Asgharzade-2018-GIPC3-Ahv-14_23.json
+++ b/testdata/phenopackets/lirical/Asgharzade-2018-GIPC3-Ahv-14_23.json
@@ -2,7 +2,6 @@
   "id": "PMID:29605370-Asgharzade-2018-GIPC3-Ahv-14:23",
   "subject": {
     "id": "Ahv-14:23",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "FEMALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Avgeris-2017-TSC1-patient_6.json
+++ b/testdata/phenopackets/lirical/Avgeris-2017-TSC1-patient_6.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "patient 6",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Avgeris-2017-TSC1-patient_6.json
+++ b/testdata/phenopackets/lirical/Avgeris-2017-TSC1-patient_6.json
@@ -2,7 +2,6 @@
   "id": "PMID:29196670-Avgeris-2017-TSC1-patient_6",
   "subject": {
     "id": "patient 6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Avrahami-2008-ST14-patient.json
+++ b/testdata/phenopackets/lirical/Avrahami-2008-ST14-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:18445049-Avrahami-2008-ST14-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y6M"

--- a/testdata/phenopackets/lirical/Badin-2017-RUNX1-Pedigree_I,_V_2.json
+++ b/testdata/phenopackets/lirical/Badin-2017-RUNX1-Pedigree_I,_V_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:28181366-Badin-2017-RUNX1-Pedigree_I,_V:2",
   "subject": {
     "id": "Pedigree I, V:2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Badin-2017-RUNX1-Pedigree_I,_V_2.json
+++ b/testdata/phenopackets/lirical/Badin-2017-RUNX1-Pedigree_I,_V_2.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "Pedigree I, V:2",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Baldi-2018-NKX6-2-F6,II-2.json
+++ b/testdata/phenopackets/lirical/Baldi-2018-NKX6-2-F6,II-2.json
@@ -2,7 +2,6 @@
   "id": "PMID:29388673-Baldi-2018-NKX6-2-F6,II-2",
   "subject": {
     "id": "F6,II-2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y6M"

--- a/testdata/phenopackets/lirical/Bao-2019-COL6A1-II.1.json
+++ b/testdata/phenopackets/lirical/Bao-2019-COL6A1-II.1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "14Y"
+        "iso8601duration": "P14Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Bao-2019-COL6A1-II.1.json
+++ b/testdata/phenopackets/lirical/Bao-2019-COL6A1-II.1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30808312-Bao-2019-COL6A1-II.1",
   "subject": {
     "id": "II.1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Bastaki-2017-CTCF-proband.json
+++ b/testdata/phenopackets/lirical/Bastaki-2017-CTCF-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:28619046-Bastaki-2017-CTCF-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Bee-2015-BBS2-II_2.json
+++ b/testdata/phenopackets/lirical/Bee-2015-BBS2-II_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:26078953-Bee-2015-BBS2-II:2",
   "subject": {
     "id": "II:2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P37Y"

--- a/testdata/phenopackets/lirical/Bee-2015-BBS2-II_2.json
+++ b/testdata/phenopackets/lirical/Bee-2015-BBS2-II_2.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "37Y"
+        "iso8601duration": "P37Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Ben_Ammar-2013-MUSK-patient.json
+++ b/testdata/phenopackets/lirical/Ben_Ammar-2013-MUSK-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:23326516-Ben_Ammar-2013-MUSK-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Bhatia-2018-PRPF31-IV_3.json
+++ b/testdata/phenopackets/lirical/Bhatia-2018-PRPF31-IV_3.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "35Y"
+        "iso8601duration": "P35Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Bhatia-2018-PRPF31-IV_3.json
+++ b/testdata/phenopackets/lirical/Bhatia-2018-PRPF31-IV_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:30099644-Bhatia-2018-PRPF31-IV:3",
   "subject": {
     "id": "IV:3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P35Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-1-1",
   "subject": {
     "id": "1-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-2.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-1-2",
   "subject": {
     "id": "1-2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-2-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-2-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-2-1",
   "subject": {
     "id": "2-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-3-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-3-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-3-1",
   "subject": {
     "id": "3-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-4-1",
   "subject": {
     "id": "4-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-2.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "p2y"
+        "iso8601duration": "P2Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-2.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-4-2",
   "subject": {
     "id": "4-2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-5-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-5-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-5-1",
   "subject": {
     "id": "5-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-6-1",
   "subject": {
     "id": "6-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-2.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-6-2",
   "subject": {
     "id": "6-2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-8-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-8-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040691-Bhoj-2016-TBCK-8-1",
   "subject": {
     "id": "8-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Bicknell-2007-FLNB-19.json
+++ b/testdata/phenopackets/lirical/Bicknell-2007-FLNB-19.json
@@ -2,7 +2,6 @@
   "id": "PMID:16801345-Bicknell-2007-FLNB-19",
   "subject": {
     "id": "19",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P17Y"

--- a/testdata/phenopackets/lirical/Blanco-Kelly-2017-CDH3-Patient.json
+++ b/testdata/phenopackets/lirical/Blanco-Kelly-2017-CDH3-Patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:28061825-Blanco-Kelly-2017-CDH3-Patient",
   "subject": {
     "id": "Patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB049.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB049.json
@@ -2,7 +2,6 @@
   "id": "PMID:29146883-Bluteau-2018-SAMD9L-UB049",
   "subject": {
     "id": "UB049",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10M"

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB081.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB081.json
@@ -2,7 +2,6 @@
   "id": "PMID:29146883-Bluteau-2018-SAMD9L-UB081",
   "subject": {
     "id": "UB081",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y1M"

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB085.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB085.json
@@ -2,7 +2,6 @@
   "id": "PMID:29146883-Bluteau-2018-SAMD9L-UB085",
   "subject": {
     "id": "UB085",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y8M"

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB612.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB612.json
@@ -2,7 +2,6 @@
   "id": "PMID:29146883-Bluteau-2018-SAMD9L-UB612",
   "subject": {
     "id": "UB612",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Boddrich-1997-NF1-0548.json
+++ b/testdata/phenopackets/lirical/Boddrich-1997-NF1-0548.json
@@ -2,7 +2,6 @@
   "id": "PMID:9101303-B\u00f6ddrich-1997-NF1-0548",
   "subject": {
     "id": "0548",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Boddrich-1997-NF1-0548.json
+++ b/testdata/phenopackets/lirical/Boddrich-1997-NF1-0548.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "2y"
+        "iso8601duration": "P2Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Bordbar-2017-PRF1-8-year-old_boy.json
+++ b/testdata/phenopackets/lirical/Bordbar-2017-PRF1-8-year-old_boy.json
@@ -2,7 +2,6 @@
   "id": "PMID:28468610-Bordbar-2017-PRF1-8-year-old_boy",
   "subject": {
     "id": "8-year-old boy",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Bulut-2017-SETBP1-proposita.json
+++ b/testdata/phenopackets/lirical/Bulut-2017-SETBP1-proposita.json
@@ -2,7 +2,6 @@
   "id": "PMID:29333303-Bulut-2017-SETBP1-proposita",
   "subject": {
     "id": "proposita",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11M"

--- a/testdata/phenopackets/lirical/Calado-2005-UMOD-proband.json
+++ b/testdata/phenopackets/lirical/Calado-2005-UMOD-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:15673476-Calado-2005-UMOD-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P49Y"

--- a/testdata/phenopackets/lirical/Canosa-2018-SOD1-patient.json
+++ b/testdata/phenopackets/lirical/Canosa-2018-SOD1-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:30236613-Canosa-2018-SOD1-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P64Y"

--- a/testdata/phenopackets/lirical/Canosa-2018-SOD1-patient.json
+++ b/testdata/phenopackets/lirical/Canosa-2018-SOD1-patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "64Y"
+        "iso8601duration": "P64Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30101859-Cao-2018-FBN1-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P24Y"

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_2.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:30101859-Cao-2018-FBN1-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P36Y"

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_3.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:30101859-Cao-2018-FBN1-Patient_3",
   "subject": {
     "id": "Patient 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P36Y"

--- a/testdata/phenopackets/lirical/Cao-2018-TGFBR2-Patient_4.json
+++ b/testdata/phenopackets/lirical/Cao-2018-TGFBR2-Patient_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:30101859-Cao-2018-TGFBR2-Patient_4",
   "subject": {
     "id": "Patient 4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Caputo-2014-SMAD4-patient.json
+++ b/testdata/phenopackets/lirical/Caputo-2014-SMAD4-patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "15Y"
+        "iso8601duration": "P15Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Caputo-2014-SMAD4-patient.json
+++ b/testdata/phenopackets/lirical/Caputo-2014-SMAD4-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:24715504-Caputo-2014-SMAD4-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Caro-Contreras-2019-ERF-proband.json
+++ b/testdata/phenopackets/lirical/Caro-Contreras-2019-ERF-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30569521-Caro-Contreras-2019-ERF-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Carre-2014-FOXE1-patient.json
+++ b/testdata/phenopackets/lirical/Carre-2014-FOXE1-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:24219130-Carr\u00e9-2014-FOXE1-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1M"

--- a/testdata/phenopackets/lirical/Chabas-2005-GBA-_boy_weighing_1690_g.json
+++ b/testdata/phenopackets/lirical/Chabas-2005-GBA-_boy_weighing_1690_g.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "25D"
+        "iso8601duration": "P25D"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Chabas-2005-GBA-_boy_weighing_1690_g.json
+++ b/testdata/phenopackets/lirical/Chabas-2005-GBA-_boy_weighing_1690_g.json
@@ -2,7 +2,6 @@
   "id": "PMID:15967693-Chab\u00e1s-2005-GBA-_boy_weighing_1690_g",
   "subject": {
     "id": " boy weighing 1690 g",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P25D"

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC6-Patient_B.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC6-Patient_B.json
@@ -2,7 +2,6 @@
   "id": "PMID:30200888-Chebly-2018-ERCC6-Patient_B",
   "subject": {
     "id": "Patient B",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y"

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_A.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_A.json
@@ -2,7 +2,6 @@
   "id": "PMID:30200888-Chebly-2018-ERCC8-Patient_A",
   "subject": {
     "id": "Patient A",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P17Y"

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_C.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_C.json
@@ -2,7 +2,6 @@
   "id": "PMID:30200888-Chebly-2018-ERCC8-Patient_C",
   "subject": {
     "id": "Patient C",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-III-1.json
+++ b/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-III-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28575651-Chelban-2017-NKX6-2-III-1",
   "subject": {
     "id": "III-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P27Y"

--- a/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-IV-6.json
+++ b/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-IV-6.json
@@ -2,7 +2,6 @@
   "id": "PMID:28575651-Chelban-2017-NKX6-2-IV-6",
   "subject": {
     "id": "IV-6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Chen-2014-RUNX2-III_3.json
+++ b/testdata/phenopackets/lirical/Chen-2014-RUNX2-III_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:24966961-Chen-2014-RUNX2-III:3",
   "subject": {
     "id": "III:3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P29Y"

--- a/testdata/phenopackets/lirical/Chen-2016-SAMD9L-II-4.json
+++ b/testdata/phenopackets/lirical/Chen-2016-SAMD9L-II-4.json
@@ -2,7 +2,6 @@
   "id": "PMID:27259050-Chen-2016-SAMD9L-II-4",
   "subject": {
     "id": "II-4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Chen-2016-SAMD9L-IV-1.json
+++ b/testdata/phenopackets/lirical/Chen-2016-SAMD9L-IV-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27259050-Chen-2016-SAMD9L-IV-1",
   "subject": {
     "id": "IV-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P18Y"

--- a/testdata/phenopackets/lirical/Cheng-2018-FBN1-Family_1,_Patient_1.json
+++ b/testdata/phenopackets/lirical/Cheng-2018-FBN1-Family_1,_Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:29191498-Cheng-2018-FBN1-Family_1,_Patient_1",
   "subject": {
     "id": "Family 1, Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y6M"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-A-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-A-II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040692-Chong-2016-TBCK-A-II-1",
   "subject": {
     "id": "A-II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-4.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-4.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040692-Chong-2016-TBCK-B-IV-4",
   "subject": {
     "id": "B-IV-4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-6.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-6.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040692-Chong-2016-TBCK-B-IV-6",
   "subject": {
     "id": "B-IV-6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-C-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-C-II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040692-Chong-2016-TBCK-C-II-1",
   "subject": {
     "id": "C-II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-D-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-D-II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27040692-Chong-2016-TBCK-D-II-1",
   "subject": {
     "id": "D-II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Claverie-Martin-2019-LMX1B-index.json
+++ b/testdata/phenopackets/lirical/Claverie-Martin-2019-LMX1B-index.json
@@ -2,7 +2,6 @@
   "id": "PMID:30881852-Claverie-Martin-2019-LMX1B-index",
   "subject": {
     "id": "index",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Cuchanski-2018-KIF5A-proband.json
+++ b/testdata/phenopackets/lirical/Cuchanski-2018-KIF5A-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30057544-Cuchanski-2018-KIF5A-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P31Y"

--- a/testdata/phenopackets/lirical/Curtis-1978-FLCN-253.json
+++ b/testdata/phenopackets/lirical/Curtis-1978-FLCN-253.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "253",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Curtis-1978-FLCN-253.json
+++ b/testdata/phenopackets/lirical/Curtis-1978-FLCN-253.json
@@ -2,7 +2,6 @@
   "id": "PMID:96481-Curtis-1978-FLCN-253",
   "subject": {
     "id": "253",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Dastsooz-2017-PANK2-Family_I_patient_I.json
+++ b/testdata/phenopackets/lirical/Dastsooz-2017-PANK2-Family_I_patient_I.json
@@ -2,7 +2,6 @@
   "id": "PMID:28821231-Dastsooz-2017-PANK2-Family_I_patient_I",
   "subject": {
     "id": "Family I patient I",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Dastsooz-2017-PLA2G6-family_II_patient_II.json
+++ b/testdata/phenopackets/lirical/Dastsooz-2017-PLA2G6-family_II_patient_II.json
@@ -2,7 +2,6 @@
   "id": "PMID:28821231-Dastsooz-2017-PLA2G6-family_II_patient_II",
   "subject": {
     "id": "family II patient II",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y6M"

--- a/testdata/phenopackets/lirical/Dauber-2014-SLC35C1-Proband_1.json
+++ b/testdata/phenopackets/lirical/Dauber-2014-SLC35C1-Proband_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:24403049-Dauber-2014-SLC35C1-Proband_1",
   "subject": {
     "id": "Proband 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Delahaye-2007-CHD7-B_III-3.json
+++ b/testdata/phenopackets/lirical/Delahaye-2007-CHD7-B_III-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:17661815-Delahaye-2007-CHD7-B_III-3",
   "subject": {
     "id": "B III-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y6M"

--- a/testdata/phenopackets/lirical/Delahaye-2007-CHD7-Patient_A_III-2.json
+++ b/testdata/phenopackets/lirical/Delahaye-2007-CHD7-Patient_A_III-2.json
@@ -2,7 +2,6 @@
   "id": "PMID:17661815-Delahaye-2007-CHD7-Patient_A_III-2",
   "subject": {
     "id": "Patient A III-2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Devalla-2016-TECRL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Devalla-2016-TECRL-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27861123-Devalla-2016-TECRL-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P22Y"

--- a/testdata/phenopackets/lirical/Devalla-2016-TECRL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Devalla-2016-TECRL-Patient_1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "22"
+        "iso8601duration": "P22Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Di_Nottia-2017-PARK7-proband.json
+++ b/testdata/phenopackets/lirical/Di_Nottia-2017-PARK7-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:27460976-Di_Nottia-2017-PARK7-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P47Y"

--- a/testdata/phenopackets/lirical/Dias-2013-TRPS1-girl.json
+++ b/testdata/phenopackets/lirical/Dias-2013-TRPS1-girl.json
@@ -2,7 +2,6 @@
   "id": "PMID:23691375-Dias-2013-TRPS1-girl",
   "subject": {
     "id": "girl",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Dias-2013-TRPS1-girl.json
+++ b/testdata/phenopackets/lirical/Dias-2013-TRPS1-girl.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "4PY"
+        "iso8601duration": "P4Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Dikoglu-2015-LONP1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Dikoglu-2015-LONP1-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:25808063-Dikoglu-2015-LONP1-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Dikoglu-2015-LONP1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Dikoglu-2015-LONP1-Patient_1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "3Y"
+        "iso8601duration": "P3Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Dinani-2017-AAGAB-family_1_proband.json
+++ b/testdata/phenopackets/lirical/Dinani-2017-AAGAB-family_1_proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:28239884-Dinani-2017-AAGAB-family_1:proband",
   "subject": {
     "id": "family 1:proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P43Y"

--- a/testdata/phenopackets/lirical/Djamshidian-2009-VCP-II-3.json
+++ b/testdata/phenopackets/lirical/Djamshidian-2009-VCP-II-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:19208399-Djamshidian-2009-VCP-II-3",
   "subject": {
     "id": "II-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P41Y"

--- a/testdata/phenopackets/lirical/Dobbs-2008-FLNB-patient.json
+++ b/testdata/phenopackets/lirical/Dobbs-2008-FLNB-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:18322662-Dobbs-2008-FLNB-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y10M"

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_1_II-1.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_1_II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28969374-Dorboz-2017-NKX6-2-Patient_1_II-1",
   "subject": {
     "id": "Patient 1 II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_3_II-3.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_3_II-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28969374-Dorboz-2017-NKX6-2-Patient_3_II-3",
   "subject": {
     "id": "Patient 3 II-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_4_II-1.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_4_II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28969374-Dorboz-2017-NKX6-2-Patient_4_II-1",
   "subject": {
     "id": "Patient 4 II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Dougherty-2016-NPC1-The_proband.json
+++ b/testdata/phenopackets/lirical/Dougherty-2016-NPC1-The_proband.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "54Y"
+        "iso8601duration": "P54Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Dougherty-2016-NPC1-The_proband.json
+++ b/testdata/phenopackets/lirical/Dougherty-2016-NPC1-The_proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:27900365-Dougherty-2016-NPC1-The_proband",
   "subject": {
     "id": "The proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P54Y"

--- a/testdata/phenopackets/lirical/Du-2018-TINF2-proband.json
+++ b/testdata/phenopackets/lirical/Du-2018-TINF2-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:29742735-Du-2018-TINF2-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P32Y"

--- a/testdata/phenopackets/lirical/Ekvall-2015-NRAS-case_1.json
+++ b/testdata/phenopackets/lirical/Ekvall-2015-NRAS-case_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:26467218-Ekvall-2015-NRAS-case_1",
   "subject": {
     "id": "case 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P28Y"

--- a/testdata/phenopackets/lirical/El-Harith-2009-MPL-FT2_VI_3.json
+++ b/testdata/phenopackets/lirical/El-Harith-2009-MPL-FT2_VI_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:19036112-El-Harith-2009-MPL-FT2:VI:3",
   "subject": {
     "id": "FT2:VI:3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/El-Jaick-2007-TGIF1-male_proband.json
+++ b/testdata/phenopackets/lirical/El-Jaick-2007-TGIF1-male_proband.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "male proband",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/El-Jaick-2007-TGIF1-male_proband.json
+++ b/testdata/phenopackets/lirical/El-Jaick-2007-TGIF1-male_proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:16962354-El-Jaick-2007-TGIF1-male_proband",
   "subject": {
     "id": "male proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Elsaadany-2016-WWOX-Patient_1.json
+++ b/testdata/phenopackets/lirical/Elsaadany-2016-WWOX-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27495153-Elsaadany-2016-WWOX-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Elsaid-2017-NT5C2-II.3.json
+++ b/testdata/phenopackets/lirical/Elsaid-2017-NT5C2-II.3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28327087-Elsaid-2017-NT5C2-II.3",
   "subject": {
     "id": "II.3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Falik_Zaccai-2014-INSR-ISR1.json
+++ b/testdata/phenopackets/lirical/Falik_Zaccai-2014-INSR-ISR1.json
@@ -2,7 +2,6 @@
   "id": "PMID:24498630-Falik_Zaccai-2014-INSR-ISR1",
   "subject": {
     "id": "ISR1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P18M"

--- a/testdata/phenopackets/lirical/Falik_Zaccai-2014-INSR-ISR1.json
+++ b/testdata/phenopackets/lirical/Falik_Zaccai-2014-INSR-ISR1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "18M"
+        "iso8601duration": "P18M"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Falik_Zaccai-2017-PLAA-A-VI3.json
+++ b/testdata/phenopackets/lirical/Falik_Zaccai-2017-PLAA-A-VI3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28007986-Falik_Zaccai-2017-PLAA-A-VI3",
   "subject": {
     "id": "A-VI3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4M"

--- a/testdata/phenopackets/lirical/Fiscaletti-2018-SP7-II_5.json
+++ b/testdata/phenopackets/lirical/Fiscaletti-2018-SP7-II_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:29382611-Fiscaletti-2018-SP7-II:5",
   "subject": {
     "id": "II:5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_1.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_1",
   "subject": {
     "id": "Subject 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_10.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_10.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_10",
   "subject": {
     "id": "Subject 10",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_2.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_2",
   "subject": {
     "id": "Subject 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y3M"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_3.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_3",
   "subject": {
     "id": "Subject 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_4.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_4",
   "subject": {
     "id": "Subject 4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_5.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_5",
   "subject": {
     "id": "Subject 5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_6.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_6.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_6",
   "subject": {
     "id": "Subject 6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_7.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_7.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_7",
   "subject": {
     "id": "Subject 7",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_8.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_8.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_8",
   "subject": {
     "id": "Subject 8",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_9.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_9.json
@@ -2,7 +2,6 @@
   "id": "PMID:27087320-Fregeau-2016-RERE-Subject_9",
   "subject": {
     "id": "Subject 9",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Fusco-2017-PMP22-Proband.json
+++ b/testdata/phenopackets/lirical/Fusco-2017-PMP22-Proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:29078790-Fusco-2017-PMP22-Proband",
   "subject": {
     "id": "Proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_A-V_2.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_A-V_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:27153400-Gan-Or-2016-CAPN1-Family_A-V:2",
   "subject": {
     "id": "Family A-V:2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P20Y"

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_B-IV_1.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_B-IV_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27153400-Gan-Or-2016-CAPN1-Family_B-IV:1",
   "subject": {
     "id": "Family B-IV:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P35Y"

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_C-IV_13.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_C-IV_13.json
@@ -2,7 +2,6 @@
   "id": "PMID:27153400-Gan-Or-2016-CAPN1-Family_C-IV:13",
   "subject": {
     "id": "Family C-IV:13",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P33Y"

--- a/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_A_II1.json
+++ b/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_A_II1.json
@@ -2,7 +2,6 @@
   "id": "PMID:31548836-Gao-2019-RUNX2-Family_A_II1",
   "subject": {
     "id": "Family_A_II1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_B_II1.json
+++ b/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_B_II1.json
@@ -2,7 +2,6 @@
   "id": "PMID:31548836-Gao-2019-RUNX2-Family_B_II1",
   "subject": {
     "id": "Family_B_II1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y9M"

--- a/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_D_II1.json
+++ b/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_D_II1.json
@@ -2,7 +2,6 @@
   "id": "PMID:31548836-Gao-2019-RUNX2-Family_D_II1",
   "subject": {
     "id": "Family_D_II1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Ge-2019-TJP2-proband.json
+++ b/testdata/phenopackets/lirical/Ge-2019-TJP2-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30658709-Ge-2019-TJP2-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y11M"

--- a/testdata/phenopackets/lirical/Gebbia-1997-ZIC3-III-1.json
+++ b/testdata/phenopackets/lirical/Gebbia-1997-ZIC3-III-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:9354794-Gebbia-1997-ZIC3-III-1",
   "subject": {
     "id": "III-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7W"

--- a/testdata/phenopackets/lirical/Gebbia-1997-ZIC3-III-1.json
+++ b/testdata/phenopackets/lirical/Gebbia-1997-ZIC3-III-1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "7W"
+        "iso8601duration": "P7W"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Geiger-2017-TUBB2B-proband.json
+++ b/testdata/phenopackets/lirical/Geiger-2017-TUBB2B-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:28966590-Geiger-2017-TUBB2B-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P31Y"

--- a/testdata/phenopackets/lirical/Gerding-2009-LITAF-Proband.json
+++ b/testdata/phenopackets/lirical/Gerding-2009-LITAF-Proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:19541485-Gerding-2009-LITAF-Proband",
   "subject": {
     "id": "Proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P57Y"

--- a/testdata/phenopackets/lirical/Giau-2018-PSEN2-proband.json
+++ b/testdata/phenopackets/lirical/Giau-2018-PSEN2-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30104866-Giau-2018-PSEN2-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P58Y"

--- a/testdata/phenopackets/lirical/Gong-2015-CBS-III_3.json
+++ b/testdata/phenopackets/lirical/Gong-2015-CBS-III_3.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "7Y"
+        "iso8601duration": "P7Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Gong-2015-CBS-III_3.json
+++ b/testdata/phenopackets/lirical/Gong-2015-CBS-III_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:26667307-Gong-2015-CBS-III:3",
   "subject": {
     "id": "III:3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Gonzalez-Perez-2009-CAV3-I1.json
+++ b/testdata/phenopackets/lirical/Gonzalez-Perez-2009-CAV3-I1.json
@@ -2,7 +2,6 @@
   "id": "PMID:18930476-Gonz\u00e1lez-P\u00e9rez-2009-CAV3-I1",
   "subject": {
     "id": "I1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P77Y"

--- a/testdata/phenopackets/lirical/Gonzalez-Perez-2009-CAV3-I1.json
+++ b/testdata/phenopackets/lirical/Gonzalez-Perez-2009-CAV3-I1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "77"
+        "iso8601duration": "P77Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Gowda-2017-MCOLN1-6_year_old_boy.json
+++ b/testdata/phenopackets/lirical/Gowda-2017-MCOLN1-6_year_old_boy.json
@@ -2,7 +2,6 @@
   "id": "PMID:28620732-Gowda-2017-MCOLN1-6_year_old_boy",
   "subject": {
     "id": "6 year old boy",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Gowda-2017-MCOLN1-6_year_old_boy.json
+++ b/testdata/phenopackets/lirical/Gowda-2017-MCOLN1-6_year_old_boy.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "6Y"
+        "iso8601duration": "P6Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Gregor-2018-FBXO11-Individual_1.json
+++ b/testdata/phenopackets/lirical/Gregor-2018-FBXO11-Individual_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30057029-Gregor-2018-FBXO11-Individual_1",
   "subject": {
     "id": "Individual 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Grumach-2015-CARD9-Patient.json
+++ b/testdata/phenopackets/lirical/Grumach-2015-CARD9-Patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:26044242-Grumach-2015-CARD9-Patient",
   "subject": {
     "id": "Patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P24Y"

--- a/testdata/phenopackets/lirical/Gu-2013-NOTCH2-proband.json
+++ b/testdata/phenopackets/lirical/Gu-2013-NOTCH2-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:23566664-Gu-2013-NOTCH2-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P60Y"

--- a/testdata/phenopackets/lirical/Gueguen-2013-ACTN1-proband.json
+++ b/testdata/phenopackets/lirical/Gueguen-2013-ACTN1-proband.json
@@ -4,8 +4,9 @@
     "id": "proband",
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "adult"
+      "ontologyClass": {
+        "id": "HP:0003581",
+        "label": "Adult onset"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Gueguen-2013-ACTN1-proband.json
+++ b/testdata/phenopackets/lirical/Gueguen-2013-ACTN1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:24069336-Gu\u00e9guen-2013-ACTN1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "ontologyClass": {
         "id": "HP:0003581",

--- a/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-3.json
+++ b/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:27275012-Guerreiro-2016-TBCK-II-3",
   "subject": {
     "id": "II-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P16Y"

--- a/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-4.json
+++ b/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-4.json
@@ -2,7 +2,6 @@
   "id": "PMID:27275012-Guerreiro-2016-TBCK-II-4",
   "subject": {
     "id": "II-4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11Y"

--- a/testdata/phenopackets/lirical/Gul-2006-CENPJ-IV-5.json
+++ b/testdata/phenopackets/lirical/Gul-2006-CENPJ-IV-5.json
@@ -2,7 +2,6 @@
   "id": "PMID:16900296-Gul-2006-CENPJ-IV-5",
   "subject": {
     "id": "IV-5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Guo-2017-EXTL3-Patient_1.json
+++ b/testdata/phenopackets/lirical/Guo-2017-EXTL3-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28331220-Guo-2017-EXTL3-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Guo-2018-KDM6A-3_month_old_boy.json
+++ b/testdata/phenopackets/lirical/Guo-2018-KDM6A-3_month_old_boy.json
@@ -2,7 +2,6 @@
   "id": "PMID:30509212-Guo-2018-KDM6A-3_month_old_boy",
   "subject": {
     "id": "3 month old boy",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3M"

--- a/testdata/phenopackets/lirical/Guo-2018-KDM6A-3_month_old_boy.json
+++ b/testdata/phenopackets/lirical/Guo-2018-KDM6A-3_month_old_boy.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "3 months"
+        "iso8601duration": "P3M"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Guo-2018-KMT2D-3_month_old_boy.json
+++ b/testdata/phenopackets/lirical/Guo-2018-KMT2D-3_month_old_boy.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "3 months"
+        "iso8601duration": "P3M"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Guo-2018-KMT2D-3_month_old_boy.json
+++ b/testdata/phenopackets/lirical/Guo-2018-KMT2D-3_month_old_boy.json
@@ -2,7 +2,6 @@
   "id": "PMID:30509212-Guo-2018-KMT2D-3_month_old_boy",
   "subject": {
     "id": "3 month old boy",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3M"

--- a/testdata/phenopackets/lirical/Habarou-2017-LIPT2-P1.json
+++ b/testdata/phenopackets/lirical/Habarou-2017-LIPT2-P1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28757203-Habarou-2017-LIPT2-P1",
   "subject": {
     "id": "P1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Haliloglu-2017-PIEZO2-Patient.json
+++ b/testdata/phenopackets/lirical/Haliloglu-2017-PIEZO2-Patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:27974811-Haliloglu-2017-PIEZO2-Patient",
   "subject": {
     "id": "Patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P18Y"

--- a/testdata/phenopackets/lirical/Haliloglu-2017-PIEZO2-Patient.json
+++ b/testdata/phenopackets/lirical/Haliloglu-2017-PIEZO2-Patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "18Y"
+        "iso8601duration": "P18Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_A-IV_6.json
+++ b/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_A-IV_6.json
@@ -2,7 +2,6 @@
   "id": "PMID:28413018-Hall-2017-PLAA-Family_A-IV:6",
   "subject": {
     "id": "Family A-IV:6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12D"

--- a/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_D-Case_VIII-1.json
+++ b/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_D-Case_VIII-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28413018-Hall-2017-PLAA-Family_D-Case_VIII-1",
   "subject": {
     "id": "Family D-Case VIII-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10M"

--- a/testdata/phenopackets/lirical/Hamamy-2014-FYB1-IV_5.json
+++ b/testdata/phenopackets/lirical/Hamamy-2014-FYB1-IV_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:25516138-Hamamy-2014-FYB1-IV:5",
   "subject": {
     "id": "IV:5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Hamzeh-2016-GPSM2-case_1.json
+++ b/testdata/phenopackets/lirical/Hamzeh-2016-GPSM2-case_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27180139-Hamzeh-2016-GPSM2-case_1",
   "subject": {
     "id": "case 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Han-2015-CHRDL1-III-1.json
+++ b/testdata/phenopackets/lirical/Han-2015-CHRDL1-III-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:24073597-Han-2015-CHRDL1-III-1",
   "subject": {
     "id": "III-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11Y"

--- a/testdata/phenopackets/lirical/Hara-2019-TGFBR1-patient.json
+++ b/testdata/phenopackets/lirical/Hara-2019-TGFBR1-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:30701076-Hara-2019-TGFBR1-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P31Y"

--- a/testdata/phenopackets/lirical/Harlalka-2013-HERC2-Pedigree_1A,VIII_8.json
+++ b/testdata/phenopackets/lirical/Harlalka-2013-HERC2-Pedigree_1A,VIII_8.json
@@ -2,7 +2,6 @@
   "id": "PMID:23243086-Harlalka-2013-HERC2-Pedigree_1A,VIII:8",
   "subject": {
     "id": "Pedigree 1A,VIII:8",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P35Y"

--- a/testdata/phenopackets/lirical/Hashemi-Gorji-2019-MED23-IV.8.json
+++ b/testdata/phenopackets/lirical/Hashemi-Gorji-2019-MED23-IV.8.json
@@ -2,7 +2,6 @@
   "id": "PMID:30847200-Hashemi-Gorji-2019-MED23-IV.8",
   "subject": {
     "id": "IV.8",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P25Y"

--- a/testdata/phenopackets/lirical/Hayette-1995-EPB42-proposita.json
+++ b/testdata/phenopackets/lirical/Hayette-1995-EPB42-proposita.json
@@ -2,7 +2,6 @@
   "id": "PMID:7803799-Hayette-1995-EPB42-proposita",
   "subject": {
     "id": "proposita",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P28Y"

--- a/testdata/phenopackets/lirical/Helmi-2017-LYST-patient.json
+++ b/testdata/phenopackets/lirical/Helmi-2017-LYST-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:28183707-Helmi-2017-LYST-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y6M"

--- a/testdata/phenopackets/lirical/Hernan-2004-STK11-20-year-old_woman_.json
+++ b/testdata/phenopackets/lirical/Hernan-2004-STK11-20-year-old_woman_.json
@@ -2,7 +2,6 @@
   "id": "PMID:15200509-Hernan-2004-STK11-20-year-old_woman_",
   "subject": {
     "id": "20-year-old woman ",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P20Y"

--- a/testdata/phenopackets/lirical/Higuchi-2017-COL2A1-proband.json
+++ b/testdata/phenopackets/lirical/Higuchi-2017-COL2A1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:28841907-Higuchi-2017-COL2A1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Hilgert-2008-TMC1-935-IV_1.json
+++ b/testdata/phenopackets/lirical/Hilgert-2008-TMC1-935-IV_1.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "935-IV:1",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Hilgert-2008-TMC1-935-IV_1.json
+++ b/testdata/phenopackets/lirical/Hilgert-2008-TMC1-935-IV_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:18616530-Hilgert-2008-TMC1-935-IV:1",
   "subject": {
     "id": "935-IV:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Hirabayashi-2018-SPINT2-two-month-old_male.json
+++ b/testdata/phenopackets/lirical/Hirabayashi-2018-SPINT2-two-month-old_male.json
@@ -2,7 +2,6 @@
   "id": "PMID:29575628-Hirabayashi-2018-SPINT2-two-month-old_male",
   "subject": {
     "id": "two-month-old male",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2M"

--- a/testdata/phenopackets/lirical/Hirschhorn-1991-ADA-Patient.json
+++ b/testdata/phenopackets/lirical/Hirschhorn-1991-ADA-Patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:1680289-Hirschhorn-1991-ADA-Patient",
   "subject": {
     "id": "Patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Ho-2018-GNPTAB-proband.json
+++ b/testdata/phenopackets/lirical/Ho-2018-GNPTAB-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30208878-Ho-2018-GNPTAB-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7M"

--- a/testdata/phenopackets/lirical/Holmberg-1997-GP1BA-73_year_old_male.json
+++ b/testdata/phenopackets/lirical/Holmberg-1997-GP1BA-73_year_old_male.json
@@ -2,7 +2,6 @@
   "id": "PMID:9233564-Holmberg-1997-GP1BA-73_year_old_male",
   "subject": {
     "id": "73 year old male",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P73Y"

--- a/testdata/phenopackets/lirical/Holmberg-1997-GP1BA-73_year_old_male.json
+++ b/testdata/phenopackets/lirical/Holmberg-1997-GP1BA-73_year_old_male.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "73Y"
+        "iso8601duration": "P73Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Horvath-2014-GLRA1-proband.json
+++ b/testdata/phenopackets/lirical/Horvath-2014-GLRA1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:24969041-Horv\u00e1th-2014-GLRA1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11D"

--- a/testdata/phenopackets/lirical/Hsu-2017-SNAP29-The_patient.json
+++ b/testdata/phenopackets/lirical/Hsu-2017-SNAP29-The_patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:29051910-Hsu-2017-SNAP29-The_patient",
   "subject": {
     "id": "The patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Hsu-2017-SNAP29-The_patient.json
+++ b/testdata/phenopackets/lirical/Hsu-2017-SNAP29-The_patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "10Y"
+        "iso8601duration": "P10Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Huang-2017-P3H1-proband.json
+++ b/testdata/phenopackets/lirical/Huang-2017-P3H1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:27864101-Huang-2017-P3H1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "ontologyClass": {
         "id": "HP:0030674",

--- a/testdata/phenopackets/lirical/Huang-2017-P3H1-proband.json
+++ b/testdata/phenopackets/lirical/Huang-2017-P3H1-proband.json
@@ -4,8 +4,9 @@
     "id": "proband",
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "fetus"
+      "ontologyClass": {
+        "id": "HP:0030674",
+        "label": "Antenatal onset"
       }
     },
     "taxonomy": {

--- a/testdata/phenopackets/lirical/Hyun-2018-TP53RK-II-1.json
+++ b/testdata/phenopackets/lirical/Hyun-2018-TP53RK-II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30053862-Hyun-2018-TP53RK-II-1",
   "subject": {
     "id": "II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10M"

--- a/testdata/phenopackets/lirical/Imani-2019-BBS5-II_2.json
+++ b/testdata/phenopackets/lirical/Imani-2019-BBS5-II_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:30850397-Imani-2019-BBS5-II:2",
   "subject": {
     "id": "II:2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Infante-2017-SMC3-patient_1.json
+++ b/testdata/phenopackets/lirical/Infante-2017-SMC3-patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28781842-Infante-2017-SMC3-patient_1",
   "subject": {
     "id": "patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7M"

--- a/testdata/phenopackets/lirical/Infante-2017-SMC3-patient_1.json
+++ b/testdata/phenopackets/lirical/Infante-2017-SMC3-patient_1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "7m"
+        "iso8601duration": "P7M"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Inlora-2017-APTX-V-3.json
+++ b/testdata/phenopackets/lirical/Inlora-2017-APTX-V-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28652255-Inlora-2017-APTX-V-3",
   "subject": {
     "id": "V-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P33Y"

--- a/testdata/phenopackets/lirical/Inui-2017-LONP1-Proband.json
+++ b/testdata/phenopackets/lirical/Inui-2017-LONP1-Proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:28148925-Inui-2017-LONP1-Proband",
   "subject": {
     "id": "Proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Irfanullah-2015-NPR2-IV-2_family-A.json
+++ b/testdata/phenopackets/lirical/Irfanullah-2015-NPR2-IV-2_family-A.json
@@ -2,7 +2,6 @@
   "id": "PMID:25959430-Irfanullah-2015-NPR2-IV-2/family-A",
   "subject": {
     "id": "IV-2/family-A",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Irfanullah-2015-NPR2-IV-2_family-A.json
+++ b/testdata/phenopackets/lirical/Irfanullah-2015-NPR2-IV-2_family-A.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "IV-2/family-A",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Ishii-2013-KCNT1-Patient-1.json
+++ b/testdata/phenopackets/lirical/Ishii-2013-KCNT1-Patient-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:24029078-Ishii-2013-KCNT1-Patient-1",
   "subject": {
     "id": "Patient-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y1M"

--- a/testdata/phenopackets/lirical/Itoh-Satoh-2002-TTN-JK109.json
+++ b/testdata/phenopackets/lirical/Itoh-Satoh-2002-TTN-JK109.json
@@ -2,7 +2,6 @@
   "id": "PMID:11846417-Itoh-Satoh-2002-TTN-JK109",
   "subject": {
     "id": "JK109",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P40Y"

--- a/testdata/phenopackets/lirical/Jagadisan-2017-PYGL-2-year_5-month_old_child.json
+++ b/testdata/phenopackets/lirical/Jagadisan-2017-PYGL-2-year_5-month_old_child.json
@@ -2,7 +2,6 @@
   "id": "PMID:28984260-Jagadisan-2017-PYGL-2-year_5-month_old_child",
   "subject": {
     "id": "2-year 5-month old child",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2T5M"

--- a/testdata/phenopackets/lirical/Janecke-2015-SLC9A3-Patient_9.json
+++ b/testdata/phenopackets/lirical/Janecke-2015-SLC9A3-Patient_9.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "1.5"
+        "iso8601duration": "P1Y6M"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Janecke-2015-SLC9A3-Patient_9.json
+++ b/testdata/phenopackets/lirical/Janecke-2015-SLC9A3-Patient_9.json
@@ -2,7 +2,6 @@
   "id": "PMID:26358773-Janecke-2015-SLC9A3-Patient_9",
   "subject": {
     "id": "Patient 9",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y6M"

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F1-II2.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F1-II2.json
@@ -2,7 +2,6 @@
   "id": "PMID:26833330-Jansen-2016-TMEM199-F1-II2",
   "subject": {
     "id": "F1-II2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F2-II2.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F2-II2.json
@@ -2,7 +2,6 @@
   "id": "PMID:26833330-Jansen-2016-TMEM199-F2-II2",
   "subject": {
     "id": "F2-II2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P41Y"

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F3-II1.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F3-II1.json
@@ -2,7 +2,6 @@
   "id": "PMID:26833330-Jansen-2016-TMEM199-F3-II1",
   "subject": {
     "id": "F3-II1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P23Y"

--- a/testdata/phenopackets/lirical/Janssen-2009-BSND-family-A-III3.json
+++ b/testdata/phenopackets/lirical/Janssen-2009-BSND-family-A-III3.json
@@ -2,7 +2,6 @@
   "id": "PMID:18776122-Janssen-2009-BSND-family-A;III3",
   "subject": {
     "id": "family-A;III3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Javadiyan-2017-MAF-patient_CSA108.01.json
+++ b/testdata/phenopackets/lirical/Javadiyan-2017-MAF-patient_CSA108.01.json
@@ -2,7 +2,6 @@
   "id": "PMID:28482824-Javadiyan-2017-MAF-patient_CSA108.01",
   "subject": {
     "id": "patient CSA108.01",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P20Y"

--- a/testdata/phenopackets/lirical/Jeon-2014-LAMC2-patient.json
+++ b/testdata/phenopackets/lirical/Jeon-2014-LAMC2-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:24533970-Jeon-2014-LAMC2-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2W"

--- a/testdata/phenopackets/lirical/Ji-2017-ATRX-Proband.json
+++ b/testdata/phenopackets/lirical/Ji-2017-ATRX-Proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:28371217-Ji-2017-ATRX-Proband",
   "subject": {
     "id": "Proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P22Y"

--- a/testdata/phenopackets/lirical/Jiang-2017-PPIB-second_fetus.json
+++ b/testdata/phenopackets/lirical/Jiang-2017-PPIB-second_fetus.json
@@ -2,7 +2,6 @@
   "id": "PMID:28242392-Jiang-2017-PPIB-second_fetus",
   "subject": {
     "id": "second fetus",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P24W"

--- a/testdata/phenopackets/lirical/Jin-2017-FBN1-patient.json
+++ b/testdata/phenopackets/lirical/Jin-2017-FBN1-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:27834076-Jin-2017-FBN1-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_2.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:29330883-Jordan-2018-RERE-Subject_2",
   "subject": {
     "id": "Subject 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8M"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_3.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:29330883-Jordan-2018-RERE-Subject_3",
   "subject": {
     "id": "Subject 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_4.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:29330883-Jordan-2018-RERE-Subject_4",
   "subject": {
     "id": "Subject 4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P13Y"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_5.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:29330883-Jordan-2018-RERE-Subject_5",
   "subject": {
     "id": "Subject 5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P25Y"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_6.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_6.json
@@ -2,7 +2,6 @@
   "id": "PMID:29330883-Jordan-2018-RERE-Subject_6",
   "subject": {
     "id": "Subject 6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6M"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_7.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_7.json
@@ -2,7 +2,6 @@
   "id": "PMID:29330883-Jordan-2018-RERE-Subject_7",
   "subject": {
     "id": "Subject 7",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P33D"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_8.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_8.json
@@ -2,7 +2,6 @@
   "id": "PMID:29330883-Jordan-2018-RERE-Subject_8",
   "subject": {
     "id": "Subject 8",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_9.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_9.json
@@ -2,7 +2,6 @@
   "id": "PMID:29330883-Jordan-2018-RERE-Subject_9",
   "subject": {
     "id": "Subject 9",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Kantaputra-2014-FBLN5-4-year-old_Burmese_girl_.json
+++ b/testdata/phenopackets/lirical/Kantaputra-2014-FBLN5-4-year-old_Burmese_girl_.json
@@ -2,7 +2,6 @@
   "id": "PMID:24962763-Kantaputra-2014-FBLN5-4-year-old_Burmese_girl_",
   "subject": {
     "id": "4-year-old Burmese girl ",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Kato-2018-HNF1B-patient.json
+++ b/testdata/phenopackets/lirical/Kato-2018-HNF1B-patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "19Y"
+        "iso8601duration": "P19Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Kato-2018-HNF1B-patient.json
+++ b/testdata/phenopackets/lirical/Kato-2018-HNF1B-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:29491316-Kato-2018-HNF1B-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P19Y"

--- a/testdata/phenopackets/lirical/Khan-2017-HOXC13-IV-1.json
+++ b/testdata/phenopackets/lirical/Khan-2017-HOXC13-IV-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28403827-Khan-2017-HOXC13-IV-1",
   "subject": {
     "id": "IV-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P37Y"

--- a/testdata/phenopackets/lirical/Kim-2016-LAMB3-proband.json
+++ b/testdata/phenopackets/lirical/Kim-2016-LAMB3-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:27220909-Kim-2016-LAMB3-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Kinnear-2017-TTC37-index.json
+++ b/testdata/phenopackets/lirical/Kinnear-2017-TTC37-index.json
@@ -2,7 +2,6 @@
   "id": "PMID:28292286-Kinnear-2017-TTC37-index",
   "subject": {
     "id": "index",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3M"

--- a/testdata/phenopackets/lirical/Kluijtmans-1996-CBS-patient.json
+++ b/testdata/phenopackets/lirical/Kluijtmans-1996-CBS-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:8755636-Kluijtmans-1996-CBS-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P20Y"

--- a/testdata/phenopackets/lirical/Kluijtmans-1996-CBS-patient.json
+++ b/testdata/phenopackets/lirical/Kluijtmans-1996-CBS-patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "20Y"
+        "iso8601duration": "P20Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam1Pat1.json
+++ b/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam1Pat1.json
@@ -2,7 +2,6 @@
   "id": "PMID:29379883-Kocoglu-2018-CAPN1-Fam1Pat1",
   "subject": {
     "id": "Fam1Pat1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam2Pat1.json
+++ b/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam2Pat1.json
@@ -2,7 +2,6 @@
   "id": "PMID:29379883-Kocoglu-2018-CAPN1-Fam2Pat1",
   "subject": {
     "id": "Fam2Pat1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Konkolova-2017-GRHPR-patient.json
+++ b/testdata/phenopackets/lirical/Konkolova-2017-GRHPR-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:28569194-Konko\u013eov\u00e1-2017-GRHPR-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11M"

--- a/testdata/phenopackets/lirical/Kou-2018-ERCC6-index.json
+++ b/testdata/phenopackets/lirical/Kou-2018-ERCC6-index.json
@@ -2,7 +2,6 @@
   "id": "PMID:30113454-Kou-2018-ERCC6-index",
   "subject": {
     "id": "index",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Kremer-2016-TANGO2-F1_II.2.json
+++ b/testdata/phenopackets/lirical/Kremer-2016-TANGO2-F1_II.2.json
@@ -2,7 +2,6 @@
   "id": "PMID:26805782-Kremer-2016-TANGO2-F1:II.2",
   "subject": {
     "id": "F1:II.2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Kretz-2011-PYCR1-Patient_4.json
+++ b/testdata/phenopackets/lirical/Kretz-2011-PYCR1-Patient_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:21487760-Kretz-2011-PYCR1-Patient_4",
   "subject": {
     "id": "Patient 4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Kruszka-2016-FGFR3-Proband_27.json
+++ b/testdata/phenopackets/lirical/Kruszka-2016-FGFR3-Proband_27.json
@@ -2,7 +2,6 @@
   "id": "PMID:26740388-Kruszka-2016-FGFR3-Proband_27",
   "subject": {
     "id": "Proband 27",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Kuptanon-2018-WNT1-proband.json
+++ b/testdata/phenopackets/lirical/Kuptanon-2018-WNT1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30012084-Kuptanon-2018-WNT1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_1.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132691-K\u00fcry-2017-PSMD12-Subject_1",
   "subject": {
     "id": "Subject 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_2.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132691-K\u00fcry-2017-PSMD12-Subject_2",
   "subject": {
     "id": "Subject 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_3.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132691-K\u00fcry-2017-PSMD12-Subject_3",
   "subject": {
     "id": "Subject 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_4.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132691-K\u00fcry-2017-PSMD12-Subject_4",
   "subject": {
     "id": "Subject 4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_2.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:26805781-Lalani-2016-TANGO2-Subject_2",
   "subject": {
     "id": "Subject 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6M"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_4.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:26805781-Lalani-2016-TANGO2-Subject_4",
   "subject": {
     "id": "Subject 4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_5.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:26805781-Lalani-2016-TANGO2-Subject_5",
   "subject": {
     "id": "Subject 5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_6.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_6.json
@@ -2,7 +2,6 @@
   "id": "PMID:26805781-Lalani-2016-TANGO2-Subject_6",
   "subject": {
     "id": "Subject 6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Suject_1.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Suject_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:26805781-Lalani-2016-TANGO2-Suject_1",
   "subject": {
     "id": "Suject 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Lambe-2018-CAPN1-II-4.json
+++ b/testdata/phenopackets/lirical/Lambe-2018-CAPN1-II-4.json
@@ -2,7 +2,6 @@
   "id": "PMID:29678961-Lambe-2018-CAPN1-II-4",
   "subject": {
     "id": "II-4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_A,_V-2.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_A,_V-2.json
@@ -2,7 +2,6 @@
   "id": "PMID:26942284-Lesage-2016-VPS13C-Family_A,_V-2",
   "subject": {
     "id": "Family A, V-2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P58Y"

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_B,_II-1.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_B,_II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:26942284-Lesage-2016-VPS13C-Family_B,_II-1",
   "subject": {
     "id": "Family B, II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P33Y"

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_C,_II-1.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_C,_II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:26942284-Lesage-2016-VPS13C-Family_C,_II-1",
   "subject": {
     "id": "Family C, II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P25Y"

--- a/testdata/phenopackets/lirical/Li-2014-BBS4-4-year-old_female_patient.json
+++ b/testdata/phenopackets/lirical/Li-2014-BBS4-4-year-old_female_patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:25533820-Li-2014-BBS4-4-year-old_female_patient",
   "subject": {
     "id": "4-year-old female patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Li-2018-STXBP1-P1.json
+++ b/testdata/phenopackets/lirical/Li-2018-STXBP1-P1.json
@@ -2,7 +2,6 @@
   "id": "PMID:29896790-Li-2018-STXBP1-P1",
   "subject": {
     "id": "P1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2M15D"

--- a/testdata/phenopackets/lirical/Liberalesso-2017-SALL1-VMFS.json
+++ b/testdata/phenopackets/lirical/Liberalesso-2017-SALL1-VMFS.json
@@ -2,7 +2,6 @@
   "id": "PMID:29110636-Liberalesso-2017-SALL1-VMFS",
   "subject": {
     "id": "VMFS",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Ling-2019-NHS-III_1.json
+++ b/testdata/phenopackets/lirical/Ling-2019-NHS-III_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30642278-Ling-2019-NHS-III:1",
   "subject": {
     "id": "III:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Ling-2019-NHS-III_1.json
+++ b/testdata/phenopackets/lirical/Ling-2019-NHS-III_1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "15y"
+        "iso8601duration": "P15Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Lopez-2018-EP300-11.json
+++ b/testdata/phenopackets/lirical/Lopez-2018-EP300-11.json
@@ -2,7 +2,6 @@
   "id": "PMID:29506490-L\u00f3pez-2018-EP300-11",
   "subject": {
     "id": "11",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P18Y"

--- a/testdata/phenopackets/lirical/Lopez-2018-EP300-38.json
+++ b/testdata/phenopackets/lirical/Lopez-2018-EP300-38.json
@@ -2,7 +2,6 @@
   "id": "PMID:29506490-L\u00f3pez-2018-EP300-38",
   "subject": {
     "id": "38",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Luco-2016-DYRK1A-Patient_2.json
+++ b/testdata/phenopackets/lirical/Luco-2016-DYRK1A-Patient_2.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "13Y"
+        "iso8601duration": "P13Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Luco-2016-DYRK1A-Patient_2.json
+++ b/testdata/phenopackets/lirical/Luco-2016-DYRK1A-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:26922654-Luco-2016-DYRK1A-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P13Y"

--- a/testdata/phenopackets/lirical/Luo-2016-COMP-II-1.json
+++ b/testdata/phenopackets/lirical/Luo-2016-COMP-II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27330822-Luo-2016-COMP-II-1",
   "subject": {
     "id": "II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Luo-2016-COMP-II-1.json
+++ b/testdata/phenopackets/lirical/Luo-2016-COMP-II-1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "3Y"
+        "iso8601duration": "P3Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Lv-2016-TMEM38B-family2-patient2.json
+++ b/testdata/phenopackets/lirical/Lv-2016-TMEM38B-family2-patient2.json
@@ -2,7 +2,6 @@
   "id": "PMID:26911354-Lv-2016-TMEM38B-family2-patient2",
   "subject": {
     "id": "family2-patient2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Ma-2018-SPTA1-proband.json
+++ b/testdata/phenopackets/lirical/Ma-2018-SPTA1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:29484404-Ma-2018-SPTA1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Mackenroth-2016-ADAMTSL2-patient.json
+++ b/testdata/phenopackets/lirical/Mackenroth-2016-ADAMTSL2-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:27057656-Mackenroth-2016-ADAMTSL2-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y3M"

--- a/testdata/phenopackets/lirical/Magerus-Chatinet-2013-FASLG-patient.json
+++ b/testdata/phenopackets/lirical/Magerus-Chatinet-2013-FASLG-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:22857792-Magerus-Chatinet-2013-FASLG-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11M"

--- a/testdata/phenopackets/lirical/Maghami-2018-FKBP10-proband.json
+++ b/testdata/phenopackets/lirical/Maghami-2018-FKBP10-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:29801479-Maghami-2018-FKBP10-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Mattioli-2017-BRPF1-Individual_11_Family_F.json
+++ b/testdata/phenopackets/lirical/Mattioli-2017-BRPF1-Individual_11_Family_F.json
@@ -2,7 +2,6 @@
   "id": "PMID:27939639-Mattioli-2017-BRPF1-Individual_11/Family_F",
   "subject": {
     "id": "Individual 11/Family F",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Mattioli-2017-BRPF1-Individual_11_Family_F.json
+++ b/testdata/phenopackets/lirical/Mattioli-2017-BRPF1-Individual_11_Family_F.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "12"
+        "iso8601duration": "P12Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Mazzucchelli-2011-LAMA3-Proband.json
+++ b/testdata/phenopackets/lirical/Mazzucchelli-2011-LAMA3-Proband.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "8M"
+        "iso8601duration": "P8M"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Mazzucchelli-2011-LAMA3-Proband.json
+++ b/testdata/phenopackets/lirical/Mazzucchelli-2011-LAMA3-Proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:20881434-Mazzucchelli-2011-LAMA3-Proband",
   "subject": {
     "id": "Proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8M"

--- a/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:25447906-Mei-2015-NIPBL-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_2.json
+++ b/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:25447906-Mei-2015-NIPBL-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_1.json
+++ b/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27132592-Metodiev-2016-TRMT10C-Subject_1",
   "subject": {
     "id": "Subject 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5M"

--- a/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_2.json
+++ b/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:27132592-Metodiev-2016-TRMT10C-Subject_2",
   "subject": {
     "id": "Subject 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Miao-2018-CLCN1-man.json
+++ b/testdata/phenopackets/lirical/Miao-2018-CLCN1-man.json
@@ -2,7 +2,6 @@
   "id": "PMID:30243293-Miao-2018-CLCN1-man",
   "subject": {
     "id": "man",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Micaglio-2019-SCN5A-proband.json
+++ b/testdata/phenopackets/lirical/Micaglio-2019-SCN5A-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:31590245-Micaglio-2019-SCN5A-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P30Y"

--- a/testdata/phenopackets/lirical/Michalska-2018-GTF2H5-male_infant.json
+++ b/testdata/phenopackets/lirical/Michalska-2018-GTF2H5-male_infant.json
@@ -2,7 +2,6 @@
   "id": "PMID:30359777-Michalska-2018-GTF2H5-male_infant",
   "subject": {
     "id": "male infant",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6M"

--- a/testdata/phenopackets/lirical/Mokbel-2013-TPM2-1A.json
+++ b/testdata/phenopackets/lirical/Mokbel-2013-TPM2-1A.json
@@ -2,7 +2,6 @@
   "id": "PMID:23378224-Mokbel-2013-TPM2-1A",
   "subject": {
     "id": "1A",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P45Y"

--- a/testdata/phenopackets/lirical/Montgomery-2015-AMN-III_1.json
+++ b/testdata/phenopackets/lirical/Montgomery-2015-AMN-III_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:26040326-Montgomery-2015-AMN-III:1",
   "subject": {
     "id": "III:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P33Y"

--- a/testdata/phenopackets/lirical/Moosa-1799-MTOR-index.json
+++ b/testdata/phenopackets/lirical/Moosa-1799-MTOR-index.json
@@ -2,7 +2,6 @@
   "id": "PMID:27753196-Moosa-1799-MTOR-index",
   "subject": {
     "id": "index",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Moreau-Le_Lan-2018-ACTA1-Patient_5.json
+++ b/testdata/phenopackets/lirical/Moreau-Le_Lan-2018-ACTA1-Patient_5.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "Patient 5",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "FEMALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Moreau-Le_Lan-2018-ACTA1-Patient_5.json
+++ b/testdata/phenopackets/lirical/Moreau-Le_Lan-2018-ACTA1-Patient_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:30517146-Moreau-Le_Lan-2018-ACTA1-Patient_5",
   "subject": {
     "id": "Patient 5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "FEMALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:23546041-Mundhofir-2013-FGFR2-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11M"

--- a/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_2.json
+++ b/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:23546041-Mundhofir-2013-FGFR2-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y6M"

--- a/testdata/phenopackets/lirical/Mwasamwaja-2018-TGFB1-patient.json
+++ b/testdata/phenopackets/lirical/Mwasamwaja-2018-TGFB1-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:30034812-Mwasamwaja-2018-TGFB1-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P35Y"

--- a/testdata/phenopackets/lirical/Mwasamwaja-2018-TGFB1-patient.json
+++ b/testdata/phenopackets/lirical/Mwasamwaja-2018-TGFB1-patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "35Y"
+        "iso8601duration": "P35Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Nakajima-2013-B3GALT6-P7_F6.json
+++ b/testdata/phenopackets/lirical/Nakajima-2013-B3GALT6-P7_F6.json
@@ -2,7 +2,6 @@
   "id": "PMID:23664117-Nakajima-2013-B3GALT6-P7/F6",
   "subject": {
     "id": "P7/F6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Nakajima-2013-B3GALT6-P7_F6.json
+++ b/testdata/phenopackets/lirical/Nakajima-2013-B3GALT6-P7_F6.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "2"
+        "iso8601duration": "P2Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Naz_Villalba-2016-NLRP3-proband.json
+++ b/testdata/phenopackets/lirical/Naz_Villalba-2016-NLRP3-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:27435956-Naz_Villalba-2016-NLRP3-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Nellist-2009-TSC1-II_3_Family_2.json
+++ b/testdata/phenopackets/lirical/Nellist-2009-TSC1-II_3_Family_2.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "II:3/Family 2",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "N/A"
-      }
-    },
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Nellist-2009-TSC1-II_3_Family_2.json
+++ b/testdata/phenopackets/lirical/Nellist-2009-TSC1-II_3_Family_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:18830229-Nellist-2009-TSC1-II:3/Family_2",
   "subject": {
     "id": "II:3/Family 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Nevidomskyte-2017-SMAD3-54-year_old_woman.json
+++ b/testdata/phenopackets/lirical/Nevidomskyte-2017-SMAD3-54-year_old_woman.json
@@ -2,7 +2,6 @@
   "id": "PMID:28286188-Nevidomskyte-2017-SMAD3-54-year_old_woman",
   "subject": {
     "id": "54-year old woman",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P54Y"

--- a/testdata/phenopackets/lirical/Nguyen-2017-NPHS1-patient_1.json
+++ b/testdata/phenopackets/lirical/Nguyen-2017-NPHS1-patient_1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "40"
+        "iso8601duration": "P40Y"
       }
     },
     "taxonomy": {

--- a/testdata/phenopackets/lirical/Nguyen-2017-NPHS1-patient_1.json
+++ b/testdata/phenopackets/lirical/Nguyen-2017-NPHS1-patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28392951-Nguyen-2017-NPHS1-patient_1",
   "subject": {
     "id": "patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P40Y"

--- a/testdata/phenopackets/lirical/Nicole-2014-AGRN-Patient_3_Kinship_2.json
+++ b/testdata/phenopackets/lirical/Nicole-2014-AGRN-Patient_3_Kinship_2.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "36"
+        "iso8601duration": "P36Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Nicole-2014-AGRN-Patient_3_Kinship_2.json
+++ b/testdata/phenopackets/lirical/Nicole-2014-AGRN-Patient_3_Kinship_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:24951643-Nicole-2014-AGRN-Patient_3/Kinship_2",
   "subject": {
     "id": "Patient 3/Kinship 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P36Y"

--- a/testdata/phenopackets/lirical/Niihori-2006-BRAF-CFC16.json
+++ b/testdata/phenopackets/lirical/Niihori-2006-BRAF-CFC16.json
@@ -2,7 +2,6 @@
   "id": "PMID:16474404-Niihori-2006-BRAF-CFC16",
   "subject": {
     "id": "CFC16",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Ning-2015-MEN1-III-3.json
+++ b/testdata/phenopackets/lirical/Ning-2015-MEN1-III-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:26239674-Ning-2015-MEN1-III-3",
   "subject": {
     "id": "III-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P54Y"

--- a/testdata/phenopackets/lirical/Noch-2017-ATP13A2-Case_1.json
+++ b/testdata/phenopackets/lirical/Noch-2017-ATP13A2-Case_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30746398-Noch-2017-ATP13A2-Case_1",
   "subject": {
     "id": "Case 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P30Y"

--- a/testdata/phenopackets/lirical/Ockeloen-2012-CFL2-_Patient_1.json
+++ b/testdata/phenopackets/lirical/Ockeloen-2012-CFL2-_Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:22560515-Ockeloen-2012-CFL2-_Patient_1",
   "subject": {
     "id": " Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Okamoto-2018-ASPM-patient.json
+++ b/testdata/phenopackets/lirical/Okamoto-2018-ASPM-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:29644084-Okamoto-2018-ASPM-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-AII-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-AII-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132690-Oud-2017-EXTL3-AII-1",
   "subject": {
     "id": "AII-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1M3W"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-BII-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-BII-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132690-Oud-2017-EXTL3-BII-1",
   "subject": {
     "id": "BII-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-B_II-2.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-B_II-2.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132690-Oud-2017-EXTL3-B:II-2",
   "subject": {
     "id": "B:II-2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3M"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-C_II-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-C_II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132690-Oud-2017-EXTL3-C:II-1",
   "subject": {
     "id": "C:II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-D_IV-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-D_IV-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132690-Oud-2017-EXTL3-D:IV-1",
   "subject": {
     "id": "D:IV-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-E_II-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-E_II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28132690-Oud-2017-EXTL3-E:II-1",
   "subject": {
     "id": "E:II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6M"

--- a/testdata/phenopackets/lirical/Papanastasiou-2010-STAT3-12_year_old_girl.json
+++ b/testdata/phenopackets/lirical/Papanastasiou-2010-STAT3-12_year_old_girl.json
@@ -2,7 +2,6 @@
   "id": "PMID:20149460-Papanastasiou-2010-STAT3-12_year_old_girl",
   "subject": {
     "id": "12 year old girl",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Park-2014-DNM2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Park-2014-DNM2-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:24465259-Park-2014-DNM2-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P35Y"

--- a/testdata/phenopackets/lirical/Park-2014-DNM2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Park-2014-DNM2-Patient_1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "35"
+        "iso8601duration": "P35Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Park-2016-GSN-III_5.json
+++ b/testdata/phenopackets/lirical/Park-2016-GSN-III_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:26915616-Park-2016-GSN-III:5",
   "subject": {
     "id": "III:5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P58Y"

--- a/testdata/phenopackets/lirical/Pasic-2013-NBN-12-year-old_girl.json
+++ b/testdata/phenopackets/lirical/Pasic-2013-NBN-12-year-old_girl.json
@@ -2,7 +2,6 @@
   "id": "PMID:24044622-Pasic-2013-NBN-12-year-old_girl",
   "subject": {
     "id": "12-year-old girl",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12T"

--- a/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P5.json
+++ b/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P5.json
@@ -2,7 +2,6 @@
   "id": "PMID:29217778-Pastor-2018-SAMD9L-P5",
   "subject": {
     "id": "P5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P7.json
+++ b/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P7.json
@@ -2,7 +2,6 @@
   "id": "PMID:29217778-Pastor-2018-SAMD9L-P7",
   "subject": {
     "id": "P7",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Patsi-2018-PNPLA6-18_year-old_female.json
+++ b/testdata/phenopackets/lirical/Patsi-2018-PNPLA6-18_year-old_female.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "18Y"
+        "iso8601duration": "P18Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Patsi-2018-PNPLA6-18_year-old_female.json
+++ b/testdata/phenopackets/lirical/Patsi-2018-PNPLA6-18_year-old_female.json
@@ -2,7 +2,6 @@
   "id": "PMID:30097146-Patsi-2018-PNPLA6-18_year-old_female",
   "subject": {
     "id": "18 year-old female",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P18Y"

--- a/testdata/phenopackets/lirical/Paun-2013-RET-DM_patient.json
+++ b/testdata/phenopackets/lirical/Paun-2013-RET-DM_patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:24331334-P\u0103un-2013-RET-DM_patient",
   "subject": {
     "id": "DM  patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P19Y"

--- a/testdata/phenopackets/lirical/Paun-2013-RET-DM_patient.json
+++ b/testdata/phenopackets/lirical/Paun-2013-RET-DM_patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "19Y"
+        "iso8601duration": "P19Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Pipilas-2016-CALM1-Case_2.json
+++ b/testdata/phenopackets/lirical/Pipilas-2016-CALM1-Case_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:27374306-Pipilas-2016-CALM1-Case_2",
   "subject": {
     "id": "Case 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Pipilas-2016-CALM2-Case_1.json
+++ b/testdata/phenopackets/lirical/Pipilas-2016-CALM2-Case_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27374306-Pipilas-2016-CALM2-Case_1",
   "subject": {
     "id": "Case 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y"

--- a/testdata/phenopackets/lirical/Prada-2014-CTSA-BAB3767.json
+++ b/testdata/phenopackets/lirical/Prada-2014-CTSA-BAB3767.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "24Y"
+        "iso8601duration": "P24Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Prada-2014-CTSA-BAB3767.json
+++ b/testdata/phenopackets/lirical/Prada-2014-CTSA-BAB3767.json
@@ -2,7 +2,6 @@
   "id": "PMID:24769197-Prada-2014-CTSA-BAB3767",
   "subject": {
     "id": "BAB3767",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P24Y"

--- a/testdata/phenopackets/lirical/Qin-2017-NRL-II_2.json
+++ b/testdata/phenopackets/lirical/Qin-2017-NRL-II_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:28106895-Qin-2017-NRL-II:2",
   "subject": {
     "id": "II:2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P42Y"

--- a/testdata/phenopackets/lirical/Rejeb-2017-VPS13B-proposita.json
+++ b/testdata/phenopackets/lirical/Rejeb-2017-VPS13B-proposita.json
@@ -2,7 +2,6 @@
   "id": "PMID:29149870-Rejeb-2017-VPS13B-proposita",
   "subject": {
     "id": "proposita",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P12Y"

--- a/testdata/phenopackets/lirical/Reyes-de_la_Rosa-2018-JAG1-Proband.json
+++ b/testdata/phenopackets/lirical/Reyes-de_la_Rosa-2018-JAG1-Proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30046498-Reyes-de_la_Rosa-2018-JAG1-Proband",
   "subject": {
     "id": "Proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y7M"

--- a/testdata/phenopackets/lirical/Rincon-2019-WRN-48-year-old_male.json
+++ b/testdata/phenopackets/lirical/Rincon-2019-WRN-48-year-old_male.json
@@ -2,7 +2,6 @@
   "id": "PMID:30891318-Rinc\u00f3n-2019-WRN-48-year-old_male",
   "subject": {
     "id": "48-year-old male",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P48Y"

--- a/testdata/phenopackets/lirical/Ritelli-2013-COL5A1-AN_002501.json
+++ b/testdata/phenopackets/lirical/Ritelli-2013-COL5A1-AN_002501.json
@@ -2,7 +2,6 @@
   "id": "PMID:23587214-Ritelli-2013-COL5A1-AN_002501",
   "subject": {
     "id": "AN_002501",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Ritelli-2014-TGFB2-proposita.json
+++ b/testdata/phenopackets/lirical/Ritelli-2014-TGFB2-proposita.json
@@ -2,7 +2,6 @@
   "id": "PMID:25163805-Ritelli-2014-TGFB2-proposita",
   "subject": {
     "id": "proposita",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P57Y"

--- a/testdata/phenopackets/lirical/Ritelli-2019-AEBP1-AN_006205.json
+++ b/testdata/phenopackets/lirical/Ritelli-2019-AEBP1-AN_006205.json
@@ -2,7 +2,6 @@
   "id": "PMID:30759870-Ritelli-2019-AEBP1-AN_006205",
   "subject": {
     "id": "AN_006205",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P53Y"

--- a/testdata/phenopackets/lirical/Rohanizadegan-2018-DHCR24-proband.json
+++ b/testdata/phenopackets/lirical/Rohanizadegan-2018-DHCR24-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:29175559-Rohanizadegan-2018-DHCR24-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y8M"

--- a/testdata/phenopackets/lirical/Romero-Quintana-2013-CTSC-Case_1P1.json
+++ b/testdata/phenopackets/lirical/Romero-Quintana-2013-CTSC-Case_1P1.json
@@ -2,7 +2,6 @@
   "id": "PMID:23311634-Romero-Quintana-2013-CTSC-Case_1P1",
   "subject": {
     "id": "Case 1P1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Salas-Alanis-2016-ANTXR1-14_year_old_brother.json
+++ b/testdata/phenopackets/lirical/Salas-Alanis-2016-ANTXR1-14_year_old_brother.json
@@ -2,7 +2,6 @@
   "id": "PMID:27587992-Salas-Alan\u00eds-2016-ANTXR1-14_year_old_brother",
   "subject": {
     "id": "14 year old brother",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P14Y"

--- a/testdata/phenopackets/lirical/Salpietro-2018-DDX59-Patient_1.json
+++ b/testdata/phenopackets/lirical/Salpietro-2018-DDX59-Patient_1.json
@@ -4,8 +4,9 @@
     "id": "Patient 1",
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "adult"
+      "ontologyClass": {
+        "id": "HP:0003581",
+        "label": "Adult onset"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Salpietro-2018-DDX59-Patient_1.json
+++ b/testdata/phenopackets/lirical/Salpietro-2018-DDX59-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:29127725-Salpietro-2018-DDX59-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "ontologyClass": {
         "id": "HP:0003581",

--- a/testdata/phenopackets/lirical/Sandal-2018-CHST14-3-year_old_boy.json
+++ b/testdata/phenopackets/lirical/Sandal-2018-CHST14-3-year_old_boy.json
@@ -2,7 +2,6 @@
   "id": "PMID:30249733-Sandal-2018-CHST14-3-year_old_boy",
   "subject": {
     "id": "3-year old boy",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Savage-2016-FANCI-NCI-309-1.json
+++ b/testdata/phenopackets/lirical/Savage-2016-FANCI-NCI-309-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:26590883-Savage-2016-FANCI-NCI-309-1",
   "subject": {
     "id": "NCI-309-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Sawal-2018-ADGRG1-Family_A,_II_2.json
+++ b/testdata/phenopackets/lirical/Sawal-2018-ADGRG1-Family_A,_II_2.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "7Y"
+        "iso8601duration": "P7Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Sawal-2018-ADGRG1-Family_A,_II_2.json
+++ b/testdata/phenopackets/lirical/Sawal-2018-ADGRG1-Family_A,_II_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:29707406-Sawal-2018-ADGRG1-Family_A,_II:2",
   "subject": {
     "id": "Family A, II:2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Schaefer-2014-POLR1D-family_1_patient.json
+++ b/testdata/phenopackets/lirical/Schaefer-2014-POLR1D-family_1_patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:24603435-Schaefer-2014-POLR1D-family_1:patient",
   "subject": {
     "id": "family 1:patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Schormair-2018-VPS13C-VPS13C_case.json
+++ b/testdata/phenopackets/lirical/Schormair-2018-VPS13C-VPS13C_case.json
@@ -2,7 +2,6 @@
   "id": "PMID:28862745-Schormair-2018-VPS13C-VPS13C_case",
   "subject": {
     "id": "VPS13C case",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P39Y"

--- a/testdata/phenopackets/lirical/Schreckenbach-2014-TPM3-II.2.json
+++ b/testdata/phenopackets/lirical/Schreckenbach-2014-TPM3-II.2.json
@@ -2,7 +2,6 @@
   "id": "PMID:24239060-Schreckenbach-2014-TPM3-II.2",
   "subject": {
     "id": "II.2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P45Y"

--- a/testdata/phenopackets/lirical/Schussler-2018-ANTXR2-II-3_.json
+++ b/testdata/phenopackets/lirical/Schussler-2018-ANTXR2-II-3_.json
@@ -2,7 +2,6 @@
   "id": "PMID:30050362-Schussler-2018-ANTXR2-II-3_",
   "subject": {
     "id": "II-3 ",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10M"

--- a/testdata/phenopackets/lirical/Schweizer-2014-HCN4-family_A_II_1.json
+++ b/testdata/phenopackets/lirical/Schweizer-2014-HCN4-family_A_II_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:25145518-Schweizer-2014-HCN4-family_A/II:1",
   "subject": {
     "id": "family A/II:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P57Y"

--- a/testdata/phenopackets/lirical/Seidlmayer-2018-RYR2-proband.json
+++ b/testdata/phenopackets/lirical/Seidlmayer-2018-RYR2-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30296944-Seidlmayer-2018-RYR2-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P17Y"

--- a/testdata/phenopackets/lirical/Sekelska-2017-SPRED1-P62.json
+++ b/testdata/phenopackets/lirical/Sekelska-2017-SPRED1-P62.json
@@ -2,7 +2,6 @@
   "id": "PMID:28150585-Sekelska-2017-SPRED1-P62",
   "subject": {
     "id": "P62",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Servian-Morilla-2016-POGLUT1-Patient_II.1.json
+++ b/testdata/phenopackets/lirical/Servian-Morilla-2016-POGLUT1-Patient_II.1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27807076-Servi\u00e1n-Morilla-2016-POGLUT1-Patient_II.1",
   "subject": {
     "id": "Patient II.1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P39Y"

--- a/testdata/phenopackets/lirical/Servian-Morilla-2016-POGLUT1-Patient_II.1.json
+++ b/testdata/phenopackets/lirical/Servian-Morilla-2016-POGLUT1-Patient_II.1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "39"
+        "iso8601duration": "P39Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Seven-2014-DYM-Patient_2.json
+++ b/testdata/phenopackets/lirical/Seven-2014-DYM-Patient_2.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "3Y"
+        "iso8601duration": "P3Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Seven-2014-DYM-Patient_2.json
+++ b/testdata/phenopackets/lirical/Seven-2014-DYM-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:24300288-Seven-2014-DYM-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Shahid-2019-FERMT3-index.json
+++ b/testdata/phenopackets/lirical/Shahid-2019-FERMT3-index.json
@@ -2,7 +2,6 @@
   "id": "PMID:31068971-Shahid-2019-FERMT3-index",
   "subject": {
     "id": "index",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7M"

--- a/testdata/phenopackets/lirical/Shalaby-2009-MYOT-patient.json
+++ b/testdata/phenopackets/lirical/Shalaby-2009-MYOT-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:19458539-Shalaby-2009-MYOT-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P57Y"

--- a/testdata/phenopackets/lirical/Shen-2017-VPS13A-Patient-2.json
+++ b/testdata/phenopackets/lirical/Shen-2017-VPS13A-Patient-2.json
@@ -2,7 +2,6 @@
   "id": "PMID:28446873-Shen-2017-VPS13A-Patient-2",
   "subject": {
     "id": "Patient-2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P45Y"

--- a/testdata/phenopackets/lirical/Sher-2014-CHSY1-IV-1.json
+++ b/testdata/phenopackets/lirical/Sher-2014-CHSY1-IV-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:24269551-Sher-2014-CHSY1-IV-1",
   "subject": {
     "id": "IV-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Shervin_Badv-2019-ASAH1-patient.json
+++ b/testdata/phenopackets/lirical/Shervin_Badv-2019-ASAH1-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:31213928-Shervin_Badv-2019-ASAH1-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Shlebak-2015-GP1BA-Patient_3.json
+++ b/testdata/phenopackets/lirical/Shlebak-2015-GP1BA-Patient_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:26044173-Shlebak-2015-GP1BA-Patient_3",
   "subject": {
     "id": "Patient 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Silva-2018-PREPL-proband.json
+++ b/testdata/phenopackets/lirical/Silva-2018-PREPL-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:29483676-Silva-2018-PREPL-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Skraban-2017-WDR26-Individual_1,_PPMD01P,_GEA055P.json
+++ b/testdata/phenopackets/lirical/Skraban-2017-WDR26-Individual_1,_PPMD01P,_GEA055P.json
@@ -2,7 +2,6 @@
   "id": "PMID:28686853-Skraban-2017-WDR26-Individual_1,_PPMD01P,_GEA055P",
   "subject": {
     "id": "Individual 1, PPMD01P, GEA055P",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Skrabl-Baumgartner-2017-ADA2-patient_1.json
+++ b/testdata/phenopackets/lirical/Skrabl-Baumgartner-2017-ADA2-patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28830446-Skrabl-Baumgartner-2017-ADA2-patient_1",
   "subject": {
     "id": "patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Skrabl-Baumgartner-2017-ADA2-patient_1.json
+++ b/testdata/phenopackets/lirical/Skrabl-Baumgartner-2017-ADA2-patient_1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "10Y"
+        "iso8601duration": "P10Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Slavotinek-2017-TBL1XR1-seven_year_old_male.json
+++ b/testdata/phenopackets/lirical/Slavotinek-2017-TBL1XR1-seven_year_old_male.json
@@ -2,7 +2,6 @@
   "id": "PMID:28687524-Slavotinek-2017-TBL1XR1-seven_year_old_male",
   "subject": {
     "id": "seven year old male",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y"

--- a/testdata/phenopackets/lirical/Slavotinek-2017-TBL1XR1-seven_year_old_male.json
+++ b/testdata/phenopackets/lirical/Slavotinek-2017-TBL1XR1-seven_year_old_male.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "7Y"
+        "iso8601duration": "P7Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Smith-2000-MITF-family_815.json
+++ b/testdata/phenopackets/lirical/Smith-2000-MITF-family_815.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "family 815",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Smith-2000-MITF-family_815.json
+++ b/testdata/phenopackets/lirical/Smith-2000-MITF-family_815.json
@@ -2,7 +2,6 @@
   "id": "PMID:10851256-Smith-2000-MITF-family_815",
   "subject": {
     "id": "family 815",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Smith-2017-ACP4-Family_1-IV_3.json
+++ b/testdata/phenopackets/lirical/Smith-2017-ACP4-Family_1-IV_3.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "Family 1-IV:3",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "FEMALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Smith-2017-ACP4-Family_1-IV_3.json
+++ b/testdata/phenopackets/lirical/Smith-2017-ACP4-Family_1-IV_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28513613-Smith-2017-ACP4-Family_1-IV:3",
   "subject": {
     "id": "Family 1-IV:3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "FEMALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Snanoudj-2019-SERAC1-proband.json
+++ b/testdata/phenopackets/lirical/Snanoudj-2019-SERAC1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:31251474-Snanoudj-2019-SERAC1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Soumittra-2014-SLC4A11-Patient_1.json
+++ b/testdata/phenopackets/lirical/Soumittra-2014-SLC4A11-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:25007886-Soumittra-2014-SLC4A11-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P46Y"

--- a/testdata/phenopackets/lirical/Steinkellner-2015-ADAMTS10-18-year-old_woman.json
+++ b/testdata/phenopackets/lirical/Steinkellner-2015-ADAMTS10-18-year-old_woman.json
@@ -2,7 +2,6 @@
   "id": "PMID:25469541-Steinkellner-2015-ADAMTS10-18-year-old_woman",
   "subject": {
     "id": "18-year-old woman",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P18Y"

--- a/testdata/phenopackets/lirical/Steinkellner-2015-ADAMTS10-18-year-old_woman.json
+++ b/testdata/phenopackets/lirical/Steinkellner-2015-ADAMTS10-18-year-old_woman.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "18Y"
+        "iso8601duration": "P18Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Stouffs-2018-RTTN-Patient_3.json
+++ b/testdata/phenopackets/lirical/Stouffs-2018-RTTN-Patient_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:29883675-Stouffs-2018-RTTN-Patient_3",
   "subject": {
     "id": "Patient 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Stouffs-2018-RTTN-Patient_3.json
+++ b/testdata/phenopackets/lirical/Stouffs-2018-RTTN-Patient_3.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "6Y"
+        "iso8601duration": "P6Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Straniero-2018-OTUD6B-proband.json
+++ b/testdata/phenopackets/lirical/Straniero-2018-OTUD6B-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30364145-Straniero-2018-OTUD6B-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Suarez-Artiles-2018-OCRL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Suarez-Artiles-2018-OCRL-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:29300302-Suarez-Artiles-2018-OCRL-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P27Y"

--- a/testdata/phenopackets/lirical/Suter-2016-USB1-patient.json
+++ b/testdata/phenopackets/lirical/Suter-2016-USB1-patient.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "patient",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Suter-2016-USB1-patient.json
+++ b/testdata/phenopackets/lirical/Suter-2016-USB1-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:27247962-Suter-2016-USB1-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Szczałuba-2018-GNB1-proband.json
+++ b/testdata/phenopackets/lirical/Szczałuba-2018-GNB1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:29174093-Szcza\u0142uba-2018-GNB1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-1-II-1.json
+++ b/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-1-II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28318500-Ta-Shma-2017-TMEM260-1-II-1",
   "subject": {
     "id": "1-II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y"

--- a/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-2-II-4.json
+++ b/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-2-II-4.json
@@ -2,7 +2,6 @@
   "id": "PMID:28318500-Ta-Shma-2017-TMEM260-2-II-4",
   "subject": {
     "id": "2-II-4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y"

--- a/testdata/phenopackets/lirical/Tadic-2017-CAPN1-Index.json
+++ b/testdata/phenopackets/lirical/Tadic-2017-CAPN1-Index.json
@@ -2,7 +2,6 @@
   "id": "PMID:28321562-Tadic-2017-CAPN1-Index",
   "subject": {
     "id": "Index",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P39Y"

--- a/testdata/phenopackets/lirical/Taghizade_Mortezaee-2015-ITGB2-P1.json
+++ b/testdata/phenopackets/lirical/Taghizade_Mortezaee-2015-ITGB2-P1.json
@@ -2,7 +2,6 @@
   "id": "PMID:26497373-Taghizade_Mortezaee-2015-ITGB2-P1",
   "subject": {
     "id": "P1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1M"

--- a/testdata/phenopackets/lirical/Takagi-2006-WNK1-Patient.json
+++ b/testdata/phenopackets/lirical/Takagi-2006-WNK1-Patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "28"
+        "iso8601duration": "P28Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Takagi-2006-WNK1-Patient.json
+++ b/testdata/phenopackets/lirical/Takagi-2006-WNK1-Patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:16636245-Takagi-2006-WNK1-Patient",
   "subject": {
     "id": "Patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P28Y"

--- a/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:24932600-Tamhankar-2014-ROR2-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y6M"

--- a/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_2.json
+++ b/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:24932600-Tamhankar-2014-ROR2-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Tamura-2017-DHCR7-patient.json
+++ b/testdata/phenopackets/lirical/Tamura-2017-DHCR7-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:28503313-Tamura-2017-DHCR7-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2M"

--- a/testdata/phenopackets/lirical/Tan-2014-CDK5RAP2-patient.json
+++ b/testdata/phenopackets/lirical/Tan-2014-CDK5RAP2-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:23726037-Tan-2014-CDK5RAP2-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-II-4.json
+++ b/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-II-4.json
@@ -2,7 +2,6 @@
   "id": "PMID:28202457-Tesi-2017-SAMD9L-II-4",
   "subject": {
     "id": "II-4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y6M"

--- a/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-III-1.json
+++ b/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-III-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28202457-Tesi-2017-SAMD9L-III-1",
   "subject": {
     "id": "III-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Tian-2018-ACVR1-patient.json
+++ b/testdata/phenopackets/lirical/Tian-2018-ACVR1-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:29482508-Tian-2018-ACVR1-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P16Y"

--- a/testdata/phenopackets/lirical/Tiecke-2001-FBN1-B15.json
+++ b/testdata/phenopackets/lirical/Tiecke-2001-FBN1-B15.json
@@ -2,7 +2,6 @@
   "id": "PMID:11175294-Tiecke-2001-FBN1-B15",
   "subject": {
     "id": "B15",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P16Y"

--- a/testdata/phenopackets/lirical/Tran-2015-GALT-FKT118.json
+++ b/testdata/phenopackets/lirical/Tran-2015-GALT-FKT118.json
@@ -2,7 +2,6 @@
   "id": "PMID:25681079-Tran-2015-GALT-FKT118",
   "subject": {
     "id": "FKT118",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/Travaglini-2017-CAPN1-index.json
+++ b/testdata/phenopackets/lirical/Travaglini-2017-CAPN1-index.json
@@ -2,7 +2,6 @@
   "id": "PMID:28566166-Travaglini-2017-CAPN1-index",
   "subject": {
     "id": "index",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P16Y"

--- a/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS324.json
+++ b/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS324.json
@@ -2,7 +2,6 @@
   "id": "PMID:20932317-Truong-2010-RAI1-SMS324",
   "subject": {
     "id": "SMS324",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P16Y"

--- a/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS335.json
+++ b/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS335.json
@@ -2,7 +2,6 @@
   "id": "PMID:20932317-Truong-2010-RAI1-SMS335",
   "subject": {
     "id": "SMS335",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P16Y"

--- a/testdata/phenopackets/lirical/Twigg-2013-EFNB1-3269.json
+++ b/testdata/phenopackets/lirical/Twigg-2013-EFNB1-3269.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "3269",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Twigg-2013-EFNB1-3269.json
+++ b/testdata/phenopackets/lirical/Twigg-2013-EFNB1-3269.json
@@ -2,7 +2,6 @@
   "id": "PMID:23335590-Twigg-2013-EFNB1-3269",
   "subject": {
     "id": "3269",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Unger-2008-CCNQ-Case_2.json
+++ b/testdata/phenopackets/lirical/Unger-2008-CCNQ-Case_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:18297069-Unger-2008-CCNQ-Case_2",
   "subject": {
     "id": "Case 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "FEMALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Unger-2008-CCNQ-Case_2.json
+++ b/testdata/phenopackets/lirical/Unger-2008-CCNQ-Case_2.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "Case 2",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "FEMALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Uysal-2017-KCNQ1-family_III-IV-5.json
+++ b/testdata/phenopackets/lirical/Uysal-2017-KCNQ1-family_III-IV-5.json
@@ -2,7 +2,6 @@
   "id": "PMID:29037160-Uysal-2017-KCNQ1-family_III;_IV-5",
   "subject": {
     "id": "family III; IV-5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Uysal-2017-KCNQ1-family_III-IV-5.json
+++ b/testdata/phenopackets/lirical/Uysal-2017-KCNQ1-family_III-IV-5.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "5Y"
+        "iso8601duration": "P5Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_1.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:29321044-Vajro-2018-TMEM199-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_2.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:29321044-Vajro-2018-TMEM199-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_3.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:29321044-Vajro-2018-TMEM199-Patient_3",
   "subject": {
     "id": "Patient 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIII_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIII_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28065471-Van_Damme-2017-ATP6V1A-PIII:1",
   "subject": {
     "id": "PIII:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIV_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIV_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28065471-Van_Damme-2017-ATP6V1A-PIV:1",
   "subject": {
     "id": "PIV:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3M"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PV_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PV_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28065471-Van_Damme-2017-ATP6V1A-PV:1",
   "subject": {
     "id": "PV:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PV_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PV_1.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "PV:1",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "sex": "MALE",
     "taxonomy": {
       "id": "NCBITaxon:9606",

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PII_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PII_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28065471-Van_Damme-2017-ATP6V1E1-PII:1",
   "subject": {
     "id": "PII:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P10Y"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PI_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PI_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28065471-Van_Damme-2017-ATP6V1E1-PI:1",
   "subject": {
     "id": "PI:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5M"

--- a/testdata/phenopackets/lirical/Van_De_Weghe-2017-ARMC9-UW132-3.json
+++ b/testdata/phenopackets/lirical/Van_De_Weghe-2017-ARMC9-UW132-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28625504-Van_De_Weghe-2017-ARMC9-UW132-3",
   "subject": {
     "id": "UW132-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P33Y"

--- a/testdata/phenopackets/lirical/Van_Zwieten-2013-SLC4A1-c.1432-2A_T.json
+++ b/testdata/phenopackets/lirical/Van_Zwieten-2013-SLC4A1-c.1432-2A_T.json
@@ -2,7 +2,6 @@
   "id": "PMID:23255290-Van_Zwieten-2013-SLC4A1-c.1432-2A>T",
   "subject": {
     "id": "c.1432-2A>T",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Van_Zwieten-2013-SLC4A1-c.1432-2A_T.json
+++ b/testdata/phenopackets/lirical/Van_Zwieten-2013-SLC4A1-c.1432-2A_T.json
@@ -3,11 +3,6 @@
   "subject": {
     "id": "c.1432-2A>T",
     "dateOfBirth": "1970-01-01T00:00:00Z",
-    "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "n/a"
-      }
-    },
     "taxonomy": {
       "id": "NCBITaxon:9606",
       "label": "Homo sapiens"

--- a/testdata/phenopackets/lirical/Vogiatzi-2018-COL11A1-proband.json
+++ b/testdata/phenopackets/lirical/Vogiatzi-2018-COL11A1-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:28971234-Vogiatzi-2018-COL11A1-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P17Y1M"

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_1.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28148688-Volpi-2017-EXTL3-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11M"

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_2.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:28148688-Volpi-2017-EXTL3-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7M"

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_3.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28148688-Volpi-2017-EXTL3-Patient_3",
   "subject": {
     "id": "Patient 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y5M"

--- a/testdata/phenopackets/lirical/Vrtel-1996-TSC2-III-1.json
+++ b/testdata/phenopackets/lirical/Vrtel-1996-TSC2-III-1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "3M"
+        "iso8601duration": "P3M"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Vrtel-1996-TSC2-III-1.json
+++ b/testdata/phenopackets/lirical/Vrtel-1996-TSC2-III-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:8825048-Vrtel-1996-TSC2-III-1",
   "subject": {
     "id": "III-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3M"

--- a/testdata/phenopackets/lirical/Wakil-2018-RETREG1-F2_IV_1.json
+++ b/testdata/phenopackets/lirical/Wakil-2018-RETREG1-F2_IV_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30643655-Wakil-2018-RETREG1-F2:IV:1",
   "subject": {
     "id": "F2:IV:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P15Y"

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-R-III_1.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-R-III_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:27320912-Wang-2016-CAPN1-R-III:1",
   "subject": {
     "id": "R-III:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P43Y"

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-399-073.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-399-073.json
@@ -2,7 +2,6 @@
   "id": "PMID:27320912-Wang-2016-CAPN1-SAL-399-073",
   "subject": {
     "id": "SAL-399-073",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P46Y"

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-584-005.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-584-005.json
@@ -2,7 +2,6 @@
   "id": "PMID:27320912-Wang-2016-CAPN1-SAL-584-005",
   "subject": {
     "id": "SAL-584-005",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P67Y"

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-Tun66275.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-Tun66275.json
@@ -2,7 +2,6 @@
   "id": "PMID:27320912-Wang-2016-CAPN1-Tun66275",
   "subject": {
     "id": "Tun66275",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P20Y"

--- a/testdata/phenopackets/lirical/Wang-2017-OCA2-B.json
+++ b/testdata/phenopackets/lirical/Wang-2017-OCA2-B.json
@@ -2,7 +2,6 @@
   "id": "PMID:29050284-Wang-2017-OCA2-B",
   "subject": {
     "id": "B",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P8Y"

--- a/testdata/phenopackets/lirical/Wang-2018-CRX-IV_5.json
+++ b/testdata/phenopackets/lirical/Wang-2018-CRX-IV_5.json
@@ -2,7 +2,6 @@
   "id": "PMID:30095615-Wang-2018-CRX-IV:5",
   "subject": {
     "id": "IV:5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P19Y"

--- a/testdata/phenopackets/lirical/Wang-2018-CRX-IV_5.json
+++ b/testdata/phenopackets/lirical/Wang-2018-CRX-IV_5.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "19Y"
+        "iso8601duration": "P19Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Wang-2018-SLC6A8-proband.json
+++ b/testdata/phenopackets/lirical/Wang-2018-SLC6A8-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30400883-Wang-2018-SLC6A8-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y1M"

--- a/testdata/phenopackets/lirical/Warnecke-2007-SPG7-II-3.json
+++ b/testdata/phenopackets/lirical/Warnecke-2007-SPG7-II-3.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "38Y"
+        "iso8601duration": "P38Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Warnecke-2007-SPG7-II-3.json
+++ b/testdata/phenopackets/lirical/Warnecke-2007-SPG7-II-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:17646629-Warnecke-2007-SPG7-II-3",
   "subject": {
     "id": "II-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P38Y"

--- a/testdata/phenopackets/lirical/Watanabe-2016-COL5A2-patient.json
+++ b/testdata/phenopackets/lirical/Watanabe-2016-COL5A2-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:27656288-Watanabe-2016-COL5A2-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Whittock-2004-DLL3-II.6.json
+++ b/testdata/phenopackets/lirical/Whittock-2004-DLL3-II.6.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "40Y"
+        "iso8601duration": "P40Y"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Whittock-2004-DLL3-II.6.json
+++ b/testdata/phenopackets/lirical/Whittock-2004-DLL3-II.6.json
@@ -2,7 +2,6 @@
   "id": "PMID:15200511-Whittock-2004-DLL3-II.6",
   "subject": {
     "id": "II.6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P40Y"

--- a/testdata/phenopackets/lirical/Wiltshire-2013-LMNA-II3.json
+++ b/testdata/phenopackets/lirical/Wiltshire-2013-LMNA-II3.json
@@ -2,7 +2,6 @@
   "id": "PMID:23313286-Wiltshire-2013-LMNA-II3",
   "subject": {
     "id": "II3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P30Y"

--- a/testdata/phenopackets/lirical/Windpassinger-2017-CDK10-F1-II_1.json
+++ b/testdata/phenopackets/lirical/Windpassinger-2017-CDK10-F1-II_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28886341-Windpassinger-2017-CDK10-F1-II:1",
   "subject": {
     "id": "F1-II:1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Wollnik-2003-PAX3-proposita.json
+++ b/testdata/phenopackets/lirical/Wollnik-2003-PAX3-proposita.json
@@ -2,7 +2,6 @@
   "id": "PMID:12949970-Wollnik-2003-PAX3-proposita",
   "subject": {
     "id": "proposita",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y1M"

--- a/testdata/phenopackets/lirical/Woo-2013-ASS1-5.json
+++ b/testdata/phenopackets/lirical/Woo-2013-ASS1-5.json
@@ -2,7 +2,6 @@
   "id": "PMID:23099195-Woo-2013-ASS1-5",
   "subject": {
     "id": "5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3M"

--- a/testdata/phenopackets/lirical/Xie-2013-COMP-patient.json
+++ b/testdata/phenopackets/lirical/Xie-2013-COMP-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:23562786-Xie-2013-COMP-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y9M"

--- a/testdata/phenopackets/lirical/Xie-2013-COMP-patient.json
+++ b/testdata/phenopackets/lirical/Xie-2013-COMP-patient.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "2Y9M"
+        "iso8601duration": "P2Y9M"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Xiong-2019-ZIC2-proband.json
+++ b/testdata/phenopackets/lirical/Xiong-2019-ZIC2-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:30855487-Xiong-2019-ZIC2-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9M"

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-1_II-3.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-1_II-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28285769-Xu-2017-CWC27-1:II-3",
   "subject": {
     "id": "1:II-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P20Y"

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-3_II-1.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-3_II-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28285769-Xu-2017-CWC27-3:II-1",
   "subject": {
     "id": "3:II-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P9Y"

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-4_II-3.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-4_II-3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28285769-Xu-2017-CWC27-4:II-3",
   "subject": {
     "id": "4:II-3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P17Y"

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-II-4.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-II-4.json
@@ -2,7 +2,6 @@
   "id": "PMID:28285769-Xu-2017-CWC27-II-4",
   "subject": {
     "id": "II-4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P18Y"

--- a/testdata/phenopackets/lirical/Yalcin-Cakmakli-2014-FBXO7-ANK-07.json
+++ b/testdata/phenopackets/lirical/Yalcin-Cakmakli-2014-FBXO7-ANK-07.json
@@ -2,7 +2,6 @@
   "id": "PMID:25085748-Yalcin-Cakmakli-2014-FBXO7-ANK-07",
   "subject": {
     "id": "ANK-07",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P21Y"

--- a/testdata/phenopackets/lirical/Yalcin-Cakmakli-2014-FBXO7-ANK-07.json
+++ b/testdata/phenopackets/lirical/Yalcin-Cakmakli-2014-FBXO7-ANK-07.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "21Y"
+        "iso8601duration": "P21Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Yang-2016-MFN2-patient.json
+++ b/testdata/phenopackets/lirical/Yang-2016-MFN2-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:26956144-Yang-2016-MFN2-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y"

--- a/testdata/phenopackets/lirical/Yao-2019-FGFR3-VI-5.json
+++ b/testdata/phenopackets/lirical/Yao-2019-FGFR3-VI-5.json
@@ -2,7 +2,6 @@
   "id": "PMID:30681580-Yao-2019-FGFR3-VI-5",
   "subject": {
     "id": "VI-5",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P7Y8M"

--- a/testdata/phenopackets/lirical/Yoshida-1991-GLB1-KT.json
+++ b/testdata/phenopackets/lirical/Yoshida-1991-GLB1-KT.json
@@ -2,7 +2,6 @@
   "id": "PMID:1907800-Yoshida-1991-GLB1-KT",
   "subject": {
     "id": "KT",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P13Y"

--- a/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_1.json
+++ b/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:30103036-Zapata-Aldana-2019-TBCK-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P5Y"

--- a/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:30103036-Zapata-Aldana-2019-TBCK-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Zemojtel-2014-KMT2A-P1.json
+++ b/testdata/phenopackets/lirical/Zemojtel-2014-KMT2A-P1.json
@@ -2,7 +2,6 @@
   "id": "PMID:25186178-Zemojtel-2014-KMT2A-P1",
   "subject": {
     "id": "P1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P3Y"

--- a/testdata/phenopackets/lirical/Zenker-2007-KRAS-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zenker-2007-KRAS-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:17056636-Zenker-2007-KRAS-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P16Y"

--- a/testdata/phenopackets/lirical/Zerkaoui-2015-GALC-child.json
+++ b/testdata/phenopackets/lirical/Zerkaoui-2015-GALC-child.json
@@ -2,7 +2,6 @@
   "id": "PMID:26567009-Zerkaoui-2015-GALC-child",
   "subject": {
     "id": "child",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P11M"

--- a/testdata/phenopackets/lirical/Zhang-2009-EDA-proband.json
+++ b/testdata/phenopackets/lirical/Zhang-2009-EDA-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:18702659-Zhang-2009-EDA-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P23Y"

--- a/testdata/phenopackets/lirical/Zhang-2011-TYRP1-patient_2.json
+++ b/testdata/phenopackets/lirical/Zhang-2011-TYRP1-patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:21739261-Zhang-2011-TYRP1-patient_2",
   "subject": {
     "id": "patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y9M"

--- a/testdata/phenopackets/lirical/Zhang-2016-RPS19-patient.json
+++ b/testdata/phenopackets/lirical/Zhang-2016-RPS19-patient.json
@@ -2,7 +2,6 @@
   "id": "PMID:27732904-Zhang-2016-RPS19-patient",
   "subject": {
     "id": "patient",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2M"

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28851325-Zhang-2017-FOXG1-Patient_1",
   "subject": {
     "id": "Patient 1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y8M"

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_2.json
@@ -2,7 +2,6 @@
   "id": "PMID:28851325-Zhang-2017-FOXG1-Patient_2",
   "subject": {
     "id": "Patient 2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P4Y6M"

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_3.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_3.json
@@ -2,7 +2,6 @@
   "id": "PMID:28851325-Zhang-2017-FOXG1-Patient_3",
   "subject": {
     "id": "Patient 3",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P1Y"

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_4.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:28851325-Zhang-2017-FOXG1-Patient_4",
   "subject": {
     "id": "Patient 4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P2Y"

--- a/testdata/phenopackets/lirical/Zhao-2008-KRT9-III_4.json
+++ b/testdata/phenopackets/lirical/Zhao-2008-KRT9-III_4.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "32Y"
+        "iso8601duration": "P32Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Zhao-2008-KRT9-III_4.json
+++ b/testdata/phenopackets/lirical/Zhao-2008-KRT9-III_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:18477167-Zhao-2008-KRT9-III:4",
   "subject": {
     "id": "III:4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P32Y"

--- a/testdata/phenopackets/lirical/Zheng-2018-PNPLA6-II.2.json
+++ b/testdata/phenopackets/lirical/Zheng-2018-PNPLA6-II.2.json
@@ -2,7 +2,6 @@
   "id": "PMID:29749493-Zheng-2018-PNPLA6-II.2",
   "subject": {
     "id": "II.2",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P50Y"

--- a/testdata/phenopackets/lirical/Zheng-2018-PNPLA6-II.2.json
+++ b/testdata/phenopackets/lirical/Zheng-2018-PNPLA6-II.2.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "50Y"
+        "iso8601duration": "P50Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Zhong-2016-PRPF3-020001-II_4.json
+++ b/testdata/phenopackets/lirical/Zhong-2016-PRPF3-020001-II_4.json
@@ -4,8 +4,9 @@
     "id": "020001-II:4",
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "adult"
+      "ontologyClass": {
+        "id": "HP:0003581",
+        "label": "Adult onset"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/Zhong-2016-PRPF3-020001-II_4.json
+++ b/testdata/phenopackets/lirical/Zhong-2016-PRPF3-020001-II_4.json
@@ -2,7 +2,6 @@
   "id": "PMID:27886254-Zhong-2016-PRPF3-020001-II:4",
   "subject": {
     "id": "020001-II:4",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "ontologyClass": {
         "id": "HP:0003581",

--- a/testdata/phenopackets/lirical/Zhou-2018-FBN2-IV_7.json
+++ b/testdata/phenopackets/lirical/Zhou-2018-FBN2-IV_7.json
@@ -2,7 +2,6 @@
   "id": "PMID:30147916-Zhou-2018-FBN2-IV:7",
   "subject": {
     "id": "IV:7",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "ontologyClass": {
         "id": "HP:0003581",

--- a/testdata/phenopackets/lirical/Zhou-2018-FBN2-IV_7.json
+++ b/testdata/phenopackets/lirical/Zhou-2018-FBN2-IV_7.json
@@ -4,8 +4,9 @@
     "id": "IV:7",
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
-      "age": {
-        "iso8601duration": "adult"
+      "ontologyClass": {
+        "id": "HP:0003581",
+        "label": "Adult onset"
       }
     },
     "sex": "FEMALE",

--- a/testdata/phenopackets/lirical/Zhu-2017-AIRE-V-1.json
+++ b/testdata/phenopackets/lirical/Zhu-2017-AIRE-V-1.json
@@ -2,7 +2,6 @@
   "id": "PMID:28540407-Zhu-2017-AIRE-V-1",
   "subject": {
     "id": "V-1",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P19Y"

--- a/testdata/phenopackets/lirical/Zhu-2017-AIRE-V-1.json
+++ b/testdata/phenopackets/lirical/Zhu-2017-AIRE-V-1.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
-        "iso8601duration": "19Y"
+        "iso8601duration": "P19Y"
       }
     },
     "sex": "MALE",

--- a/testdata/phenopackets/lirical/de_Vries-2012-FANCC-proband.json
+++ b/testdata/phenopackets/lirical/de_Vries-2012-FANCC-proband.json
@@ -2,7 +2,6 @@
   "id": "PMID:22701786-de_Vries-2012-FANCC-proband",
   "subject": {
     "id": "proband",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P6Y"

--- a/testdata/phenopackets/lirical/van_Oorschot-2019-GFI1B-II_6.json
+++ b/testdata/phenopackets/lirical/van_Oorschot-2019-GFI1B-II_6.json
@@ -2,7 +2,6 @@
   "id": "PMID:30655368-van_Oorschot-2019-GFI1B-II:6",
   "subject": {
     "id": "II:6",
-    "dateOfBirth": "1970-01-01T00:00:00Z",
     "timeAtLastEncounter": {
       "age": {
         "iso8601duration": "P42Y"


### PR DESCRIPTION
Correctly formatting the `time_at_last_encounter` field in the phenopacket `subject`. This included correctly formatting to iso8601duration, removing n/a values and adding `ontologyClass` fields where necessary to describe the age.