### PR TITLE
122 add info variable to probandcausativevariant dataclass

### DIFF
--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -200,8 +200,8 @@ class VcfSpiker:
             proband_variant_data.info
             if proband_variant_data.info is not None
             else "SPIKED_VARIANT_" + proband_variant_data.genotype.upper(),
-            "GT:AD:DP:GQ:PL",
-            genotype_codes[proband_variant_data.genotype.lower()] + ":0,2:2:12:180,12,0" + "\n",
+            "GT",
+            genotype_codes[proband_variant_data.genotype.lower()] + "\n",
         ]
 
     def construct_vcf_records(self):

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -192,10 +192,14 @@ class VcfSpiker:
             str(proband_variant_data.variant.pos),
             ".",
             proband_variant_data.variant.ref,
-            proband_variant_data.variant.alt,
+            f"<{proband_variant_data.variant.alt}>"
+            if proband_variant_data.variant.ref == "N"
+            else proband_variant_data.variant.alt,
             "100",
             "PASS",
-            "SPIKED_VARIANT_" + proband_variant_data.genotype.upper(),
+            proband_variant_data.info
+            if proband_variant_data.info is not None
+            else "SPIKED_VARIANT_" + proband_variant_data.genotype.upper(),
             "GT:AD:DP:GQ:PL",
             genotype_codes[proband_variant_data.genotype.lower()] + ":0,2:2:12:180,12,0" + "\n",
         ]

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -48,6 +48,7 @@ class ProbandCausativeVariant:
     assembly: str
     variant: GenomicVariant
     genotype: str
+    info: str = None
 
 
 @dataclass
@@ -168,6 +169,7 @@ class PhenopacketUtil:
                         vcf_record.alt,
                     ),
                     genotype.label,
+                    vcf_record.info,
                 )
                 all_variants.append(variant_data)
         return all_variants

--- a/tests/test_create_spiked_vcf.py
+++ b/tests/test_create_spiked_vcf.py
@@ -178,11 +178,31 @@ class TestVcfSpiker(unittest.TestCase):
             ],
             VcfHeader("TEMPLATE", "GRCh37", True),
         )
+        cls.structural_variant_vcf_spiker = VcfSpiker(
+            hg38_vcf,
+            [
+                ProbandCausativeVariant(
+                    "TEST1",
+                    "GRCh38",
+                    GenomicVariant("5", 134858794, "N", "DEL"),
+                    "heterozygous",
+                    "SVTYPE=DEL;END=135099433;SVLEN=-269958227",
+                )
+            ],
+            VcfHeader("TEMPLATE", "GRCh38", True),
+        )
         cls.variant = ProbandCausativeVariant(
             "TEST1",
             "GRCh37",
             GenomicVariant("1", 886190, "G", "A"),
             "heterozygous",
+        )
+        cls.structural_variant = ProbandCausativeVariant(
+            proband_id="test-subject-1",
+            assembly="GRCh38",
+            variant=GenomicVariant(chrom="5", pos=134858794, ref="N", alt="DEL"),
+            genotype="heterozygous",
+            info="SVTYPE=DEL;END=135099433;SVLEN=-269958227",
         )
 
     def test_construct_variant(self):
@@ -197,6 +217,23 @@ class TestVcfSpiker(unittest.TestCase):
                 "100",
                 "PASS",
                 "SPIKED_VARIANT_HETEROZYGOUS",
+                "GT:AD:DP:GQ:PL",
+                "0/1:0,2:2:12:180,12,0\n",
+            ],
+        )
+
+    def test_construct_variant_structural_variant(self):
+        self.assertEqual(
+            self.structural_variant_vcf_spiker.construct_variant_entry(self.structural_variant),
+            [
+                "chr5",
+                "134858794",
+                ".",
+                "N",
+                "<DEL>",
+                "100",
+                "PASS",
+                "SVTYPE=DEL;END=135099433;SVLEN=-269958227",
                 "GT:AD:DP:GQ:PL",
                 "0/1:0,2:2:12:180,12,0\n",
             ],

--- a/tests/test_create_spiked_vcf.py
+++ b/tests/test_create_spiked_vcf.py
@@ -217,8 +217,8 @@ class TestVcfSpiker(unittest.TestCase):
                 "100",
                 "PASS",
                 "SPIKED_VARIANT_HETEROZYGOUS",
-                "GT:AD:DP:GQ:PL",
-                "0/1:0,2:2:12:180,12,0\n",
+                "GT",
+                "0/1\n",
             ],
         )
 
@@ -234,29 +234,26 @@ class TestVcfSpiker(unittest.TestCase):
                 "100",
                 "PASS",
                 "SVTYPE=DEL;END=135099433;SVLEN=-269958227",
-                "GT:AD:DP:GQ:PL",
-                "0/1:0,2:2:12:180,12,0\n",
+                "GT",
+                "0/1\n",
             ],
         )
 
     def test_construct_vcf_records_single_variant(self):
         self.assertEqual(
             self.vcf_spiker.construct_vcf_records()[59],
-            "chr1\t886190\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HETEROZYGOUS\t"
-            "GT:AD:DP:GQ:PL\t0/1:0,2:2:12:180,12,0\n",
+            "chr1\t886190\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HETEROZYGOUS\t" "GT\t0/1\n",
         )
 
     def test_construct_vcf_records_multiple_variants(self):
         updated_records = self.vcf_spiker_multiple_variants.construct_vcf_records()
         self.assertEqual(
             updated_records[59],
-            "chr1\t886190\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HETEROZYGOUS\t"
-            "GT:AD:DP:GQ:PL\t0/1:0,2:2:12:180,12,0\n",
+            "chr1\t886190\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HETEROZYGOUS\t" "GT\t0/1\n",
         )
         self.assertEqual(
             updated_records[64],
-            "chr3\t61580860\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HOMOZYGOUS\t"
-            "GT:AD:DP:GQ:PL\t1/1:0,2:2:12:180,12,0\n",
+            "chr3\t61580860\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HOMOZYGOUS\t" "GT\t1/1\n",
         )
 
     def test_construct_header(self):

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -86,6 +86,40 @@ interpretations = [
         ),
     )
 ]
