### PR TITLE
decode encoded characters from uri path

### DIFF
--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -2,6 +2,7 @@
 import gzip
 import logging
 import secrets
+import urllib.parse
 from copy import copy
 from dataclasses import dataclass
 from pathlib import Path
@@ -297,7 +298,7 @@ def generate_spiked_vcf_file(
     )
     VcfWriter(spiked_vcf, spiked_vcf_path).write_vcf_file()
     return File(
-        uri=spiked_vcf_path.as_uri(),
+        uri=urllib.parse.unquote(spiked_vcf_path.as_uri()),
         file_attributes={"fileFormat": "vcf", "genomeAssembly": vcf_assembly},
     )
 


### PR DESCRIPTION
The URI path written to the phenopacket after spiking the VCF is now decoded before writing. Using the built-in library `urllib` to decode any URL-encoded characters in the path