### PR TITLE
fix blank info field in spiked vcf records

### DIFF
--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -206,7 +206,7 @@ class VcfSpiker:
             "100",
             "PASS",
             proband_variant_data.info
-            if proband_variant_data.info is not None
+            if proband_variant_data.info != ""
             else "SPIKED_VARIANT_" + proband_variant_data.genotype.upper(),
             "GT",
             genotype_codes[proband_variant_data.genotype.lower()] + "\n",

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -206,7 +206,7 @@ class VcfSpiker:
             "100",
             "PASS",
             proband_variant_data.info
-            if not proband_variant_data.info
+            if proband_variant_data.info
             else "SPIKED_VARIANT_" + proband_variant_data.genotype.upper(),
             "GT",
             genotype_codes[proband_variant_data.genotype.lower()] + "\n",

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -206,7 +206,7 @@ class VcfSpiker:
             "100",
             "PASS",
             proband_variant_data.info
-            if proband_variant_data.info != ""
+            if not proband_variant_data.info
             else "SPIKED_VARIANT_" + proband_variant_data.genotype.upper(),
             "GT",
             genotype_codes[proband_variant_data.genotype.lower()] + "\n",

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -205,9 +205,7 @@ class VcfSpiker:
             else proband_variant_data.variant.alt,
             "100",
             "PASS",
-            proband_variant_data.info
-            if proband_variant_data.info
-            else "SPIKED_VARIANT_" + proband_variant_data.genotype.upper(),
+            proband_variant_data.info if proband_variant_data.info else ".",
             "GT",
             genotype_codes[proband_variant_data.genotype.lower()] + "\n",
         ]

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -48,7 +48,7 @@ class ProbandCausativeVariant:
     assembly: str
     variant: GenomicVariant
     genotype: str
-    info: str = None
+    info: str = ""
 
 
 @dataclass

--- a/tests/test_create_spiked_vcf.py
+++ b/tests/test_create_spiked_vcf.py
@@ -315,7 +315,7 @@ class TestVcfSpiker(unittest.TestCase):
                 "A",
                 "100",
                 "PASS",
-                "SPIKED_VARIANT_HETEROZYGOUS",
+                ".",
                 "GT",
                 "0/1\n",
             ],
@@ -341,18 +341,18 @@ class TestVcfSpiker(unittest.TestCase):
     def test_construct_vcf_records_single_variant(self):
         self.assertEqual(
             self.vcf_spiker.construct_vcf_records()[40],
-            "chr1\t886190\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HETEROZYGOUS\t" "GT\t0/1\n",
+            "chr1\t886190\t.\tG\tA\t100\tPASS\t.\t" "GT\t0/1\n",
         )
 
     def test_construct_vcf_records_multiple_variants(self):
         updated_records = self.vcf_spiker_multiple_variants.construct_vcf_records()
         self.assertEqual(
             updated_records[40],
-            "chr1\t886190\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HETEROZYGOUS\t" "GT\t0/1\n",
+            "chr1\t886190\t.\tG\tA\t100\tPASS\t.\t" "GT\t0/1\n",
         )
         self.assertEqual(
             updated_records[45],
-            "chr3\t61580860\t.\tG\tA\t100\tPASS\tSPIKED_VARIANT_HOMOZYGOUS\t" "GT\t1/1\n",
+            "chr3\t61580860\t.\tG\tA\t100\tPASS\t.\t" "GT\t1/1\n",
         )
 
     def test_construct_header(self):


### PR DESCRIPTION
Fixed the occurrence of a blank `INFO` field in spiked VCF records - this happened because the absence of a value in the phenopacket is not `None` and is instead an empty string 