+
+structural_variant_interpretations = [
+    Interpretation(
+        id="test-subject-1-int",
+        progress_status="SOLVED",
+        diagnosis=Diagnosis(
+            genomic_interpretations=[
+                GenomicInterpretation(
+                    subject_or_biosample_id="test-subject-1",
+                    interpretation_status=4,
+                    variant_interpretation=VariantInterpretation(
+                        acmg_pathogenicity_classification="NOT_PROVIDED",
+                        therapeutic_actionability="UNKNOWN_ACTIONABILITY",
+                        variation_descriptor=VariationDescriptor(
+                            gene_context=GeneDescriptor(value_id="ENSG00000069011", symbol="PITX1"),
+                            vcf_record=VcfRecord(
+                                genome_assembly="GRCh38",
+                                chrom="5",
+                                pos=134858794,
+                                ref="N",
+                                alt="DEL",
+                                info="SVTYPE=DEL;END=135099433;SVLEN=-269958227",
+                            ),
+                            allelic_state=OntologyClass(
+                                id="GENO:0000135",
+                                label="heterozygous",
+                            ),
+                        ),
+                    ),
+                ),
+            ]
+        ),
+    )
+]
 updated_interpretations = [
     Interpretation(
         id="test-subject-1-int",
@@ -291,6 +325,15 @@ phenopacket = Phenopacket(
     files=phenopacket_files,
     meta_data=phenopacket_metadata,
 )
+
+structural_variant_phenopacket = Phenopacket(
+    id="test-subject",
+    subject=Individual(id="test-subject-1", sex=1),
+    phenotypic_features=phenotypic_features_with_excluded,
+    interpretations=structural_variant_interpretations,
+    files=phenopacket_files,
+    meta_data=phenopacket_metadata,
+)
 phenopacket_no_variant_data = Phenopacket(
     id="test-subject",
     subject=Individual(id="test-subject-1", sex=1),
@@ -370,6 +413,7 @@ class TestPhenopacketUtil(unittest.TestCase):
         cls.phenopacket = PhenopacketUtil(phenopacket)
         cls.phenopacket_no_variants = PhenopacketUtil(phenopacket_no_variant_data)
         cls.phenopacket_excluded_pf = PhenopacketUtil(phenopacket_with_all_excluded_terms)
+        cls.structural_variant_phenopacket = PhenopacketUtil(structural_variant_phenopacket)
         cls.family = PhenopacketUtil(family)
         cls.family_incorrect_files = PhenopacketUtil(family_incorrect_files)
         cls.family_incorrect_file_format = PhenopacketUtil(family_incorrect_file_format)
@@ -424,9 +468,44 @@ class TestPhenopacketUtil(unittest.TestCase):
     def test_interpretations_family(self):
         self.assertEqual(list(self.family.interpretations()), interpretations)
 
-    def test_causative_variants(self):
+    def test_causative_variants_type(self):
         for causative_variant in self.phenopacket.causative_variants():
             self.assertEqual(type(causative_variant), ProbandCausativeVariant)
+
+    def test_causative_variants(self):
+        self.assertEqual(
+            self.phenopacket.causative_variants(),
+            [
+                ProbandCausativeVariant(
+                    proband_id="test-subject-1",
+                    assembly="GRCh37",
+                    variant=GenomicVariant(chrom="X", pos=54492285, ref="C", alt="T"),
+                    genotype="hemizygous",
+                    info="",
+                ),
+                ProbandCausativeVariant(
+                    proband_id="test-subject-1",
+                    assembly="GRCh37",
+                    variant=GenomicVariant(chrom="18", pos=67691994, ref="G", alt="A"),
+                    genotype="compound heterozygous",
+                    info="",
+                ),
+            ],
+        )
+
+    def test_causative_variants_structural(self):
+        self.assertEqual(
+            self.structural_variant_phenopacket.causative_variants(),
+            [
+                ProbandCausativeVariant(
+                    proband_id="test-subject-1",
+                    assembly="GRCh38",
+                    variant=GenomicVariant(chrom="5", pos=134858794, ref="N", alt="DEL"),
+                    genotype="heterozygous",
+                    info="SVTYPE=DEL;END=135099433;SVLEN=-269958227",
+                )
+            ],
+        )
 
     def test_files_phenopacket(self):
         self.assertEqual(list(self.phenopacket.files()), phenopacket_files)


### PR DESCRIPTION
Added an `info` field to the `ProbandCausativeVariant` data class. This is implemented in the `causative_variants()` method, when the phenopacket variants are retrieved for spiking into the VCF file. This `info` field is now spiked into the VCF record and structural variants are spiked correctly according to the VCF specification e.g., a deletion variant will contain `N` in the `ref` field and `<DEL>` in the `alt` field. Added relevant tests for any new functionality