### PR TITLE
changing VCF file format to be expected in file attributes 

### DIFF
--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -179,7 +179,7 @@ class PhenopacketUtil:
     def vcf_file_data(self, phenopacket_path: Path, vcf_dir: Path) -> File:
         """Retrieves the genome assembly and vcf name from a phenopacket."""
         compatible_genome_assembly = ["GRCh37", "hg19", "GRCh38", "hg38"]
-        vcf_data = [file for file in self.files() if file.file_attributes["fileFormat"] == "VCF"][0]
+        vcf_data = [file for file in self.files() if file.file_attributes["fileFormat"] == "vcf"][0]
         if not Path(vcf_data.uri).name.endswith(".vcf") and not Path(vcf_data.uri).name.endswith(
             ".vcf.gz"
         ):

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -267,7 +267,7 @@ class PhenopacketRebuilder:
         """Adds spiked vcf path to phenopacket."""
         phenopacket = copy(self.phenopacket)
         phenopacket_files = [
-            file for file in phenopacket.files if file.file_attributes["fileFormat"] != "VCF"
+            file for file in phenopacket.files if file.file_attributes["fileFormat"] != "vcf"
         ]
         phenopacket_files.append(spiked_vcf_file_data)
         del phenopacket.files[:]

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -537,13 +537,13 @@ class TestPhenopacketRebuilder(unittest.TestCase):
         updated_phenopacket = self.phenopacket_rebuilder.add_spiked_vcf_path(
             File(
                 uri=str(Path("input_dir/test_vcf_dir/test_1.vcf").absolute()),
-                file_attributes={"fileFormat": "VCF", "genomeAssembly": "GRCh37"},
+                file_attributes={"fileFormat": "vcf", "genomeAssembly": "GRCh37"},
             )
         )
         vcf_file = [
             file
             for file in updated_phenopacket.files
-            if file.file_attributes["fileFormat"] == "VCF"
+            if file.file_attributes["fileFormat"] == "vcf"
         ][0]
         self.assertEqual(vcf_file.uri, str(Path("input_dir/test_vcf_dir/test_1.vcf").absolute()))
 

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -241,7 +241,7 @@ proband = Phenopacket(
 phenopacket_files = [
     File(
         uri="test/path/to/test_1.vcf",
-        file_attributes={"fileFormat": "VCF", "genomeAssembly": "GRCh37"},
+        file_attributes={"fileFormat": "vcf", "genomeAssembly": "GRCh37"},
     ),
     File(
         uri="test_1.ped",
@@ -251,7 +251,7 @@ phenopacket_files = [
 incorrect_genome_assembly = [
     File(
         uri="test/path/to/test_1.vcf",
-        file_attributes={"fileFormat": "VCF", "genomeAssembly": "hg10"},
+        file_attributes={"fileFormat": "vcf", "genomeAssembly": "hg10"},
     ),
     File(
         uri="test_1.ped",
@@ -261,7 +261,7 @@ incorrect_genome_assembly = [
 incorrect_file_format = [
     File(
         uri="test/path/to/test_1.ped",
-        file_attributes={"fileFormat": "VCF", "genomeAssembly": "GRCh37"},
+        file_attributes={"fileFormat": "vcf", "genomeAssembly": "GRCh37"},
     ),
     File(
         uri="test_1.vcf",
@@ -442,7 +442,7 @@ class TestPhenopacketUtil(unittest.TestCase):
             vcf_file_data,
             File(
                 uri="input_dir/test_1.vcf",
-                file_attributes={"fileFormat": "VCF", "genomeAssembly": "GRCh37"},
+                file_attributes={"fileFormat": "vcf", "genomeAssembly": "GRCh37"},
             ),
         )
         with self.assertRaises(IncompatibleGenomeAssemblyError):


### PR DESCRIPTION
In the `PhenopacketUtil` class and `PhenopacketRebuilder` class, where the file format of the VCF file is either being added/checked/file name taken from the path, these methods looked for files where the file attributes matched `VCF` these needed to be changed to `vcf` for consistency with what is added to the phenopacket after the VCF is spiked as well as what is described in the phenopacket schema documentation