### PR TITLE
adding variation descriptor id field to interpretations

### DIFF
--- a/testdata/phenopackets/lirical/Abdul_Wahab-2016-GCDH-Patient_5.json
+++ b/testdata/phenopackets/lirical/Abdul_Wahab-2016-GCDH-Patient_5.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:553722",
                 "geneContext": {
                   "valueId": "ENSG00000105607",
                   "symbol": "GCDH",
@@ -198,6 +199,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ajmal-2013-BBS1-IV-5_family_A.json
+++ b/testdata/phenopackets/lirical/Ajmal-2013-BBS1-IV-5_family_A.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1324292",
                 "geneContext": {
                   "valueId": "ENSG00000174483",
                   "symbol": "BBS1",
@@ -233,6 +234,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Al-Dosari-2010-TFAP2A-10-year-old_girl.json
+++ b/testdata/phenopackets/lirical/Al-Dosari-2010-TFAP2A-10-year-old_girl.json
@@ -267,6 +267,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "6-10404742-T-A",
                 "geneContext": {
                   "valueId": "ENSG00000137203",
                   "symbol": "TFAP2A",

--- a/testdata/phenopackets/lirical/Al-Hashmi-2018-SNX14-IV-1.json
+++ b/testdata/phenopackets/lirical/Al-Hashmi-2018-SNX14-IV-1.json
@@ -360,6 +360,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "6-86224293-TTCTC-T",
                 "geneContext": {
                   "valueId": "ENSG00000135317",
                   "symbol": "SNX14",

--- a/testdata/phenopackets/lirical/Al-Qattan-2018-SCARF2-proband.json
+++ b/testdata/phenopackets/lirical/Al-Qattan-2018-SCARF2-proband.json
@@ -338,6 +338,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:31046",
                 "geneContext": {
                   "valueId": "ENSG00000244486",
                   "symbol": "SCARF2",
@@ -415,6 +416,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Al-Semari-2013-FGD1-II-1.json
+++ b/testdata/phenopackets/lirical/Al-Semari-2013-FGD1-II-1.json
@@ -212,6 +212,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-54492285-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000102302",
                   "symbol": "FGD1",

--- a/testdata/phenopackets/lirical/AlSubhi-2016-ALG9-IV_5.json
+++ b/testdata/phenopackets/lirical/AlSubhi-2016-ALG9-IV_5.json
@@ -319,6 +319,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:3748",
                 "geneContext": {
                   "valueId": "ENSG00000086848",
                   "symbol": "ALG9",
@@ -396,6 +397,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Alazami-2016-ATP6V1E1-Family_5_-_IV_2.json
+++ b/testdata/phenopackets/lirical/Alazami-2016-ATP6V1E1-Family_5_-_IV_2.json
@@ -99,6 +99,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417760",
                 "geneContext": {
                   "valueId": "ENSG00000131100",
                   "symbol": "ATP6V1E1",
@@ -176,6 +177,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ali-2017-MYH3-proband.json
+++ b/testdata/phenopackets/lirical/Ali-2017-MYH3-proband.json
@@ -265,6 +265,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:14138",
                 "geneContext": {
                   "valueId": "ENSG00000109063",
                   "symbol": "MYH3",
@@ -341,6 +342,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Alzahrani-2018-EPG5-18-month_son.json
+++ b/testdata/phenopackets/lirical/Alzahrani-2018-EPG5-18-month_son.json
@@ -301,6 +301,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:217320",
                 "geneContext": {
                   "valueId": "ENSG00000152223",
                   "symbol": "EPG5",
@@ -377,6 +378,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Anazi-2017-NKX6-2-Patient_36-16DG1123.json
+++ b/testdata/phenopackets/lirical/Anazi-2017-NKX6-2-Patient_36-16DG1123.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "10-134599256-CG-C",
                 "geneContext": {
                   "valueId": "ENSG00000148826",
                   "symbol": "NKX6-2",

--- a/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_1.json
+++ b/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_1.json
@@ -175,6 +175,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417754",
                 "geneContext": {
                   "valueId": "ENSG00000104880",
                   "symbol": "ARHGEF18",
@@ -204,6 +205,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417755",
                 "geneContext": {
                   "valueId": "ENSG00000104880",
                   "symbol": "ARHGEF18",
@@ -281,6 +283,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_2.json
+++ b/testdata/phenopackets/lirical/Arno-2017-ARHGEF18-Individual_2.json
@@ -175,6 +175,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-7532386-GCGAGCGGCTGGAGCAGGAGCGGGC-G",
                 "geneContext": {
                   "valueId": "ENSG00000104880",
                   "symbol": "ARHGEF18",
@@ -204,6 +205,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417757",
                 "geneContext": {
                   "valueId": "ENSG00000104880",
                   "symbol": "ARHGEF18",
@@ -281,6 +283,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Arora-2019-COG8-proband.json
+++ b/testdata/phenopackets/lirical/Arora-2019-COG8-proband.json
@@ -521,6 +521,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:932935",
                 "geneContext": {
                   "valueId": "ENSG00000213380",
                   "symbol": "COG8",
@@ -598,6 +599,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Asgharzade-2018-GIPC3-Ahv-14_23.json
+++ b/testdata/phenopackets/lirical/Asgharzade-2018-GIPC3-Ahv-14_23.json
@@ -49,6 +49,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-3586872-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000179855",
                   "symbol": "GIPC3",

--- a/testdata/phenopackets/lirical/Avgeris-2017-TSC1-patient_6.json
+++ b/testdata/phenopackets/lirical/Avgeris-2017-TSC1-patient_6.json
@@ -158,6 +158,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-135787681-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000165699",
                   "symbol": "TSC1",

--- a/testdata/phenopackets/lirical/Avrahami-2008-ST14-patient.json
+++ b/testdata/phenopackets/lirical/Avrahami-2008-ST14-patient.json
@@ -158,6 +158,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:4039",
                 "geneContext": {
                   "valueId": "ENSG00000149418",
                   "symbol": "ST14",
@@ -235,6 +236,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Badin-2017-RUNX1-Pedigree_I,_V_2.json
+++ b/testdata/phenopackets/lirical/Badin-2017-RUNX1-Pedigree_I,_V_2.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:14465",
                 "geneContext": {
                   "valueId": "ENSG00000159216",
                   "symbol": "RUNX1",
@@ -161,6 +162,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Baldi-2018-NKX6-2-F6,II-2.json
+++ b/testdata/phenopackets/lirical/Baldi-2018-NKX6-2-F6,II-2.json
@@ -464,6 +464,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "10-134598646-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000148826",
                   "symbol": "NKX6-2",

--- a/testdata/phenopackets/lirical/Bao-2019-COL6A1-II.1.json
+++ b/testdata/phenopackets/lirical/Bao-2019-COL6A1-II.1.json
@@ -417,6 +417,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "21-47409540-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000142156",
                   "symbol": "COL6A1",

--- a/testdata/phenopackets/lirical/Bastaki-2017-CTCF-proband.json
+++ b/testdata/phenopackets/lirical/Bastaki-2017-CTCF-proband.json
@@ -535,6 +535,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "16-67645346-CAAAG-C",
                 "geneContext": {
                   "valueId": "ENSG00000102974",
                   "symbol": "CTCF",

--- a/testdata/phenopackets/lirical/Bee-2015-BBS2-II_2.json
+++ b/testdata/phenopackets/lirical/Bee-2015-BBS2-II_2.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:284737",
                 "geneContext": {
                   "valueId": "ENSG00000125124",
                   "symbol": "BBS2",
@@ -222,6 +223,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "16-56519631-A-T",
                 "geneContext": {
                   "valueId": "ENSG00000125124",
                   "symbol": "BBS2",

--- a/testdata/phenopackets/lirical/Ben_Ammar-2013-MUSK-patient.json
+++ b/testdata/phenopackets/lirical/Ben_Ammar-2013-MUSK-patient.json
@@ -341,6 +341,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-113563161-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000030304",
                   "symbol": "MUSK",

--- a/testdata/phenopackets/lirical/Bhatia-2018-PRPF31-IV_3.json
+++ b/testdata/phenopackets/lirical/Bhatia-2018-PRPF31-IV_3.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-54629943-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000105618",
                   "symbol": "PRPF31",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-1.json
@@ -393,6 +393,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:183338",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -470,6 +471,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-1-2.json
@@ -167,6 +167,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:183338",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -244,6 +245,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-2-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-2-1.json
@@ -248,6 +248,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225235",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -277,6 +278,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225238",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -354,6 +356,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-3-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-3-1.json
@@ -303,6 +303,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-107152924-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-1.json
@@ -214,6 +214,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225239",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -243,6 +244,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-107168420-CTTCA-C",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-4-2.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225239",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -132,6 +133,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-107168420-CTTCA-c",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-5-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-5-1.json
@@ -355,6 +355,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225235",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -432,6 +433,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-1.json
@@ -266,6 +266,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-107156504-GT-G",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-2.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-6-2.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-107156504-GT-G",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",

--- a/testdata/phenopackets/lirical/Bhoj-2016-TBCK-8-1.json
+++ b/testdata/phenopackets/lirical/Bhoj-2016-TBCK-8-1.json
@@ -284,6 +284,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225235",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -361,6 +362,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Bicknell-2007-FLNB-19.json
+++ b/testdata/phenopackets/lirical/Bicknell-2007-FLNB-19.json
@@ -247,6 +247,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:21292",
                 "geneContext": {
                   "valueId": "ENSG00000136068",
                   "symbol": "FLNB",
@@ -324,6 +325,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Blanco-Kelly-2017-CDH3-Patient.json
+++ b/testdata/phenopackets/lirical/Blanco-Kelly-2017-CDH3-Patient.json
@@ -286,6 +286,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2137841",
                 "geneContext": {
                   "valueId": "ENSG00000062038",
                   "symbol": "CDH3",
@@ -315,6 +316,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "16-68713838-AG-A",
                 "geneContext": {
                   "valueId": "ENSG00000062038",
                   "symbol": "CDH3",

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB049.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB049.json
@@ -162,6 +162,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "7-92760808-T-C",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB081.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB081.json
@@ -160,6 +160,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "7-92760637-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB085.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB085.json
@@ -249,6 +249,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1394671",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",
@@ -326,6 +327,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB612.json
+++ b/testdata/phenopackets/lirical/Bluteau-2018-SAMD9L-UB612.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "7-92762329-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",

--- a/testdata/phenopackets/lirical/Boddrich-1997-NF1-0548.json
+++ b/testdata/phenopackets/lirical/Boddrich-1997-NF1-0548.json
@@ -167,6 +167,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-29665753-C-CTT",
                 "geneContext": {
                   "valueId": "ENSG00000196712",
                   "symbol": "NF1",

--- a/testdata/phenopackets/lirical/Bordbar-2017-PRF1-8-year-old_boy.json
+++ b/testdata/phenopackets/lirical/Bordbar-2017-PRF1-8-year-old_boy.json
@@ -140,6 +140,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:397653",
                 "geneContext": {
                   "valueId": "ENSG00000180644",
                   "symbol": "PRF1",
@@ -217,6 +218,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Bulut-2017-SETBP1-proposita.json
+++ b/testdata/phenopackets/lirical/Bulut-2017-SETBP1-proposita.json
@@ -500,6 +500,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1035",
                 "geneContext": {
                   "valueId": "ENSG00000152217",
                   "symbol": "SETBP1",
@@ -577,6 +578,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Calado-2005-UMOD-proband.json
+++ b/testdata/phenopackets/lirical/Calado-2005-UMOD-proband.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "16-20359598-T-G",
                 "geneContext": {
                   "valueId": "ENSG00000169344",
                   "symbol": "UMOD",

--- a/testdata/phenopackets/lirical/Canosa-2018-SOD1-patient.json
+++ b/testdata/phenopackets/lirical/Canosa-2018-SOD1-patient.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "21-33039650-C-CT",
                 "geneContext": {
                   "valueId": "ENSG00000142168",
                   "symbol": "SOD1",

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_1.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-48808561-T-A",
                 "geneContext": {
                   "valueId": "ENSG00000166147",
                   "symbol": "FBN1",

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_2.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_2.json
@@ -229,6 +229,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-48719763-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000166147",
                   "symbol": "FBN1",

--- a/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_3.json
+++ b/testdata/phenopackets/lirical/Cao-2018-FBN1-Patient_3.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:16429",
                 "geneContext": {
                   "valueId": "ENSG00000166147",
                   "symbol": "FBN1",
@@ -180,6 +181,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Cao-2018-TGFBR2-Patient_4.json
+++ b/testdata/phenopackets/lirical/Cao-2018-TGFBR2-Patient_4.json
@@ -301,6 +301,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "3-30713759-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000163513",
                   "symbol": "TGFBR2",

--- a/testdata/phenopackets/lirical/Caputo-2014-SMAD4-patient.json
+++ b/testdata/phenopackets/lirical/Caputo-2014-SMAD4-patient.json
@@ -358,6 +358,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:88673",
                 "geneContext": {
                   "valueId": "ENSG00000141646",
                   "symbol": "SMAD4",
@@ -434,6 +435,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Caro-Contreras-2019-ERF-proband.json
+++ b/testdata/phenopackets/lirical/Caro-Contreras-2019-ERF-proband.json
@@ -338,6 +338,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:267443",
                 "geneContext": {
                   "valueId": "ENSG00000105722",
                   "symbol": "ERF",
@@ -415,6 +416,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Carre-2014-FOXE1-patient.json
+++ b/testdata/phenopackets/lirical/Carre-2014-FOXE1-patient.json
@@ -156,6 +156,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-100616413-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000178919",
                   "symbol": "FOXE1",

--- a/testdata/phenopackets/lirical/Chabas-2005-GBA-_boy_weighing_1690_g.json
+++ b/testdata/phenopackets/lirical/Chabas-2005-GBA-_boy_weighing_1690_g.json
@@ -150,6 +150,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-155204848-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000177628",
                   "symbol": "GBA",

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC6-Patient_B.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC6-Patient_B.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:190158",
                 "geneContext": {
                   "valueId": "ENSG00000225830",
                   "symbol": "ERCC6",
@@ -198,6 +199,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_A.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_A.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-60186791-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000049167",
                   "symbol": "ERCC8",

--- a/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_C.json
+++ b/testdata/phenopackets/lirical/Chebly-2018-ERCC8-Patient_C.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-60194102-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000049167",
                   "symbol": "ERCC8",

--- a/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-III-1.json
+++ b/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-III-1.json
@@ -375,6 +375,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:430622",
                 "geneContext": {
                   "valueId": "ENSG00000148826",
                   "symbol": "NKX6-2",
@@ -452,6 +453,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-IV-6.json
+++ b/testdata/phenopackets/lirical/Chelban-2017-NKX6-2-IV-6.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:430623",
                 "geneContext": {
                   "valueId": "ENSG00000148826",
                   "symbol": "NKX6-2",
@@ -180,6 +181,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chen-2014-RUNX2-III_3.json
+++ b/testdata/phenopackets/lirical/Chen-2014-RUNX2-III_3.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1489954",
                 "geneContext": {
                   "valueId": "ENSG00000124813",
                   "symbol": "RUNX2",
@@ -288,6 +289,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chen-2016-SAMD9L-II-4.json
+++ b/testdata/phenopackets/lirical/Chen-2016-SAMD9L-II-4.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:242373",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",
@@ -216,6 +217,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chen-2016-SAMD9L-IV-1.json
+++ b/testdata/phenopackets/lirical/Chen-2016-SAMD9L-IV-1.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:242372",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",
@@ -198,6 +199,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Cheng-2018-FBN1-Family_1,_Patient_1.json
+++ b/testdata/phenopackets/lirical/Cheng-2018-FBN1-Family_1,_Patient_1.json
@@ -285,6 +285,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-48752455-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000166147",
                   "symbol": "FBN1",

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-A-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-A-II-1.json
@@ -535,6 +535,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225235",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -612,6 +613,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-4.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-4.json
@@ -463,6 +463,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225236",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -540,6 +541,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-6.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-B-IV-6.json
@@ -319,6 +319,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225236",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -396,6 +397,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-C-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-C-II-1.json
@@ -504,6 +504,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225237",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -581,6 +582,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Chong-2016-TBCK-D-II-1.json
+++ b/testdata/phenopackets/lirical/Chong-2016-TBCK-D-II-1.json
@@ -519,6 +519,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225235",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -596,6 +597,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Claverie-Martin-2019-LMX1B-index.json
+++ b/testdata/phenopackets/lirical/Claverie-Martin-2019-LMX1B-index.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:587694",
                 "geneContext": {
                   "valueId": "ENSG00000136944",
                   "symbol": "LMX1B",
@@ -216,6 +217,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Cuchanski-2018-KIF5A-proband.json
+++ b/testdata/phenopackets/lirical/Cuchanski-2018-KIF5A-proband.json
@@ -250,6 +250,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:424651",
                 "geneContext": {
                   "valueId": "ENSG00000155980",
                   "symbol": "KIF5A",
@@ -327,6 +328,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Curtis-1978-FLCN-253.json
+++ b/testdata/phenopackets/lirical/Curtis-1978-FLCN-253.json
@@ -66,6 +66,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:96481",
                 "geneContext": {
                   "valueId": "ENSG00000154803",
                   "symbol": "FLCN",
@@ -142,6 +143,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Dastsooz-2017-PANK2-Family_I_patient_I.json
+++ b/testdata/phenopackets/lirical/Dastsooz-2017-PANK2-Family_I_patient_I.json
@@ -160,6 +160,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "20-3897586-GATGA-G",
                 "geneContext": {
                   "valueId": "ENSG00000125779",
                   "symbol": "PANK2",

--- a/testdata/phenopackets/lirical/Dastsooz-2017-PLA2G6-family_II_patient_II.json
+++ b/testdata/phenopackets/lirical/Dastsooz-2017-PLA2G6-family_II_patient_II.json
@@ -177,6 +177,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:429031",
                 "geneContext": {
                   "valueId": "ENSG00000184381",
                   "symbol": "PLA2G6",
@@ -254,6 +255,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Dauber-2014-SLC35C1-Proband_1.json
+++ b/testdata/phenopackets/lirical/Dauber-2014-SLC35C1-Proband_1.json
@@ -398,6 +398,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:95906",
                 "geneContext": {
                   "valueId": "ENSG00000181830",
                   "symbol": "SLC35C1",
@@ -427,6 +428,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-45827852-CCTT-C",
                 "geneContext": {
                   "valueId": "ENSG00000181830",
                   "symbol": "SLC35C1",

--- a/testdata/phenopackets/lirical/Delahaye-2007-CHD7-B_III-3.json
+++ b/testdata/phenopackets/lirical/Delahaye-2007-CHD7-B_III-3.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:195321",
                 "geneContext": {
                   "valueId": "ENSG00000171316",
                   "symbol": "CHD7",
@@ -360,6 +361,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Delahaye-2007-CHD7-Patient_A_III-2.json
+++ b/testdata/phenopackets/lirical/Delahaye-2007-CHD7-Patient_A_III-2.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "8-61728948-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000171316",
                   "symbol": "CHD7",

--- a/testdata/phenopackets/lirical/Devalla-2016-TECRL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Devalla-2016-TECRL-Patient_1.json
@@ -176,6 +176,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:372284",
                 "geneContext": {
                   "valueId": "ENSG00000205678",
                   "symbol": "TECRL",
@@ -252,6 +253,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Di_Nottia-2017-PARK7-proband.json
+++ b/testdata/phenopackets/lirical/Di_Nottia-2017-PARK7-proband.json
@@ -267,6 +267,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8045005-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000116288",
                   "symbol": "PARK7",

--- a/testdata/phenopackets/lirical/Dias-2013-TRPS1-girl.json
+++ b/testdata/phenopackets/lirical/Dias-2013-TRPS1-girl.json
@@ -104,6 +104,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "8-116616998-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000104447",
                   "symbol": "TRPS1",
@@ -133,6 +134,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:574440",
                 "geneContext": {
                   "valueId": "ENSG00000104447",
                   "symbol": "TRPS1",
@@ -210,6 +212,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Dikoglu-2015-LONP1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Dikoglu-2015-LONP1-Patient_1.json
@@ -176,6 +176,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1065599",
                 "geneContext": {
                   "valueId": "ENSG00000196365",
                   "symbol": "LONP1",
@@ -205,6 +206,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-5694418-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000196365",
                   "symbol": "LONP1",

--- a/testdata/phenopackets/lirical/Dinani-2017-AAGAB-family_1_proband.json
+++ b/testdata/phenopackets/lirical/Dinani-2017-AAGAB-family_1_proband.json
@@ -106,6 +106,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1069032",
                 "geneContext": {
                   "valueId": "ENSG00000103591",
                   "symbol": "AAGAB",
@@ -182,6 +183,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Djamshidian-2009-VCP-II-3.json
+++ b/testdata/phenopackets/lirical/Djamshidian-2009-VCP-II-3.json
@@ -231,6 +231,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-35065355-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000165280",
                   "symbol": "VCP",

--- a/testdata/phenopackets/lirical/Dobbs-2008-FLNB-patient.json
+++ b/testdata/phenopackets/lirical/Dobbs-2008-FLNB-patient.json
@@ -249,6 +249,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "3-58062988-G-C",
                 "geneContext": {
                   "valueId": "ENSG00000136068",
                   "symbol": "FLNB",

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_1_II-1.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_1_II-1.json
@@ -265,6 +265,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:627618",
                 "geneContext": {
                   "valueId": "ENSG00000148826",
                   "symbol": "NKX6-2",
@@ -342,6 +343,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_3_II-3.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_3_II-3.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:627615",
                 "geneContext": {
                   "valueId": "ENSG00000148826",
                   "symbol": "NKX6-2",
@@ -270,6 +271,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_4_II-1.json
+++ b/testdata/phenopackets/lirical/Dorboz-2017-NKX6-2-Patient_4_II-1.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:627616",
                 "geneContext": {
                   "valueId": "ENSG00000148826",
                   "symbol": "NKX6-2",
@@ -240,6 +241,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:627617",
                 "geneContext": {
                   "valueId": "ENSG00000148826",
                   "symbol": "NKX6-2",
@@ -317,6 +319,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Dougherty-2016-NPC1-The_proband.json
+++ b/testdata/phenopackets/lirical/Dougherty-2016-NPC1-The_proband.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "18-21115443-T-C",
                 "geneContext": {
                   "valueId": "ENSG00000141458",
                   "symbol": "NPC1",
@@ -312,6 +313,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2971",
                 "geneContext": {
                   "valueId": "ENSG00000141458",
                   "symbol": "NPC1",
@@ -388,6 +390,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Du-2018-TINF2-proband.json
+++ b/testdata/phenopackets/lirical/Du-2018-TINF2-proband.json
@@ -251,6 +251,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-24709842-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000092330",
                   "symbol": "TINF2",

--- a/testdata/phenopackets/lirical/Ekvall-2015-NRAS-case_1.json
+++ b/testdata/phenopackets/lirical/Ekvall-2015-NRAS-case_1.json
@@ -301,6 +301,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-115256532-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000213281",
                   "symbol": "NRAS",

--- a/testdata/phenopackets/lirical/El-Harith-2009-MPL-FT2_VI_3.json
+++ b/testdata/phenopackets/lirical/El-Harith-2009-MPL-FT2_VI_3.json
@@ -49,6 +49,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:265248",
                 "geneContext": {
                   "valueId": "ENSG00000117400",
                   "symbol": "MPL",
@@ -126,6 +127,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/El-Jaick-2007-TGIF1-male_proband.json
+++ b/testdata/phenopackets/lirical/El-Jaick-2007-TGIF1-male_proband.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "18-3456468-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000177426",
                   "symbol": "TGIF1",

--- a/testdata/phenopackets/lirical/Elsaadany-2016-WWOX-Patient_1.json
+++ b/testdata/phenopackets/lirical/Elsaadany-2016-WWOX-Patient_1.json
@@ -357,6 +357,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:372547",
                 "geneContext": {
                   "valueId": "ENSG00000186153",
                   "symbol": "WWOX",
@@ -434,6 +435,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Elsaid-2017-NT5C2-II.3.json
+++ b/testdata/phenopackets/lirical/Elsaid-2017-NT5C2-II.3.json
@@ -266,6 +266,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "10-104852895-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000076685",
                   "symbol": "NT5C2",

--- a/testdata/phenopackets/lirical/Falik_Zaccai-2014-INSR-ISR1.json
+++ b/testdata/phenopackets/lirical/Falik_Zaccai-2014-INSR-ISR1.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-7184444-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000171105",
                   "symbol": "INSR",

--- a/testdata/phenopackets/lirical/Falik_Zaccai-2017-PLAA-A-VI3.json
+++ b/testdata/phenopackets/lirical/Falik_Zaccai-2017-PLAA-A-VI3.json
@@ -339,6 +339,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:427940",
                 "geneContext": {
                   "valueId": "ENSG00000137055",
                   "symbol": "PLAA",
@@ -416,6 +417,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Fiscaletti-2018-SP7-II_5.json
+++ b/testdata/phenopackets/lirical/Fiscaletti-2018-SP7-II_5.json
@@ -320,6 +320,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:560212",
                 "geneContext": {
                   "valueId": "ENSG00000170374",
                   "symbol": "SP7",
@@ -397,6 +398,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_1.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_1.json
@@ -1678,6 +1678,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8419976-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_10.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_10.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:996676",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -216,6 +217,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_2.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_2.json
@@ -1609,6 +1609,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8418276-T-TGGTGGA",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_3.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_3.json
@@ -1814,6 +1814,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:236217",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -1891,6 +1892,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_4.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_4.json
@@ -1661,6 +1661,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:224822",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -1738,6 +1739,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_5.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_5.json
@@ -1750,6 +1750,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:224822",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -1827,6 +1828,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_6.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_6.json
@@ -1493,6 +1493,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8420444-AG-A",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_7.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_7.json
@@ -1687,6 +1687,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8425908-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_8.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_8.json
@@ -1778,6 +1778,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8555122-CT-C",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_9.json
+++ b/testdata/phenopackets/lirical/Fregeau-2016-RERE-Subject_9.json
@@ -1611,6 +1611,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8421296-C-CCCTGGAGGAGCTGAGGAGGGAG",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Fusco-2017-PMP22-Proband.json
+++ b/testdata/phenopackets/lirical/Fusco-2017-PMP22-Proband.json
@@ -160,6 +160,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-15162409-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000109099",
                   "symbol": "PMP22",

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_A-V_2.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_A-V_2.json
@@ -175,6 +175,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225765",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -252,6 +253,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_B-IV_1.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_B-IV_1.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225766",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -234,6 +235,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_C-IV_13.json
+++ b/testdata/phenopackets/lirical/Gan-Or-2016-CAPN1-Family_C-IV_13.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-64951012-TC-T",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -114,6 +115,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225768",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -191,6 +193,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_A_II1.json
+++ b/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_A_II1.json
@@ -373,6 +373,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:829868",
                 "geneContext": {
                   "valueId": "ENSG00000124813",
                   "symbol": "RUNX2",
@@ -459,6 +460,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0",

--- a/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_B_II1.json
+++ b/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_B_II1.json
@@ -373,6 +373,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "6-45399750-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000124813",
                   "symbol": "RUNX2",

--- a/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_D_II1.json
+++ b/testdata/phenopackets/lirical/Gao-2019-RUNX2-Family_D_II1.json
@@ -373,6 +373,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "6-45459710-AGTTT-A",
                 "geneContext": {
                   "valueId": "ENSG00000124813",
                   "symbol": "RUNX2",

--- a/testdata/phenopackets/lirical/Ge-2019-TJP2-proband.json
+++ b/testdata/phenopackets/lirical/Ge-2019-TJP2-proband.json
@@ -342,6 +342,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:987324",
                 "geneContext": {
                   "valueId": "ENSG00000119139",
                   "symbol": "TJP2",
@@ -371,6 +372,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-71855042-AC-A",
                 "geneContext": {
                   "valueId": "ENSG00000119139",
                   "symbol": "TJP2",

--- a/testdata/phenopackets/lirical/Gebbia-1997-ZIC3-III-1.json
+++ b/testdata/phenopackets/lirical/Gebbia-1997-ZIC3-III-1.json
@@ -236,6 +236,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:11433",
                 "geneContext": {
                   "valueId": "ENSG00000156925",
                   "symbol": "ZIC3",
@@ -312,6 +313,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Geiger-2017-TUBB2B-proband.json
+++ b/testdata/phenopackets/lirical/Geiger-2017-TUBB2B-proband.json
@@ -358,6 +358,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:420140",
                 "geneContext": {
                   "valueId": "ENSG00000137285",
                   "symbol": "TUBB2B",
@@ -435,6 +436,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Gerding-2009-LITAF-Proband.json
+++ b/testdata/phenopackets/lirical/Gerding-2009-LITAF-Proband.json
@@ -287,6 +287,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "16-11643549-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000189067",
                   "symbol": "LITAF",

--- a/testdata/phenopackets/lirical/Giau-2018-PSEN2-proband.json
+++ b/testdata/phenopackets/lirical/Giau-2018-PSEN2-proband.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1100640",
                 "geneContext": {
                   "valueId": "ENSG00000143801",
                   "symbol": "PSEN2",
@@ -162,6 +163,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Gong-2015-CBS-III_3.json
+++ b/testdata/phenopackets/lirical/Gong-2015-CBS-III_3.json
@@ -247,6 +247,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "21-44486397-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000160200",
                   "symbol": "CBS",
@@ -276,6 +277,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1481680",
                 "geneContext": {
                   "valueId": "ENSG00000160200",
                   "symbol": "CBS",
@@ -352,6 +354,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Gonzalez-Perez-2009-CAV3-I1.json
+++ b/testdata/phenopackets/lirical/Gonzalez-Perez-2009-CAV3-I1.json
@@ -326,6 +326,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "3-8775642-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000182533",
                   "symbol": "CAV3",

--- a/testdata/phenopackets/lirical/Gowda-2017-MCOLN1-6_year_old_boy.json
+++ b/testdata/phenopackets/lirical/Gowda-2017-MCOLN1-6_year_old_boy.json
@@ -175,6 +175,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-7592840-C-CC",
                 "geneContext": {
                   "valueId": "ENSG00000090674",
                   "symbol": "MCOLN1",

--- a/testdata/phenopackets/lirical/Gregor-2018-FBXO11-Individual_1.json
+++ b/testdata/phenopackets/lirical/Gregor-2018-FBXO11-Individual_1.json
@@ -502,6 +502,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:559600",
                 "geneContext": {
                   "valueId": "ENSG00000138081",
                   "symbol": "FBXO11",
@@ -579,6 +580,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Grumach-2015-CARD9-Patient.json
+++ b/testdata/phenopackets/lirical/Grumach-2015-CARD9-Patient.json
@@ -178,6 +178,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2414980",
                 "geneContext": {
                   "valueId": "ENSG00000187796",
                   "symbol": "CARD9",
@@ -255,6 +256,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Gu-2013-NOTCH2-proband.json
+++ b/testdata/phenopackets/lirical/Gu-2013-NOTCH2-proband.json
@@ -248,6 +248,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:30057",
                 "geneContext": {
                   "valueId": "ENSG00000134250",
                   "symbol": "NOTCH2",
@@ -325,6 +326,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Gueguen-2013-ACTN1-proband.json
+++ b/testdata/phenopackets/lirical/Gueguen-2013-ACTN1-proband.json
@@ -123,6 +123,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:42031",
                 "geneContext": {
                   "valueId": "ENSG00000072110",
                   "symbol": "ACTN1",
@@ -200,6 +201,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-3.json
+++ b/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-3.json
@@ -409,6 +409,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-107168420-CTTCA-C",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",

--- a/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-4.json
+++ b/testdata/phenopackets/lirical/Guerreiro-2016-TBCK-II-4.json
@@ -303,6 +303,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-107168420-CTTCA-C",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",

--- a/testdata/phenopackets/lirical/Gul-2006-CENPJ-IV-5.json
+++ b/testdata/phenopackets/lirical/Gul-2006-CENPJ-IV-5.json
@@ -160,6 +160,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "13-25463508-TCTGA-T",
                 "geneContext": {
                   "valueId": "ENSG00000151849",
                   "symbol": "CENPJ",

--- a/testdata/phenopackets/lirical/Guo-2017-EXTL3-Patient_1.json
+++ b/testdata/phenopackets/lirical/Guo-2017-EXTL3-Patient_1.json
@@ -931,6 +931,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:623480",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -1008,6 +1009,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Guo-2018-KDM6A-3_month_old_boy.json
+++ b/testdata/phenopackets/lirical/Guo-2018-KDM6A-3_month_old_boy.json
@@ -413,6 +413,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-44833910-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000147050",
                   "symbol": "KDM6A",

--- a/testdata/phenopackets/lirical/Guo-2018-KMT2D-3_month_old_boy.json
+++ b/testdata/phenopackets/lirical/Guo-2018-KMT2D-3_month_old_boy.json
@@ -392,6 +392,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-44833910-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000167548",
                   "symbol": "KMT2D",

--- a/testdata/phenopackets/lirical/Habarou-2017-LIPT2-P1.json
+++ b/testdata/phenopackets/lirical/Habarou-2017-LIPT2-P1.json
@@ -319,6 +319,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:438640",
                 "geneContext": {
                   "valueId": "ENSG00000175536",
                   "symbol": "LIPT2",
@@ -348,6 +349,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-74204372-A-C",
                 "geneContext": {
                   "valueId": "ENSG00000175536",
                   "symbol": "LIPT2",

--- a/testdata/phenopackets/lirical/Haliloglu-2017-PIEZO2-Patient.json
+++ b/testdata/phenopackets/lirical/Haliloglu-2017-PIEZO2-Patient.json
@@ -247,6 +247,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:632546",
                 "geneContext": {
                   "valueId": "ENSG00000154864",
                   "symbol": "PIEZO2",
@@ -323,6 +324,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_A-IV_6.json
+++ b/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_A-IV_6.json
@@ -427,6 +427,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-26946976-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000137055",
                   "symbol": "PLAA",

--- a/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_D-Case_VIII-1.json
+++ b/testdata/phenopackets/lirical/Hall-2017-PLAA-Family_D-Case_VIII-1.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:427942",
                 "geneContext": {
                   "valueId": "ENSG00000137055",
                   "symbol": "PLAA",
@@ -360,6 +361,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Hamamy-2014-FYB1-IV_5.json
+++ b/testdata/phenopackets/lirical/Hamamy-2014-FYB1-IV_5.json
@@ -104,6 +104,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-39138766-CAT-C",
                 "geneContext": {
                   "valueId": "ENSG00000082074",
                   "symbol": "FYB1",

--- a/testdata/phenopackets/lirical/Hamzeh-2016-GPSM2-case_1.json
+++ b/testdata/phenopackets/lirical/Hamzeh-2016-GPSM2-case_1.json
@@ -265,6 +265,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-109445849-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000121957",
                   "symbol": "GPSM2",

--- a/testdata/phenopackets/lirical/Han-2015-CHRDL1-III-1.json
+++ b/testdata/phenopackets/lirical/Han-2015-CHRDL1-III-1.json
@@ -104,6 +104,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-110005962-AG-A",
                 "geneContext": {
                   "valueId": "ENSG00000101938",
                   "symbol": "CHRDL1",

--- a/testdata/phenopackets/lirical/Hara-2019-TGFBR1-patient.json
+++ b/testdata/phenopackets/lirical/Hara-2019-TGFBR1-patient.json
@@ -355,6 +355,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1310495",
                 "geneContext": {
                   "valueId": "ENSG00000106799",
                   "symbol": "TGFBR1",
@@ -432,6 +433,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Harlalka-2013-HERC2-Pedigree_1A,VIII_8.json
+++ b/testdata/phenopackets/lirical/Harlalka-2013-HERC2-Pedigree_1A,VIII_8.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:88738",
                 "geneContext": {
                   "valueId": "ENSG00000128731",
                   "symbol": "HERC2",
@@ -270,6 +271,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Hashemi-Gorji-2019-MED23-IV.8.json
+++ b/testdata/phenopackets/lirical/Hashemi-Gorji-2019-MED23-IV.8.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:437437",
                 "geneContext": {
                   "valueId": "ENSG00000112282",
                   "symbol": "MED23",
@@ -234,6 +235,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Hayette-1995-EPB42-proposita.json
+++ b/testdata/phenopackets/lirical/Hayette-1995-EPB42-proposita.json
@@ -116,6 +116,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-43508486-AC-A",
                 "geneContext": {
                   "valueId": "ENSG00000166947",
                   "symbol": "EPB42",

--- a/testdata/phenopackets/lirical/Helmi-2017-LYST-patient.json
+++ b/testdata/phenopackets/lirical/Helmi-2017-LYST-patient.json
@@ -290,6 +290,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-235926112-TAC-T",
                 "geneContext": {
                   "valueId": "ENSG00000143669",
                   "symbol": "LYST",

--- a/testdata/phenopackets/lirical/Hernan-2004-STK11-20-year-old_woman_.json
+++ b/testdata/phenopackets/lirical/Hernan-2004-STK11-20-year-old_woman_.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-1221215-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000118046",
                   "symbol": "STK11",

--- a/testdata/phenopackets/lirical/Higuchi-2017-COL2A1-proband.json
+++ b/testdata/phenopackets/lirical/Higuchi-2017-COL2A1-proband.json
@@ -376,6 +376,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "12-48381473-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000139219",
                   "symbol": "COL2A1",

--- a/testdata/phenopackets/lirical/Hilgert-2008-TMC1-935-IV_1.json
+++ b/testdata/phenopackets/lirical/Hilgert-2008-TMC1-935-IV_1.json
@@ -68,6 +68,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:4103",
                 "geneContext": {
                   "valueId": "ENSG00000165091",
                   "symbol": "TMC1",
@@ -145,6 +146,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Hirabayashi-2018-SPINT2-two-month-old_male.json
+++ b/testdata/phenopackets/lirical/Hirabayashi-2018-SPINT2-two-month-old_male.json
@@ -265,6 +265,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:5205",
                 "geneContext": {
                   "valueId": "ENSG00000167642",
                   "symbol": "SPINT2",
@@ -294,6 +295,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-38774325-G-GTA",
                 "geneContext": {
                   "valueId": "ENSG00000167642",
                   "symbol": "SPINT2",

--- a/testdata/phenopackets/lirical/Hirschhorn-1991-ADA-Patient.json
+++ b/testdata/phenopackets/lirical/Hirschhorn-1991-ADA-Patient.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1968",
                 "geneContext": {
                   "valueId": "ENSG00000196839",
                   "symbol": "ADA",
@@ -215,6 +216,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ho-2018-GNPTAB-proband.json
+++ b/testdata/phenopackets/lirical/Ho-2018-GNPTAB-proband.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "12-102158291-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000111670",
                   "symbol": "GNPTAB",
@@ -312,6 +313,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "12-102157979-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000111670",
                   "symbol": "GNPTAB",

--- a/testdata/phenopackets/lirical/Holmberg-1997-GP1BA-73_year_old_male.json
+++ b/testdata/phenopackets/lirical/Holmberg-1997-GP1BA-73_year_old_male.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:4157",
                 "geneContext": {
                   "valueId": "ENSG00000185245",
                   "symbol": "GP1BA",
@@ -197,6 +198,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Horvath-2014-GLRA1-proband.json
+++ b/testdata/phenopackets/lirical/Horvath-2014-GLRA1-proband.json
@@ -122,6 +122,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-151266323-T-A",
                 "geneContext": {
                   "valueId": "ENSG00000145888",
                   "symbol": "GLRA1",

--- a/testdata/phenopackets/lirical/Hsu-2017-SNAP29-The_patient.json
+++ b/testdata/phenopackets/lirical/Hsu-2017-SNAP29-The_patient.json
@@ -373,6 +373,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:280840",
                 "geneContext": {
                   "valueId": "ENSG00000099940",
                   "symbol": "SNAP29",
@@ -449,6 +450,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Huang-2017-P3H1-proband.json
+++ b/testdata/phenopackets/lirical/Huang-2017-P3H1-proband.json
@@ -102,6 +102,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-43232522-CGGCGAAGAGCAGATCA-C",
                 "geneContext": {
                   "valueId": "ENSG00000117385",
                   "symbol": "P3H1",
@@ -131,6 +132,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:288206",
                 "geneContext": {
                   "valueId": "ENSG00000117385",
                   "symbol": "P3H1",
@@ -208,6 +210,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Hyun-2018-TP53RK-II-1.json
+++ b/testdata/phenopackets/lirical/Hyun-2018-TP53RK-II-1.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "20-45317860-T-A",
                 "geneContext": {
                   "valueId": "ENSG00000172315",
                   "symbol": "TP53RK",

--- a/testdata/phenopackets/lirical/Imani-2019-BBS5-II_2.json
+++ b/testdata/phenopackets/lirical/Imani-2019-BBS5-II_2.json
@@ -140,6 +140,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "2-170343646-T-C",
                 "geneContext": {
                   "valueId": "ENSG00000163093",
                   "symbol": "BBS5",

--- a/testdata/phenopackets/lirical/Infante-2017-SMC3-patient_1.json
+++ b/testdata/phenopackets/lirical/Infante-2017-SMC3-patient_1.json
@@ -446,6 +446,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:212271",
                 "geneContext": {
                   "valueId": "ENSG00000108055",
                   "symbol": "SMC3",
@@ -522,6 +523,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Inlora-2017-APTX-V-3.json
+++ b/testdata/phenopackets/lirical/Inlora-2017-APTX-V-3.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:426093",
                 "geneContext": {
                   "valueId": "ENSG00000137074",
                   "symbol": "APTX",
@@ -180,6 +181,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Inui-2017-LONP1-Proband.json
+++ b/testdata/phenopackets/lirical/Inui-2017-LONP1-Proband.json
@@ -268,6 +268,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-5719847-G-GC",
                 "geneContext": {
                   "valueId": "ENSG00000196365",
                   "symbol": "LONP1",
@@ -297,6 +298,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-5693745-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000196365",
                   "symbol": "LONP1",

--- a/testdata/phenopackets/lirical/Irfanullah-2015-NPR2-IV-2_family-A.json
+++ b/testdata/phenopackets/lirical/Irfanullah-2015-NPR2-IV-2_family-A.json
@@ -212,6 +212,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:593743",
                 "geneContext": {
                   "valueId": "ENSG00000159899",
                   "symbol": "NPR2",
@@ -289,6 +290,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ishii-2013-KCNT1-Patient-1.json
+++ b/testdata/phenopackets/lirical/Ishii-2013-KCNT1-Patient-1.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-138651532-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000107147",
                   "symbol": "KCNT1",

--- a/testdata/phenopackets/lirical/Itoh-Satoh-2002-TTN-JK109.json
+++ b/testdata/phenopackets/lirical/Itoh-Satoh-2002-TTN-JK109.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:12655",
                 "geneContext": {
                   "valueId": "ENSG00000155657",
                   "symbol": "TTN",
@@ -180,6 +181,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jagadisan-2017-PYGL-2-year_5-month_old_child.json
+++ b/testdata/phenopackets/lirical/Jagadisan-2017-PYGL-2-year_5-month_old_child.json
@@ -289,6 +289,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-51382160-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000100504",
                   "symbol": "PYGL",

--- a/testdata/phenopackets/lirical/Janecke-2015-SLC9A3-Patient_9.json
+++ b/testdata/phenopackets/lirical/Janecke-2015-SLC9A3-Patient_9.json
@@ -194,6 +194,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:224597",
                 "geneContext": {
                   "valueId": "ENSG00000066230",
                   "symbol": "SLC9A3",
@@ -223,6 +224,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-477461-AG-A",
                 "geneContext": {
                   "valueId": "ENSG00000066230",
                   "symbol": "SLC9A3",

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F1-II2.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F1-II2.json
@@ -229,6 +229,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-26684713-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F2-II2.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F2-II2.json
@@ -340,6 +340,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:223001",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -369,6 +370,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:223000",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -446,6 +448,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F3-II1.json
+++ b/testdata/phenopackets/lirical/Jansen-2016-TMEM199-F3-II1.json
@@ -235,6 +235,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:223000",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -312,6 +313,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Janssen-2009-BSND-family-A-III3.json
+++ b/testdata/phenopackets/lirical/Janssen-2009-BSND-family-A-III3.json
@@ -194,6 +194,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-55464998-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000162399",
                   "symbol": "BSND",

--- a/testdata/phenopackets/lirical/Javadiyan-2017-MAF-patient_CSA108.01.json
+++ b/testdata/phenopackets/lirical/Javadiyan-2017-MAF-patient_CSA108.01.json
@@ -49,6 +49,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "16-79633624-G-C",
                 "geneContext": {
                   "valueId": "ENSG00000178573",
                   "symbol": "MAF",

--- a/testdata/phenopackets/lirical/Jeon-2014-LAMC2-patient.json
+++ b/testdata/phenopackets/lirical/Jeon-2014-LAMC2-patient.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-183155566-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000058085",
                   "symbol": "LAMC2",
@@ -150,6 +151,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2120792",
                 "geneContext": {
                   "valueId": "ENSG00000058085",
                   "symbol": "LAMC2",
@@ -227,6 +229,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ji-2017-ATRX-Proband.json
+++ b/testdata/phenopackets/lirical/Ji-2017-ATRX-Proband.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:11728",
                 "geneContext": {
                   "valueId": "ENSG00000085224",
                   "symbol": "ATRX",
@@ -270,6 +271,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jiang-2017-PPIB-second_fetus.json
+++ b/testdata/phenopackets/lirical/Jiang-2017-PPIB-second_fetus.json
@@ -120,6 +120,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-64455161-T-C",
                 "geneContext": {
                   "valueId": "ENSG00000166794",
                   "symbol": "PPIB",
@@ -149,6 +150,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1393219",
                 "geneContext": {
                   "valueId": "ENSG00000166794",
                   "symbol": "PPIB",
@@ -225,6 +227,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jin-2017-FBN1-patient.json
+++ b/testdata/phenopackets/lirical/Jin-2017-FBN1-patient.json
@@ -338,6 +338,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1172375",
                 "geneContext": {
                   "valueId": "ENSG00000166147",
                   "symbol": "FBN1",
@@ -415,6 +416,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_2.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_2.json
@@ -438,6 +438,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:562003",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -515,6 +516,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_3.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_3.json
@@ -665,6 +665,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:235329",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -742,6 +743,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_4.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_4.json
@@ -326,6 +326,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:562005",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -403,6 +404,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_5.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_5.json
@@ -595,6 +595,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8418291-T-C",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_6.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_6.json
@@ -265,6 +265,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:562005",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -294,6 +295,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:562006",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -371,6 +373,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_7.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_7.json
@@ -715,6 +715,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8418276-T-TGGTGGA",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_8.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_8.json
@@ -704,6 +704,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-8418276-T-TGGTGGA",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",

--- a/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_9.json
+++ b/testdata/phenopackets/lirical/Jordan-2018-RERE-Subject_9.json
@@ -410,6 +410,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:391564",
                 "geneContext": {
                   "valueId": "ENSG00000142599",
                   "symbol": "RERE",
@@ -487,6 +488,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Kantaputra-2014-FBLN5-4-year-old_Burmese_girl_.json
+++ b/testdata/phenopackets/lirical/Kantaputra-2014-FBLN5-4-year-old_Burmese_girl_.json
@@ -249,6 +249,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1804877",
                 "geneContext": {
                   "valueId": "ENSG00000140092",
                   "symbol": "FBLN5",
@@ -326,6 +327,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Kato-2018-HNF1B-patient.json
+++ b/testdata/phenopackets/lirical/Kato-2018-HNF1B-patient.json
@@ -140,6 +140,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:635700",
                 "geneContext": {
                   "valueId": "ENSG00000275410",
                   "symbol": "HNF1B",
@@ -216,6 +217,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Khan-2017-HOXC13-IV-1.json
+++ b/testdata/phenopackets/lirical/Khan-2017-HOXC13-IV-1.json
@@ -159,6 +159,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "12-54338976-A-C",
                 "geneContext": {
                   "valueId": "ENSG00000123364",
                   "symbol": "HOXC13",

--- a/testdata/phenopackets/lirical/Kim-2016-LAMB3-proband.json
+++ b/testdata/phenopackets/lirical/Kim-2016-LAMB3-proband.json
@@ -67,6 +67,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-209788676-ACGCTTCT-A",
                 "geneContext": {
                   "valueId": "ENSG00000196878",
                   "symbol": "LAMB3",

--- a/testdata/phenopackets/lirical/Kinnear-2017-TTC37-index.json
+++ b/testdata/phenopackets/lirical/Kinnear-2017-TTC37-index.json
@@ -340,6 +340,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-94803683-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000198677",
                   "symbol": "TTC37",

--- a/testdata/phenopackets/lirical/Kluijtmans-1996-CBS-patient.json
+++ b/testdata/phenopackets/lirical/Kluijtmans-1996-CBS-patient.json
@@ -104,6 +104,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:126",
                 "geneContext": {
                   "valueId": "ENSG00000160200",
                   "symbol": "CBS",
@@ -180,6 +181,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam1Pat1.json
+++ b/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam1Pat1.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-64955949-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",

--- a/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam2Pat1.json
+++ b/testdata/phenopackets/lirical/Kocoglu-2018-CAPN1-Fam2Pat1.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:802687",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -234,6 +235,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Konkolova-2017-GRHPR-patient.json
+++ b/testdata/phenopackets/lirical/Konkolova-2017-GRHPR-patient.json
@@ -232,6 +232,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-37428529-C-CA",
                 "geneContext": {
                   "valueId": "ENSG00000137106",
                   "symbol": "GRHPR",

--- a/testdata/phenopackets/lirical/Kou-2018-ERCC6-index.json
+++ b/testdata/phenopackets/lirical/Kou-2018-ERCC6-index.json
@@ -355,6 +355,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1932260",
                 "geneContext": {
                   "valueId": "ENSG00000225830",
                   "symbol": "ERCC6",
@@ -432,6 +433,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Kremer-2016-TANGO2-F1_II.2.json
+++ b/testdata/phenopackets/lirical/Kremer-2016-TANGO2-F1_II.2.json
@@ -445,6 +445,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "22-20024324-GT-G",
                 "geneContext": {
                   "valueId": "ENSG00000183597",
                   "symbol": "TANGO2",

--- a/testdata/phenopackets/lirical/Kretz-2011-PYCR1-Patient_4.json
+++ b/testdata/phenopackets/lirical/Kretz-2011-PYCR1-Patient_4.json
@@ -321,6 +321,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-79892546-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000183010",
                   "symbol": "PYCR1",

--- a/testdata/phenopackets/lirical/Kruszka-2016-FGFR3-Proband_27.json
+++ b/testdata/phenopackets/lirical/Kruszka-2016-FGFR3-Proband_27.json
@@ -122,6 +122,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-1803571-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000068078",
                   "symbol": "FGFR3",

--- a/testdata/phenopackets/lirical/Kuptanon-2018-WNT1-proband.json
+++ b/testdata/phenopackets/lirical/Kuptanon-2018-WNT1-proband.json
@@ -232,6 +232,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "12-49372435-TG-T",
                 "geneContext": {
                   "valueId": "ENSG00000125084",
                   "symbol": "WNT1",

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_1.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_1.json
@@ -643,6 +643,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:427779",
                 "geneContext": {
                   "valueId": "ENSG00000197170",
                   "symbol": "PSMD12",
@@ -720,6 +721,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_2.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_2.json
@@ -573,6 +573,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:427780",
                 "geneContext": {
                   "valueId": "ENSG00000197170",
                   "symbol": "PSMD12",
@@ -650,6 +651,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_3.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_3.json
@@ -251,6 +251,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:427781",
                 "geneContext": {
                   "valueId": "ENSG00000197170",
                   "symbol": "PSMD12",
@@ -328,6 +329,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_4.json
+++ b/testdata/phenopackets/lirical/Kury-2017-PSMD12-Subject_4.json
@@ -409,6 +409,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:427782",
                 "geneContext": {
                   "valueId": "ENSG00000197170",
                   "symbol": "PSMD12",
@@ -486,6 +487,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_2.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_2.json
@@ -626,6 +626,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:208823",
                 "geneContext": {
                   "valueId": "ENSG00000183597",
                   "symbol": "TANGO2",
@@ -703,6 +704,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_4.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_4.json
@@ -319,6 +319,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:208823",
                 "geneContext": {
                   "valueId": "ENSG00000183597",
                   "symbol": "TANGO2",
@@ -396,6 +397,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_5.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_5.json
@@ -409,6 +409,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:208823",
                 "geneContext": {
                   "valueId": "ENSG00000183597",
                   "symbol": "TANGO2",
@@ -486,6 +487,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_6.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Subject_6.json
@@ -340,6 +340,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "22-20049207-G-C",
                 "geneContext": {
                   "valueId": "ENSG00000183597",
                   "symbol": "TANGO2",

--- a/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Suject_1.json
+++ b/testdata/phenopackets/lirical/Lalani-2016-TANGO2-Suject_1.json
@@ -392,6 +392,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:208823",
                 "geneContext": {
                   "valueId": "ENSG00000183597",
                   "symbol": "TANGO2",
@@ -469,6 +470,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lambe-2018-CAPN1-II-4.json
+++ b/testdata/phenopackets/lirical/Lambe-2018-CAPN1-II-4.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:871873",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -198,6 +199,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_A,_V-2.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_A,_V-2.json
@@ -358,6 +358,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:222067",
                 "geneContext": {
                   "valueId": "ENSG00000129003",
                   "symbol": "VPS13C",
@@ -435,6 +436,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_B,_II-1.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_B,_II-1.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:222068",
                 "geneContext": {
                   "valueId": "ENSG00000129003",
                   "symbol": "VPS13C",
@@ -150,6 +151,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:222069",
                 "geneContext": {
                   "valueId": "ENSG00000129003",
                   "symbol": "VPS13C",
@@ -227,6 +229,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_C,_II-1.json
+++ b/testdata/phenopackets/lirical/Lesage-2016-VPS13C-Family_C,_II-1.json
@@ -104,6 +104,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:222070",
                 "geneContext": {
                   "valueId": "ENSG00000129003",
                   "symbol": "VPS13C",
@@ -133,6 +134,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-62239490-TG-T",
                 "geneContext": {
                   "valueId": "ENSG00000129003",
                   "symbol": "VPS13C",

--- a/testdata/phenopackets/lirical/Li-2014-BBS4-4-year-old_female_patient.json
+++ b/testdata/phenopackets/lirical/Li-2014-BBS4-4-year-old_female_patient.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:634524",
                 "geneContext": {
                   "valueId": "ENSG00000140463",
                   "symbol": "BBS4",
@@ -287,6 +288,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Li-2018-STXBP1-P1.json
+++ b/testdata/phenopackets/lirical/Li-2018-STXBP1-P1.json
@@ -138,6 +138,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-130438126-AC-A",
                 "geneContext": {
                   "valueId": "ENSG00000136854",
                   "symbol": "STXBP1",

--- a/testdata/phenopackets/lirical/Liberalesso-2017-SALL1-VMFS.json
+++ b/testdata/phenopackets/lirical/Liberalesso-2017-SALL1-VMFS.json
@@ -448,6 +448,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1013100",
                 "geneContext": {
                   "valueId": "ENSG00000103449",
                   "symbol": "SALL1",
@@ -525,6 +526,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ling-2019-NHS-III_1.json
+++ b/testdata/phenopackets/lirical/Ling-2019-NHS-III_1.json
@@ -186,6 +186,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-17750140-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000188158",
                   "symbol": "NHS",

--- a/testdata/phenopackets/lirical/Lopez-2018-EP300-11.json
+++ b/testdata/phenopackets/lirical/Lopez-2018-EP300-11.json
@@ -509,6 +509,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:253310",
                 "geneContext": {
                   "valueId": "ENSG00000100393",
                   "symbol": "EP300",
@@ -586,6 +587,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Lopez-2018-EP300-38.json
+++ b/testdata/phenopackets/lirical/Lopez-2018-EP300-38.json
@@ -506,6 +506,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:253312",
                 "geneContext": {
                   "valueId": "ENSG00000100393",
                   "symbol": "EP300",
@@ -583,6 +584,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Luco-2016-DYRK1A-Patient_2.json
+++ b/testdata/phenopackets/lirical/Luco-2016-DYRK1A-Patient_2.json
@@ -373,6 +373,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:279970",
                 "geneContext": {
                   "valueId": "ENSG00000157540",
                   "symbol": "DYRK1A",
@@ -449,6 +450,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Luo-2016-COMP-II-1.json
+++ b/testdata/phenopackets/lirical/Luo-2016-COMP-II-1.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-18897434-GGCA-G",
                 "geneContext": {
                   "valueId": "ENSG00000105664",
                   "symbol": "COMP",

--- a/testdata/phenopackets/lirical/Lv-2016-TMEM38B-family2-patient2.json
+++ b/testdata/phenopackets/lirical/Lv-2016-TMEM38B-family2-patient2.json
@@ -195,6 +195,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1323694",
                 "geneContext": {
                   "valueId": "ENSG00000095209",
                   "symbol": "TMEM38B",
@@ -272,6 +273,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ma-2018-SPTA1-proband.json
+++ b/testdata/phenopackets/lirical/Ma-2018-SPTA1-proband.json
@@ -214,6 +214,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-158655001-T-G",
                 "geneContext": {
                   "valueId": "ENSG00000163554",
                   "symbol": "SPTA1",
@@ -243,6 +244,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:258948",
                 "geneContext": {
                   "valueId": "ENSG00000163554",
                   "symbol": "SPTA1",
@@ -320,6 +322,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Mackenroth-2016-ADAMTSL2-patient.json
+++ b/testdata/phenopackets/lirical/Mackenroth-2016-ADAMTSL2-patient.json
@@ -320,6 +320,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:914430",
                 "geneContext": {
                   "valueId": "ENSG00000197859",
                   "symbol": "ADAMTSL2",
@@ -349,6 +350,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-136412195-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000197859",
                   "symbol": "ADAMTSL2",

--- a/testdata/phenopackets/lirical/Magerus-Chatinet-2013-FASLG-patient.json
+++ b/testdata/phenopackets/lirical/Magerus-Chatinet-2013-FASLG-patient.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-172628599-GT-G",
                 "geneContext": {
                   "valueId": "ENSG00000117560",
                   "symbol": "FASLG",

--- a/testdata/phenopackets/lirical/Maghami-2018-FKBP10-proband.json
+++ b/testdata/phenopackets/lirical/Maghami-2018-FKBP10-proband.json
@@ -199,6 +199,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-39977197-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000141756",
                   "symbol": "FKBP10",

--- a/testdata/phenopackets/lirical/Mattioli-2017-BRPF1-Individual_11_Family_F.json
+++ b/testdata/phenopackets/lirical/Mattioli-2017-BRPF1-Individual_11_Family_F.json
@@ -230,6 +230,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:375493",
                 "geneContext": {
                   "valueId": "ENSG00000156983",
                   "symbol": "BRPF1",
@@ -307,6 +308,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Mazzucchelli-2011-LAMA3-Proband.json
+++ b/testdata/phenopackets/lirical/Mazzucchelli-2011-LAMA3-Proband.json
@@ -67,6 +67,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:8792",
                 "geneContext": {
                   "valueId": "ENSG00000053747",
                   "symbol": "LAMA3",
@@ -144,6 +145,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_1.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-36985760-CA-C",
                 "geneContext": {
                   "valueId": "ENSG00000164190",
                   "symbol": "NIPBL",

--- a/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_2.json
+++ b/testdata/phenopackets/lirical/Mei-2015-NIPBL-Patient_2.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-37044760-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000164190",
                   "symbol": "NIPBL",

--- a/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_1.json
+++ b/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_1.json
@@ -356,6 +356,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:224316",
                 "geneContext": {
                   "valueId": "ENSG00000174173",
                   "symbol": "TRMT10C",
@@ -385,6 +386,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:224317",
                 "geneContext": {
                   "valueId": "ENSG00000174173",
                   "symbol": "TRMT10C",
@@ -462,6 +464,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_2.json
+++ b/testdata/phenopackets/lirical/Metodiev-2016-TRMT10C-Subject_2.json
@@ -301,6 +301,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:224316",
                 "geneContext": {
                   "valueId": "ENSG00000174173",
                   "symbol": "TRMT10C",
@@ -378,6 +379,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Miao-2018-CLCN1-man.json
+++ b/testdata/phenopackets/lirical/Miao-2018-CLCN1-man.json
@@ -159,6 +159,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "7-143029967-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000188037",
                   "symbol": "CLCN1",

--- a/testdata/phenopackets/lirical/Micaglio-2019-SCN5A-proband.json
+++ b/testdata/phenopackets/lirical/Micaglio-2019-SCN5A-proband.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1454071",
                 "geneContext": {
                   "valueId": "ENSG00000183873",
                   "symbol": "SCN5A",
@@ -171,6 +172,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0",

--- a/testdata/phenopackets/lirical/Michalska-2018-GTF2H5-male_infant.json
+++ b/testdata/phenopackets/lirical/Michalska-2018-GTF2H5-male_infant.json
@@ -517,6 +517,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:975159",
                 "geneContext": {
                   "valueId": "ENSG00000272047",
                   "symbol": "GTF2H5",
@@ -546,6 +547,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:975160",
                 "geneContext": {
                   "valueId": "ENSG00000272047",
                   "symbol": "GTF2H5",
@@ -623,6 +625,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Mokbel-2013-TPM2-1A.json
+++ b/testdata/phenopackets/lirical/Mokbel-2013-TPM2-1A.json
@@ -116,6 +116,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-35689792-ATCT-A",
                 "geneContext": {
                   "valueId": "ENSG00000198467",
                   "symbol": "TPM2",

--- a/testdata/phenopackets/lirical/Montgomery-2015-AMN-III_1.json
+++ b/testdata/phenopackets/lirical/Montgomery-2015-AMN-III_1.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-103389059-CA-C",
                 "geneContext": {
                   "valueId": "ENSG00000166126",
                   "symbol": "AMN",
@@ -114,6 +115,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-103390315-T-A",
                 "geneContext": {
                   "valueId": "ENSG00000166126",
                   "symbol": "AMN",

--- a/testdata/phenopackets/lirical/Moosa-1799-MTOR-index.json
+++ b/testdata/phenopackets/lirical/Moosa-1799-MTOR-index.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:217823",
                 "geneContext": {
                   "valueId": "ENSG00000198793",
                   "symbol": "MTOR",
@@ -270,6 +271,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Moreau-Le_Lan-2018-ACTA1-Patient_5.json
+++ b/testdata/phenopackets/lirical/Moreau-Le_Lan-2018-ACTA1-Patient_5.json
@@ -217,6 +217,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-229567587-T-A",
                 "geneContext": {
                   "valueId": "ENSG00000143632",
                   "symbol": "ACTA1",

--- a/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_1.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "10-123279677-G-C",
                 "geneContext": {
                   "valueId": "ENSG00000066468",
                   "symbol": "FGFR2",

--- a/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_2.json
+++ b/testdata/phenopackets/lirical/Mundhofir-2013-FGFR2-Patient_2.json
@@ -319,6 +319,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "10-123279674-G-C",
                 "geneContext": {
                   "valueId": "ENSG00000066468",
                   "symbol": "FGFR2",

--- a/testdata/phenopackets/lirical/Mwasamwaja-2018-TGFB1-patient.json
+++ b/testdata/phenopackets/lirical/Mwasamwaja-2018-TGFB1-patient.json
@@ -268,6 +268,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:12531",
                 "geneContext": {
                   "valueId": "ENSG00000105329",
                   "symbol": "TGFB1",
@@ -344,6 +345,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Nakajima-2013-B3GALT6-P7_F6.json
+++ b/testdata/phenopackets/lirical/Nakajima-2013-B3GALT6-P7_F6.json
@@ -565,6 +565,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-1167851-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000176022",
                   "symbol": "B3GALT6",
@@ -594,6 +595,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-1167659-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000176022",
                   "symbol": "B3GALT6",

--- a/testdata/phenopackets/lirical/Naz_Villalba-2016-NLRP3-proband.json
+++ b/testdata/phenopackets/lirical/Naz_Villalba-2016-NLRP3-proband.json
@@ -195,6 +195,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:97909",
                 "geneContext": {
                   "valueId": "ENSG00000162711",
                   "symbol": "NLRP3",
@@ -272,6 +273,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Nellist-2009-TSC1-II_3_Family_2.json
+++ b/testdata/phenopackets/lirical/Nellist-2009-TSC1-II_3_Family_2.json
@@ -156,6 +156,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-135796816-A-C",
                 "geneContext": {
                   "valueId": "ENSG00000165699",
                   "symbol": "TSC1",
@@ -185,6 +186,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:41696",
                 "geneContext": {
                   "valueId": "ENSG00000165699",
                   "symbol": "TSC1",
@@ -261,6 +263,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Nevidomskyte-2017-SMAD3-54-year_old_woman.json
+++ b/testdata/phenopackets/lirical/Nevidomskyte-2017-SMAD3-54-year_old_woman.json
@@ -67,6 +67,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-67473653-G-C",
                 "geneContext": {
                   "valueId": "ENSG00000166949",
                   "symbol": "SMAD3",

--- a/testdata/phenopackets/lirical/Nguyen-2017-NPHS1-patient_1.json
+++ b/testdata/phenopackets/lirical/Nguyen-2017-NPHS1-patient_1.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-36342212-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000161270",
                   "symbol": "NPHS1",
@@ -222,6 +223,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-36339962-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000161270",
                   "symbol": "NPHS1",
@@ -251,6 +253,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:56497",
                 "geneContext": {
                   "valueId": "ENSG00000161270",
                   "symbol": "NPHS1",
@@ -328,6 +331,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Nicole-2014-AGRN-Patient_3_Kinship_2.json
+++ b/testdata/phenopackets/lirical/Nicole-2014-AGRN-Patient_3_Kinship_2.json
@@ -302,6 +302,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:243037",
                 "geneContext": {
                   "valueId": "ENSG00000188157",
                   "symbol": "AGRN",
@@ -331,6 +332,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-977517-C-CC",
                 "geneContext": {
                   "valueId": "ENSG00000188157",
                   "symbol": "AGRN",

--- a/testdata/phenopackets/lirical/Niihori-2006-BRAF-CFC16.json
+++ b/testdata/phenopackets/lirical/Niihori-2006-BRAF-CFC16.json
@@ -321,6 +321,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:13973",
                 "geneContext": {
                   "valueId": "ENSG00000157764",
                   "symbol": "BRAF",
@@ -398,6 +399,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ning-2015-MEN1-III-3.json
+++ b/testdata/phenopackets/lirical/Ning-2015-MEN1-III-3.json
@@ -302,6 +302,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-64574571-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000133895",
                   "symbol": "MEN1",

--- a/testdata/phenopackets/lirical/Noch-2017-ATP13A2-Case_1.json
+++ b/testdata/phenopackets/lirical/Noch-2017-ATP13A2-Case_1.json
@@ -248,6 +248,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:520750",
                 "geneContext": {
                   "valueId": "ENSG00000159363",
                   "symbol": "ATP13A2",
@@ -325,6 +326,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ockeloen-2012-CFL2-_Patient_1.json
+++ b/testdata/phenopackets/lirical/Ockeloen-2012-CFL2-_Patient_1.json
@@ -249,6 +249,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:60554",
                 "geneContext": {
                   "valueId": "ENSG00000165410",
                   "symbol": "CFL2",
@@ -326,6 +327,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Okamoto-2018-ASPM-patient.json
+++ b/testdata/phenopackets/lirical/Okamoto-2018-ASPM-patient.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-197059409-AGTTT-A",
                 "geneContext": {
                   "valueId": "ENSG00000066279",
                   "symbol": "ASPM",
@@ -240,6 +241,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-197070597-TTC-T",
                 "geneContext": {
                   "valueId": "ENSG00000066279",
                   "symbol": "ASPM",

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-AII-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-AII-1.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "8-28575113-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-BII-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-BII-1.json
@@ -499,6 +499,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1394264",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -576,6 +577,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-B_II-2.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-B_II-2.json
@@ -507,6 +507,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1394264",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -584,6 +585,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-C_II-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-C_II-1.json
@@ -247,6 +247,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417794",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -324,6 +325,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-D_IV-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-D_IV-1.json
@@ -445,6 +445,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417794",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -522,6 +523,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Oud-2017-EXTL3-E_II-1.json
+++ b/testdata/phenopackets/lirical/Oud-2017-EXTL3-E_II-1.json
@@ -391,6 +391,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417795",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -468,6 +469,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Papanastasiou-2010-STAT3-12_year_old_girl.json
+++ b/testdata/phenopackets/lirical/Papanastasiou-2010-STAT3-12_year_old_girl.json
@@ -250,6 +250,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-40485715-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000168610",
                   "symbol": "STAT3",

--- a/testdata/phenopackets/lirical/Park-2014-DNM2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Park-2014-DNM2-Patient_1.json
@@ -249,6 +249,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:931135",
                 "geneContext": {
                   "valueId": "ENSG00000079805",
                   "symbol": "DNM2",
@@ -325,6 +326,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Park-2016-GSN-III_5.json
+++ b/testdata/phenopackets/lirical/Park-2016-GSN-III_5.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-124073097-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000148180",
                   "symbol": "GSN",

--- a/testdata/phenopackets/lirical/Pasic-2013-NBN-12-year-old_girl.json
+++ b/testdata/phenopackets/lirical/Pasic-2013-NBN-12-year-old_girl.json
@@ -355,6 +355,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:490059",
                 "geneContext": {
                   "valueId": "ENSG00000104320",
                   "symbol": "NBN",
@@ -432,6 +433,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P5.json
+++ b/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P5.json
@@ -67,6 +67,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "7-92762329-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",

--- a/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P7.json
+++ b/testdata/phenopackets/lirical/Pastor-2018-SAMD9L-P7.json
@@ -67,6 +67,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:242372",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",
@@ -144,6 +145,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Patsi-2018-PNPLA6-18_year-old_female.json
+++ b/testdata/phenopackets/lirical/Patsi-2018-PNPLA6-18_year-old_female.json
@@ -337,6 +337,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:962428",
                 "geneContext": {
                   "valueId": "ENSG00000032444",
                   "symbol": "PNPLA6",
@@ -413,6 +414,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Paun-2013-RET-DM_patient.json
+++ b/testdata/phenopackets/lirical/Paun-2013-RET-DM_patient.json
@@ -82,6 +82,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "10-43609950-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000165731",
                   "symbol": "RET",

--- a/testdata/phenopackets/lirical/Pipilas-2016-CALM1-Case_2.json
+++ b/testdata/phenopackets/lirical/Pipilas-2016-CALM1-Case_2.json
@@ -104,6 +104,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-90870832-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000198668",
                   "symbol": "CALM1",

--- a/testdata/phenopackets/lirical/Pipilas-2016-CALM2-Case_1.json
+++ b/testdata/phenopackets/lirical/Pipilas-2016-CALM2-Case_1.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1456260",
                 "geneContext": {
                   "valueId": "ENSG00000143933",
                   "symbol": "CALM2",
@@ -180,6 +181,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Prada-2014-CTSA-BAB3767.json
+++ b/testdata/phenopackets/lirical/Prada-2014-CTSA-BAB3767.json
@@ -271,6 +271,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:381",
                 "geneContext": {
                   "valueId": "ENSG00000064601",
                   "symbol": "CTSA",
@@ -300,6 +301,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "20-44523342-CTA-C",
                 "geneContext": {
                   "valueId": "ENSG00000064601",
                   "symbol": "CTSA",

--- a/testdata/phenopackets/lirical/Qin-2017-NRL-II_2.json
+++ b/testdata/phenopackets/lirical/Qin-2017-NRL-II_2.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-24551908-TGAA-T",
                 "geneContext": {
                   "valueId": "ENSG00000129535",
                   "symbol": "NRL",

--- a/testdata/phenopackets/lirical/Rejeb-2017-VPS13B-proposita.json
+++ b/testdata/phenopackets/lirical/Rejeb-2017-VPS13B-proposita.json
@@ -357,6 +357,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "8-100479777-CT-C",
                 "geneContext": {
                   "valueId": "ENSG00000132549",
                   "symbol": "VPS13B",
@@ -386,6 +387,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "8-100712000-CAT-C",
                 "geneContext": {
                   "valueId": "ENSG00000132549",
                   "symbol": "VPS13B",

--- a/testdata/phenopackets/lirical/Reyes-de_la_Rosa-2018-JAG1-Proband.json
+++ b/testdata/phenopackets/lirical/Reyes-de_la_Rosa-2018-JAG1-Proband.json
@@ -356,6 +356,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "20-10653644-G-GC",
                 "geneContext": {
                   "valueId": "ENSG00000101384",
                   "symbol": "JAG1",

--- a/testdata/phenopackets/lirical/Rincon-2019-WRN-48-year-old_male.json
+++ b/testdata/phenopackets/lirical/Rincon-2019-WRN-48-year-old_male.json
@@ -358,6 +358,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2071717",
                 "geneContext": {
                   "valueId": "ENSG00000165392",
                   "symbol": "WRN",
@@ -435,6 +436,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ritelli-2013-COL5A1-AN_002501.json
+++ b/testdata/phenopackets/lirical/Ritelli-2013-COL5A1-AN_002501.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-137534120-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000130635",
                   "symbol": "COL5A1",

--- a/testdata/phenopackets/lirical/Ritelli-2014-TGFB2-proposita.json
+++ b/testdata/phenopackets/lirical/Ritelli-2014-TGFB2-proposita.json
@@ -302,6 +302,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-218609311-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000092969",
                   "symbol": "TGFB2",

--- a/testdata/phenopackets/lirical/Ritelli-2019-AEBP1-AN_006205.json
+++ b/testdata/phenopackets/lirical/Ritelli-2019-AEBP1-AN_006205.json
@@ -446,6 +446,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:995972",
                 "geneContext": {
                   "valueId": "ENSG00000106624",
                   "symbol": "AEBP1",
@@ -523,6 +524,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Rohanizadegan-2018-DHCR24-proband.json
+++ b/testdata/phenopackets/lirical/Rohanizadegan-2018-DHCR24-proband.json
@@ -644,6 +644,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:4369",
                 "geneContext": {
                   "valueId": "ENSG00000116133",
                   "symbol": "DHCR24",
@@ -721,6 +722,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Romero-Quintana-2013-CTSC-Case_1P1.json
+++ b/testdata/phenopackets/lirical/Romero-Quintana-2013-CTSC-Case_1P1.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:839668",
                 "geneContext": {
                   "valueId": "ENSG00000109861",
                   "symbol": "CTSC",
@@ -216,6 +217,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Salas-Alanis-2016-ANTXR1-14_year_old_brother.json
+++ b/testdata/phenopackets/lirical/Salas-Alanis-2016-ANTXR1-14_year_old_brother.json
@@ -218,6 +218,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "2-69298917-A-T",
                 "geneContext": {
                   "valueId": "ENSG00000169604",
                   "symbol": "ANTXR1",

--- a/testdata/phenopackets/lirical/Salpietro-2018-DDX59-Patient_1.json
+++ b/testdata/phenopackets/lirical/Salpietro-2018-DDX59-Patient_1.json
@@ -229,6 +229,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-200635683-GA-G",
                 "geneContext": {
                   "valueId": "ENSG00000118197",
                   "symbol": "DDX59",

--- a/testdata/phenopackets/lirical/Sandal-2018-CHST14-3-year_old_boy.json
+++ b/testdata/phenopackets/lirical/Sandal-2018-CHST14-3-year_old_boy.json
@@ -319,6 +319,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-40764208-T-TA",
                 "geneContext": {
                   "valueId": "ENSG00000169105",
                   "symbol": "CHST14",

--- a/testdata/phenopackets/lirical/Savage-2016-FANCI-NCI-309-1.json
+++ b/testdata/phenopackets/lirical/Savage-2016-FANCI-NCI-309-1.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1524566",
                 "geneContext": {
                   "valueId": "ENSG00000140525",
                   "symbol": "FANCI",
@@ -222,6 +223,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:414864",
                 "geneContext": {
                   "valueId": "ENSG00000140525",
                   "symbol": "FANCI",
@@ -298,6 +300,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Sawal-2018-ADGRG1-Family_A,_II_2.json
+++ b/testdata/phenopackets/lirical/Sawal-2018-ADGRG1-Family_A,_II_2.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:158619",
                 "geneContext": {
                   "valueId": "ENSG00000205336",
                   "symbol": "ADGRG1",
@@ -179,6 +180,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Schaefer-2014-POLR1D-family_1_patient.json
+++ b/testdata/phenopackets/lirical/Schaefer-2014-POLR1D-family_1_patient.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "13-28239968-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000186184",
                   "symbol": "POLR1D",

--- a/testdata/phenopackets/lirical/Schormair-2018-VPS13C-VPS13C_case.json
+++ b/testdata/phenopackets/lirical/Schormair-2018-VPS13C-VPS13C_case.json
@@ -229,6 +229,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-62274656-A-C",
                 "geneContext": {
                   "valueId": "ENSG00000129003",
                   "symbol": "VPS13C",
@@ -258,6 +259,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-62256151-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000129003",
                   "symbol": "VPS13C",

--- a/testdata/phenopackets/lirical/Schreckenbach-2014-TPM3-II.2.json
+++ b/testdata/phenopackets/lirical/Schreckenbach-2014-TPM3-II.2.json
@@ -400,6 +400,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2443942",
                 "geneContext": {
                   "valueId": "ENSG00000143549",
                   "symbol": "TPM3",
@@ -477,6 +478,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Schussler-2018-ANTXR2-II-3_.json
+++ b/testdata/phenopackets/lirical/Schussler-2018-ANTXR2-II-3_.json
@@ -265,6 +265,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-80905082-CCA-C",
                 "geneContext": {
                   "valueId": "ENSG00000163297",
                   "symbol": "ANTXR2",

--- a/testdata/phenopackets/lirical/Schweizer-2014-HCN4-family_A_II_1.json
+++ b/testdata/phenopackets/lirical/Schweizer-2014-HCN4-family_A_II_1.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-73622060-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000138622",
                   "symbol": "HCN4",

--- a/testdata/phenopackets/lirical/Seidlmayer-2018-RYR2-proband.json
+++ b/testdata/phenopackets/lirical/Seidlmayer-2018-RYR2-proband.json
@@ -141,6 +141,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-237947532-T-A",
                 "geneContext": {
                   "valueId": "ENSG00000198626",
                   "symbol": "RYR2",

--- a/testdata/phenopackets/lirical/Sekelska-2017-SPRED1-P62.json
+++ b/testdata/phenopackets/lirical/Sekelska-2017-SPRED1-P62.json
@@ -67,6 +67,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-38591587-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000166068",
                   "symbol": "SPRED1",

--- a/testdata/phenopackets/lirical/Servian-Morilla-2016-POGLUT1-Patient_II.1.json
+++ b/testdata/phenopackets/lirical/Servian-Morilla-2016-POGLUT1-Patient_II.1.json
@@ -259,6 +259,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "3-119205740-T-G",
                 "geneContext": {
                   "valueId": "ENSG00000163389",
                   "symbol": "POGLUT1",

--- a/testdata/phenopackets/lirical/Seven-2014-DYM-Patient_2.json
+++ b/testdata/phenopackets/lirical/Seven-2014-DYM-Patient_2.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "18-46860138-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000141627",
                   "symbol": "DYM",

--- a/testdata/phenopackets/lirical/Shahid-2019-FERMT3-index.json
+++ b/testdata/phenopackets/lirical/Shahid-2019-FERMT3-index.json
@@ -105,6 +105,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-63978208-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000149781",
                   "symbol": "FERMT3",

--- a/testdata/phenopackets/lirical/Shalaby-2009-MYOT-patient.json
+++ b/testdata/phenopackets/lirical/Shalaby-2009-MYOT-patient.json
@@ -122,6 +122,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-137222576-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000120729",
                   "symbol": "MYOT",

--- a/testdata/phenopackets/lirical/Shen-2017-VPS13A-Patient-2.json
+++ b/testdata/phenopackets/lirical/Shen-2017-VPS13A-Patient-2.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-79980446-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000197969",
                   "symbol": "VPS13A",
@@ -222,6 +223,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-80020779-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000197969",
                   "symbol": "VPS13A",

--- a/testdata/phenopackets/lirical/Sher-2014-CHSY1-IV-1.json
+++ b/testdata/phenopackets/lirical/Sher-2014-CHSY1-IV-1.json
@@ -322,6 +322,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-101718105-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000131873",
                   "symbol": "CHSY1",

--- a/testdata/phenopackets/lirical/Shervin_Badv-2019-ASAH1-patient.json
+++ b/testdata/phenopackets/lirical/Shervin_Badv-2019-ASAH1-patient.json
@@ -267,6 +267,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:35544",
                 "geneContext": {
                   "valueId": "ENSG00000104763",
                   "symbol": "ASAH1",
@@ -344,6 +345,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Shlebak-2015-GP1BA-Patient_3.json
+++ b/testdata/phenopackets/lirical/Shlebak-2015-GP1BA-Patient_3.json
@@ -214,6 +214,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-4836699-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000185245",
                   "symbol": "GP1BA",

--- a/testdata/phenopackets/lirical/Silva-2018-PREPL-proband.json
+++ b/testdata/phenopackets/lirical/Silva-2018-PREPL-proband.json
@@ -355,6 +355,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "2-44573406-CT-C",
                 "geneContext": {
                   "valueId": "ENSG00000138078",
                   "symbol": "PREPL",

--- a/testdata/phenopackets/lirical/Skraban-2017-WDR26-Individual_1,_PPMD01P,_GEA055P.json
+++ b/testdata/phenopackets/lirical/Skraban-2017-WDR26-Individual_1,_PPMD01P,_GEA055P.json
@@ -997,6 +997,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:433006",
                 "geneContext": {
                   "valueId": "ENSG00000162923",
                   "symbol": "WDR26",
@@ -1074,6 +1075,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Skrabl-Baumgartner-2017-ADA2-patient_1.json
+++ b/testdata/phenopackets/lirical/Skrabl-Baumgartner-2017-ADA2-patient_1.json
@@ -265,6 +265,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "22-17690429-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000093072",
                   "symbol": "ADA2",
@@ -294,6 +295,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "22-17663510-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000093072",
                   "symbol": "ADA2",

--- a/testdata/phenopackets/lirical/Slavotinek-2017-TBL1XR1-seven_year_old_male.json
+++ b/testdata/phenopackets/lirical/Slavotinek-2017-TBL1XR1-seven_year_old_male.json
@@ -554,6 +554,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:225874",
                 "geneContext": {
                   "valueId": "ENSG00000177565",
                   "symbol": "TBL1XR1",
@@ -630,6 +631,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Smith-2000-MITF-family_815.json
+++ b/testdata/phenopackets/lirical/Smith-2000-MITF-family_815.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:14275",
                 "geneContext": {
                   "valueId": "ENSG00000187098",
                   "symbol": "MITF",
@@ -216,6 +217,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Smith-2017-ACP4-Family_1-IV_3.json
+++ b/testdata/phenopackets/lirical/Smith-2017-ACP4-Family_1-IV_3.json
@@ -67,6 +67,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:375694",
                 "geneContext": {
                   "valueId": "ENSG00000142513",
                   "symbol": "ACP4",
@@ -144,6 +145,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Snanoudj-2019-SERAC1-proband.json
+++ b/testdata/phenopackets/lirical/Snanoudj-2019-SERAC1-proband.json
@@ -447,6 +447,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:120184",
                 "geneContext": {
                   "valueId": "ENSG00000122335",
                   "symbol": "SERAC1",
@@ -476,6 +477,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "6-158571622-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000122335",
                   "symbol": "SERAC1",

--- a/testdata/phenopackets/lirical/Soumittra-2014-SLC4A11-Patient_1.json
+++ b/testdata/phenopackets/lirical/Soumittra-2014-SLC4A11-Patient_1.json
@@ -66,6 +66,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "20-3214218-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000088836",
                   "symbol": "SLC4A11",

--- a/testdata/phenopackets/lirical/Steinkellner-2015-ADAMTS10-18-year-old_woman.json
+++ b/testdata/phenopackets/lirical/Steinkellner-2015-ADAMTS10-18-year-old_woman.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-8670555-A-T",
                 "geneContext": {
                   "valueId": "ENSG00000142303",
                   "symbol": "ADAMTS10",

--- a/testdata/phenopackets/lirical/Stouffs-2018-RTTN-Patient_3.json
+++ b/testdata/phenopackets/lirical/Stouffs-2018-RTTN-Patient_3.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "18-67834203-T-C",
                 "geneContext": {
                   "valueId": "ENSG00000176225",
                   "symbol": "RTTN",

--- a/testdata/phenopackets/lirical/Straniero-2018-OTUD6B-proband.json
+++ b/testdata/phenopackets/lirical/Straniero-2018-OTUD6B-proband.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "8-92083518-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000155100",
                   "symbol": "OTUD6B",
@@ -312,6 +313,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "8-92086140-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000155100",
                   "symbol": "OTUD6B",

--- a/testdata/phenopackets/lirical/Suarez-Artiles-2018-OCRL-Patient_1.json
+++ b/testdata/phenopackets/lirical/Suarez-Artiles-2018-OCRL-Patient_1.json
@@ -176,6 +176,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-128723933-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000122126",
                   "symbol": "OCRL",

--- a/testdata/phenopackets/lirical/Suter-2016-USB1-patient.json
+++ b/testdata/phenopackets/lirical/Suter-2016-USB1-patient.json
@@ -156,6 +156,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:496756",
                 "geneContext": {
                   "valueId": "ENSG00000103005",
                   "symbol": "USB1",
@@ -233,6 +234,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Szczałuba-2018-GNB1-proband.json
+++ b/testdata/phenopackets/lirical/Szczałuba-2018-GNB1-proband.json
@@ -212,6 +212,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-1737951-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000078369",
                   "symbol": "GNB1",

--- a/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-1-II-1.json
+++ b/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-1-II-1.json
@@ -454,6 +454,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:426075",
                 "geneContext": {
                   "valueId": "ENSG00000070269",
                   "symbol": "TMEM260",
@@ -531,6 +532,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-2-II-4.json
+++ b/testdata/phenopackets/lirical/Ta-Shma-2017-TMEM260-2-II-4.json
@@ -379,6 +379,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-57099859-GTATC-G",
                 "geneContext": {
                   "valueId": "ENSG00000070269",
                   "symbol": "TMEM260",

--- a/testdata/phenopackets/lirical/Tadic-2017-CAPN1-Index.json
+++ b/testdata/phenopackets/lirical/Tadic-2017-CAPN1-Index.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-64953810-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",

--- a/testdata/phenopackets/lirical/Taghizade_Mortezaee-2015-ITGB2-P1.json
+++ b/testdata/phenopackets/lirical/Taghizade_Mortezaee-2015-ITGB2-P1.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "21-46313399-AG-A",
                 "geneContext": {
                   "valueId": "ENSG00000160255",
                   "symbol": "ITGB2",

--- a/testdata/phenopackets/lirical/Takagi-2006-WNK1-Patient.json
+++ b/testdata/phenopackets/lirical/Takagi-2006-WNK1-Patient.json
@@ -270,6 +270,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:5164",
                 "geneContext": {
                   "valueId": "ENSG00000060237",
                   "symbol": "WNK1",
@@ -299,6 +300,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:637897",
                 "geneContext": {
                   "valueId": "ENSG00000060237",
                   "symbol": "WNK1",
@@ -375,6 +377,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_1.json
+++ b/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_1.json
@@ -391,6 +391,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-94499750-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000169071",
                   "symbol": "ROR2",

--- a/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_2.json
+++ b/testdata/phenopackets/lirical/Tamhankar-2014-ROR2-Patient_2.json
@@ -373,6 +373,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-94519790-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000169071",
                   "symbol": "ROR2",

--- a/testdata/phenopackets/lirical/Tamura-2017-DHCR7-patient.json
+++ b/testdata/phenopackets/lirical/Tamura-2017-DHCR7-patient.json
@@ -266,6 +266,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-71148914-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000172893",
                   "symbol": "DHCR7",
@@ -295,6 +296,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:854086",
                 "geneContext": {
                   "valueId": "ENSG00000172893",
                   "symbol": "DHCR7",
@@ -372,6 +374,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Tan-2014-CDK5RAP2-patient.json
+++ b/testdata/phenopackets/lirical/Tan-2014-CDK5RAP2-patient.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-123298783-CTGCCT-C",
                 "geneContext": {
                   "valueId": "ENSG00000136861",
                   "symbol": "CDK5RAP2",
@@ -168,6 +169,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:158146",
                 "geneContext": {
                   "valueId": "ENSG00000136861",
                   "symbol": "CDK5RAP2",
@@ -245,6 +247,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-II-4.json
+++ b/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-II-4.json
@@ -265,6 +265,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:446529",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",
@@ -342,6 +343,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-III-1.json
+++ b/testdata/phenopackets/lirical/Tesi-2017-SAMD9L-III-1.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "7-92762329-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000177409",
                   "symbol": "SAMD9L",

--- a/testdata/phenopackets/lirical/Tian-2018-ACVR1-patient.json
+++ b/testdata/phenopackets/lirical/Tian-2018-ACVR1-patient.json
@@ -215,6 +215,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:18309",
                 "geneContext": {
                   "valueId": "ENSG00000115170",
                   "symbol": "ACVR1",
@@ -292,6 +293,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Tiecke-2001-FBN1-B15.json
+++ b/testdata/phenopackets/lirical/Tiecke-2001-FBN1-B15.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-48782093-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000166147",
                   "symbol": "FBN1",

--- a/testdata/phenopackets/lirical/Tran-2015-GALT-FKT118.json
+++ b/testdata/phenopackets/lirical/Tran-2015-GALT-FKT118.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:3614",
                 "geneContext": {
                   "valueId": "ENSG00000213930",
                   "symbol": "GALT",
@@ -186,6 +187,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:3614",
                 "geneContext": {
                   "valueId": "ENSG00000213930",
                   "symbol": "GALT",
@@ -263,6 +265,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Travaglini-2017-CAPN1-index.json
+++ b/testdata/phenopackets/lirical/Travaglini-2017-CAPN1-index.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1510947",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -132,6 +133,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2060731",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -209,6 +211,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS324.json
+++ b/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS324.json
@@ -481,6 +481,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2076392",
                 "geneContext": {
                   "valueId": "ENSG00000108557",
                   "symbol": "RAI1",
@@ -558,6 +559,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS335.json
+++ b/testdata/phenopackets/lirical/Truong-2010-RAI1-SMS335.json
@@ -301,6 +301,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2076392",
                 "geneContext": {
                   "valueId": "ENSG00000108557",
                   "symbol": "RAI1",
@@ -378,6 +379,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Twigg-2013-EFNB1-3269.json
+++ b/testdata/phenopackets/lirical/Twigg-2013-EFNB1-3269.json
@@ -337,6 +337,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:100627",
                 "geneContext": {
                   "valueId": "ENSG00000090776",
                   "symbol": "EFNB1",
@@ -413,6 +414,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Unger-2008-CCNQ-Case_2.json
+++ b/testdata/phenopackets/lirical/Unger-2008-CCNQ-Case_2.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-152860129-T-TA",
                 "geneContext": {
                   "valueId": "ENSG00000262919",
                   "symbol": "CCNQ",

--- a/testdata/phenopackets/lirical/Uysal-2017-KCNQ1-family_III-IV-5.json
+++ b/testdata/phenopackets/lirical/Uysal-2017-KCNQ1-family_III-IV-5.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-2606506-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000053918",
                   "symbol": "KCNQ1",

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_1.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_1.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-26684704-CTT-C",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -186,6 +187,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:218964",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -263,6 +265,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_2.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_2.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-26684704-CTT-C",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -186,6 +187,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:218964",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -263,6 +265,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_3.json
+++ b/testdata/phenopackets/lirical/Vajro-2018-TMEM199-Patient_3.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-26684704-CTT-C",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -168,6 +169,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:218964",
                 "geneContext": {
                   "valueId": "ENSG00000244045",
                   "symbol": "TMEM199",
@@ -245,6 +247,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIII_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIII_1.json
@@ -288,6 +288,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417772",
                 "geneContext": {
                   "valueId": "ENSG00000114573",
                   "symbol": "ATP6V1A",
@@ -365,6 +366,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIV_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PIV_1.json
@@ -377,6 +377,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417773",
                 "geneContext": {
                   "valueId": "ENSG00000114573",
                   "symbol": "ATP6V1A",
@@ -454,6 +455,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PV_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1A-PV_1.json
@@ -233,6 +233,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417773",
                 "geneContext": {
                   "valueId": "ENSG00000114573",
                   "symbol": "ATP6V1A",
@@ -310,6 +311,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PII_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PII_1.json
@@ -269,6 +269,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417760",
                 "geneContext": {
                   "valueId": "ENSG00000131100",
                   "symbol": "ATP6V1E1",
@@ -346,6 +347,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PI_1.json
+++ b/testdata/phenopackets/lirical/Van_Damme-2017-ATP6V1E1-PI_1.json
@@ -269,6 +269,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417759",
                 "geneContext": {
                   "valueId": "ENSG00000131100",
                   "symbol": "ATP6V1E1",
@@ -346,6 +347,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Van_De_Weghe-2017-ARMC9-UW132-3.json
+++ b/testdata/phenopackets/lirical/Van_De_Weghe-2017-ARMC9-UW132-3.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:427930",
                 "geneContext": {
                   "valueId": "ENSG00000135931",
                   "symbol": "ARMC9",
@@ -150,6 +151,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:427939",
                 "geneContext": {
                   "valueId": "ENSG00000135931",
                   "symbol": "ARMC9",
@@ -227,6 +229,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Van_Zwieten-2013-SLC4A1-c.1432-2A_T.json
+++ b/testdata/phenopackets/lirical/Van_Zwieten-2013-SLC4A1-c.1432-2A_T.json
@@ -84,6 +84,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-42334914-T-A",
                 "geneContext": {
                   "valueId": "ENSG00000004939",
                   "symbol": "SLC4A1",

--- a/testdata/phenopackets/lirical/Vogiatzi-2018-COL11A1-proband.json
+++ b/testdata/phenopackets/lirical/Vogiatzi-2018-COL11A1-proband.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-103427814-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000060718",
                   "symbol": "COL11A1",

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_1.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_1.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417796",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -288,6 +289,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_2.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_2.json
@@ -175,6 +175,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417796",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -252,6 +253,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_3.json
+++ b/testdata/phenopackets/lirical/Volpi-2017-EXTL3-Patient_3.json
@@ -535,6 +535,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:417794",
                 "geneContext": {
                   "valueId": "ENSG00000012232",
                   "symbol": "EXTL3",
@@ -612,6 +613,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Vrtel-1996-TSC2-III-1.json
+++ b/testdata/phenopackets/lirical/Vrtel-1996-TSC2-III-1.json
@@ -99,6 +99,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:12394",
                 "geneContext": {
                   "valueId": "ENSG00000103197",
                   "symbol": "TSC2",
@@ -175,6 +176,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Wakil-2018-RETREG1-F2_IV_1.json
+++ b/testdata/phenopackets/lirical/Wakil-2018-RETREG1-F2_IV_1.json
@@ -177,6 +177,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:328",
                 "geneContext": {
                   "valueId": "ENSG00000154153",
                   "symbol": "RETREG1",
@@ -254,6 +255,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-R-III_1.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-R-III_1.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-64950669-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-399-073.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-399-073.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-64953394-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -186,6 +187,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-64956194-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-584-005.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-SAL-584-005.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-64950354-T-TC",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",

--- a/testdata/phenopackets/lirical/Wang-2016-CAPN1-Tun66275.json
+++ b/testdata/phenopackets/lirical/Wang-2016-CAPN1-Tun66275.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:871873",
                 "geneContext": {
                   "valueId": "ENSG00000014216",
                   "symbol": "CAPN1",
@@ -162,6 +163,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Wang-2017-OCA2-B.json
+++ b/testdata/phenopackets/lirical/Wang-2017-OCA2-B.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:198063",
                 "geneContext": {
                   "valueId": "ENSG00000104044",
                   "symbol": "OCA2",
@@ -132,6 +133,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "15-28228568-T-C",
                 "geneContext": {
                   "valueId": "ENSG00000104044",
                   "symbol": "OCA2",

--- a/testdata/phenopackets/lirical/Wang-2018-CRX-IV_5.json
+++ b/testdata/phenopackets/lirical/Wang-2018-CRX-IV_5.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-48342860-T-TG",
                 "geneContext": {
                   "valueId": "ENSG00000105392",
                   "symbol": "CRX",

--- a/testdata/phenopackets/lirical/Wang-2018-SLC6A8-proband.json
+++ b/testdata/phenopackets/lirical/Wang-2018-SLC6A8-proband.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-152959399-C-A",
                 "geneContext": {
                   "valueId": "ENSG00000130821",
                   "symbol": "SLC6A8",

--- a/testdata/phenopackets/lirical/Warnecke-2007-SPG7-II-3.json
+++ b/testdata/phenopackets/lirical/Warnecke-2007-SPG7-II-3.json
@@ -269,6 +269,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "16-89620340-G-C",
                 "geneContext": {
                   "valueId": "ENSG00000197912",
                   "symbol": "SPG7",

--- a/testdata/phenopackets/lirical/Watanabe-2016-COL5A2-patient.json
+++ b/testdata/phenopackets/lirical/Watanabe-2016-COL5A2-patient.json
@@ -176,6 +176,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1695835",
                 "geneContext": {
                   "valueId": "ENSG00000204262",
                   "symbol": "COL5A2",
@@ -253,6 +254,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Whittock-2004-DLL3-II.6.json
+++ b/testdata/phenopackets/lirical/Whittock-2004-DLL3-II.6.json
@@ -140,6 +140,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:6835",
                 "geneContext": {
                   "valueId": "ENSG00000090932",
                   "symbol": "DLL3",
@@ -169,6 +170,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "19-39998024-CG-C",
                 "geneContext": {
                   "valueId": "ENSG00000090932",
                   "symbol": "DLL3",

--- a/testdata/phenopackets/lirical/Wiltshire-2013-LMNA-II3.json
+++ b/testdata/phenopackets/lirical/Wiltshire-2013-LMNA-II3.json
@@ -247,6 +247,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-156106776-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000160789",
                   "symbol": "LMNA",

--- a/testdata/phenopackets/lirical/Windpassinger-2017-CDK10-F1-II_1.json
+++ b/testdata/phenopackets/lirical/Windpassinger-2017-CDK10-F1-II_1.json
@@ -391,6 +391,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:440754",
                 "geneContext": {
                   "valueId": "ENSG00000185324",
                   "symbol": "CDK10",
@@ -468,6 +469,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Wollnik-2003-PAX3-proposita.json
+++ b/testdata/phenopackets/lirical/Wollnik-2003-PAX3-proposita.json
@@ -175,6 +175,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "2-223161750-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000135903",
                   "symbol": "PAX3",

--- a/testdata/phenopackets/lirical/Woo-2013-ASS1-5.json
+++ b/testdata/phenopackets/lirical/Woo-2013-ASS1-5.json
@@ -175,6 +175,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-133342110-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000130707",
                   "symbol": "ASS1",

--- a/testdata/phenopackets/lirical/Xie-2013-COMP-patient.json
+++ b/testdata/phenopackets/lirical/Xie-2013-COMP-patient.json
@@ -339,6 +339,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:2138262",
                 "geneContext": {
                   "valueId": "ENSG00000105664",
                   "symbol": "COMP",
@@ -415,6 +416,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Xiong-2019-ZIC2-proband.json
+++ b/testdata/phenopackets/lirical/Xiong-2019-ZIC2-proband.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "13-100635387-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000043355",
                   "symbol": "ZIC2",

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-1_II-3.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-1_II-3.json
@@ -247,6 +247,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:426072",
                 "geneContext": {
                   "valueId": "ENSG00000153015",
                   "symbol": "CWC27",
@@ -324,6 +325,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-3_II-1.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-3_II-1.json
@@ -67,6 +67,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-64181325-C-CA",
                 "geneContext": {
                   "valueId": "ENSG00000153015",
                   "symbol": "CWC27",

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-4_II-3.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-4_II-3.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-64082455-G-A",
                 "geneContext": {
                   "valueId": "ENSG00000153015",
                   "symbol": "CWC27",

--- a/testdata/phenopackets/lirical/Xu-2017-CWC27-II-4.json
+++ b/testdata/phenopackets/lirical/Xu-2017-CWC27-II-4.json
@@ -229,6 +229,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:426072",
                 "geneContext": {
                   "valueId": "ENSG00000153015",
                   "symbol": "CWC27",
@@ -306,6 +307,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Yalcin-Cakmakli-2014-FBXO7-ANK-07.json
+++ b/testdata/phenopackets/lirical/Yalcin-Cakmakli-2014-FBXO7-ANK-07.json
@@ -158,6 +158,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:4809",
                 "geneContext": {
                   "valueId": "ENSG00000100225",
                   "symbol": "FBXO7",
@@ -234,6 +235,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Yang-2016-MFN2-patient.json
+++ b/testdata/phenopackets/lirical/Yang-2016-MFN2-patient.json
@@ -233,6 +233,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-12059066-G-C",
                 "geneContext": {
                   "valueId": "ENSG00000116688",
                   "symbol": "MFN2",

--- a/testdata/phenopackets/lirical/Yao-2019-FGFR3-VI-5.json
+++ b/testdata/phenopackets/lirical/Yao-2019-FGFR3-VI-5.json
@@ -197,6 +197,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "4-1805540-C-T",
                 "geneContext": {
                   "valueId": "ENSG00000068078",
                   "symbol": "FGFR3",

--- a/testdata/phenopackets/lirical/Yoshida-1991-GLB1-KT.json
+++ b/testdata/phenopackets/lirical/Yoshida-1991-GLB1-KT.json
@@ -141,6 +141,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "3-33114129-A-G",
                 "geneContext": {
                   "valueId": "ENSG00000170266",
                   "symbol": "GLB1",

--- a/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_1.json
+++ b/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_1.json
@@ -572,6 +572,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:429339",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -649,6 +650,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zapata-Aldana-2019-TBCK-Patient_2.json
@@ -319,6 +319,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:429339",
                 "geneContext": {
                   "valueId": "ENSG00000145348",
                   "symbol": "TBCK",
@@ -396,6 +397,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Zemojtel-2014-KMT2A-P1.json
+++ b/testdata/phenopackets/lirical/Zemojtel-2014-KMT2A-P1.json
@@ -319,6 +319,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "11-118373871-G-T",
                 "geneContext": {
                   "valueId": "ENSG00000118058",
                   "symbol": "KMT2A",

--- a/testdata/phenopackets/lirical/Zenker-2007-KRAS-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zenker-2007-KRAS-Patient_2.json
@@ -283,6 +283,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:12589",
                 "geneContext": {
                   "valueId": "ENSG00000133703",
                   "symbol": "KRAS",
@@ -360,6 +361,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Zerkaoui-2015-GALC-child.json
+++ b/testdata/phenopackets/lirical/Zerkaoui-2015-GALC-child.json
@@ -139,6 +139,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:856001",
                 "geneContext": {
                   "valueId": "ENSG00000054983",
                   "symbol": "GALC",
@@ -168,6 +169,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1373081",
                 "geneContext": {
                   "valueId": "ENSG00000054983",
                   "symbol": "GALC",
@@ -245,6 +247,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Zhang-2009-EDA-proband.json
+++ b/testdata/phenopackets/lirical/Zhang-2009-EDA-proband.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "X-69255234-TG-T",
                 "geneContext": {
                   "valueId": "ENSG00000158813",
                   "symbol": "EDA",

--- a/testdata/phenopackets/lirical/Zhang-2011-TYRP1-patient_2.json
+++ b/testdata/phenopackets/lirical/Zhang-2011-TYRP1-patient_2.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1911492",
                 "geneContext": {
                   "valueId": "ENSG00000107165",
                   "symbol": "TYRP1",
@@ -114,6 +115,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:870834",
                 "geneContext": {
                   "valueId": "ENSG00000107165",
                   "symbol": "TYRP1",
@@ -191,6 +193,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Zhang-2016-RPS19-patient.json
+++ b/testdata/phenopackets/lirical/Zhang-2016-RPS19-patient.json
@@ -125,6 +125,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:6316",
                 "geneContext": {
                   "valueId": "ENSG00000105372",
                   "symbol": "RPS19",
@@ -202,6 +203,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_1.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_1.json
@@ -247,6 +247,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-29237342-T-TC",
                 "geneContext": {
                   "valueId": "ENSG00000176165",
                   "symbol": "FOXG1",

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_2.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_2.json
@@ -229,6 +229,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-29237179-A-T",
                 "geneContext": {
                   "valueId": "ENSG00000176165",
                   "symbol": "FOXG1",

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_3.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_3.json
@@ -193,6 +193,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "14-29236938-C-CG",
                 "geneContext": {
                   "valueId": "ENSG00000176165",
                   "symbol": "FOXG1",

--- a/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_4.json
+++ b/testdata/phenopackets/lirical/Zhang-2017-FOXG1-Patient_4.json
@@ -194,6 +194,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:1325763",
                 "geneContext": {
                   "valueId": "ENSG00000176165",
                   "symbol": "FOXG1",
@@ -271,6 +272,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Zhao-2008-KRT9-III_4.json
+++ b/testdata/phenopackets/lirical/Zhao-2008-KRT9-III_4.json
@@ -85,6 +85,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "17-39727775-A-C",
                 "geneContext": {
                   "valueId": "ENSG00000171403",
                   "symbol": "KRT9",

--- a/testdata/phenopackets/lirical/Zheng-2018-PNPLA6-II.2.json
+++ b/testdata/phenopackets/lirical/Zheng-2018-PNPLA6-II.2.json
@@ -175,6 +175,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:430847",
                 "geneContext": {
                   "valueId": "ENSG00000032444",
                   "symbol": "PNPLA6",
@@ -204,6 +205,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:430848",
                 "geneContext": {
                   "valueId": "ENSG00000032444",
                   "symbol": "PNPLA6",
@@ -280,6 +282,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"

--- a/testdata/phenopackets/lirical/Zhong-2016-PRPF3-020001-II_4.json
+++ b/testdata/phenopackets/lirical/Zhong-2016-PRPF3-020001-II_4.json
@@ -103,6 +103,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "1-150315847-C-G",
                 "geneContext": {
                   "valueId": "ENSG00000117360",
                   "symbol": "PRPF3",

--- a/testdata/phenopackets/lirical/Zhou-2018-FBN2-IV_7.json
+++ b/testdata/phenopackets/lirical/Zhou-2018-FBN2-IV_7.json
@@ -143,6 +143,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "5-127668649-A-C",
                 "geneContext": {
                   "valueId": "ENSG00000138829",
                   "symbol": "FBN2",

--- a/testdata/phenopackets/lirical/Zhu-2017-AIRE-V-1.json
+++ b/testdata/phenopackets/lirical/Zhu-2017-AIRE-V-1.json
@@ -211,6 +211,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "21-45706513-A-C",
                 "geneContext": {
                   "valueId": "ENSG00000160224",
                   "symbol": "AIRE",

--- a/testdata/phenopackets/lirical/de_Vries-2012-FANCC-proband.json
+++ b/testdata/phenopackets/lirical/de_Vries-2012-FANCC-proband.json
@@ -157,6 +157,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "9-98011506-TC-T",
                 "geneContext": {
                   "valueId": "ENSG00000158169",
                   "symbol": "FANCC",

--- a/testdata/phenopackets/lirical/van_Oorschot-2019-GFI1B-II_6.json
+++ b/testdata/phenopackets/lirical/van_Oorschot-2019-GFI1B-II_6.json
@@ -121,6 +121,7 @@
             "interpretationStatus": "CAUSATIVE",
             "variantInterpretation": {
               "variationDescriptor": {
+                "id": "clinvar:102428",
                 "geneContext": {
                   "valueId": "ENSG00000165702",
                   "symbol": "GFI1B",
@@ -198,6 +199,14 @@
         "name": "Online Mendelian Inheritance in Man",
         "url": "https://www.omim.org",
         "namespacePrefix": "OMIM"
+      },
+      {
+        "id": "clinvar",
+        "name": "Clinical Variation",
+        "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+        "version": "2023-04-06",
+        "namespacePrefix": "clinvar",
+        "iriPrefix": "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
       }
     ],
     "phenopacketSchemaVersion": "2.0.0"


### PR DESCRIPTION
Added the clinvar accession number to the `variationDescriptor` id field in the `interpretations` and the reference. For those that did not have a clinvar accession, these were given an id of `{chromosome}-{position}-{reference_allele}-{alternate_allele}`