### PR TITLE
165 implement support within analysis methods for disease matching

### DIFF
--- a/src/pheval/analyse/analysis.py
+++ b/src/pheval/analyse/analysis.py
@@ -6,26 +6,29 @@ from pathlib import Path
 import click
 import pandas as pd
 
-from pheval.analyse.generate_plots import (
-    TrackGenePrioritisation,
-    TrackPrioritisation,
-    TrackVariantPrioritisation,
-)
+from pheval.analyse.generate_plots import TrackPrioritisation, TrackRunPrioritisation
 from pheval.analyse.generate_summary_outputs import (
     RankStatsWriter,
+    generate_benchmark_comparison_disease_output,
     generate_benchmark_comparison_gene_output,
     generate_benchmark_comparison_variant_output,
+    generate_benchmark_disease_output,
     generate_benchmark_gene_output,
     generate_benchmark_variant_output,
 )
 from pheval.analyse.rank_stats import RankStats
-from pheval.post_processing.post_processing import RankedPhEvalGeneResult, RankedPhEvalVariantResult
+from pheval.post_processing.post_processing import (
+    RankedPhEvalDiseaseResult,
+    RankedPhEvalGeneResult,
+    RankedPhEvalVariantResult,
+)
 from pheval.prepare.custom_exceptions import InputError
 from pheval.utils.file_utils import all_files, files_with_suffix, obtain_closest_file_name
 from pheval.utils.phenopacket_utils import (
     GenomicVariant,
     PhenopacketUtil,
     ProbandCausativeGene,
+    ProbandDisease,
     phenopacket_reader,
 )
 
@@ -37,18 +40,26 @@ def _read_standardised_result(standardised_result_path: Path) -> dict:
 
 def parse_pheval_gene_result(pheval_gene_result: pd.DataFrame) -> [RankedPhEvalGeneResult]:
     """Parse PhEval gene result into RankedPhEvalGeneResult dataclass."""
-    ranked_gene_results = []
-    for _index, result in pheval_gene_result.iterrows():
-        ranked_gene_results.append((RankedPhEvalGeneResult(*result)))
-    return ranked_gene_results
+    return [
+        RankedPhEvalGeneResult(**row._asdict())
+        for row in pheval_gene_result.itertuples(index=False)
+    ]
 
 
 def parse_pheval_variant_result(pheval_variant_result: pd.DataFrame) -> [RankedPhEvalVariantResult]:
     """Parse PhEval variant result into RankedPhEvalVariantResult dataclass."""
-    ranked_variant_results = []
-    for _index, result in pheval_variant_result.iterrows():
-        ranked_variant_results.append(RankedPhEvalVariantResult(*result))
-    return ranked_variant_results
+    return [
+        RankedPhEvalVariantResult(**row._asdict())
+        for row in pheval_variant_result.itertuples(index=False)
+    ]
+
+
+def parse_pheval_disease_result(pheval_disease_result: pd.DataFrame) -> [RankedPhEvalDiseaseResult]:
+    """Parse PhEval disease result into RankedPhEvalDiseaseResult dataclass."""
+    return [
+        RankedPhEvalDiseaseResult(**row._asdict())
+        for row in pheval_disease_result.itertuples(index=False)
+    ]
 
 
 @dataclass
@@ -66,6 +77,15 @@ class VariantPrioritisationResult:
 
     phenopacket_path: Path
     variant: GenomicVariant
+    rank: int = 0
+
+
+@dataclass
+class DiseasePrioritisationResult:
+    """Store rank data for known diseases."""
+
+    phenopacket_path: Path
+    disease: ProbandDisease
     rank: int = 0
 
 
@@ -89,14 +109,23 @@ class PrioritisationRankRecorder:
             [variant.chrom, str(variant.pos), variant.ref, variant.alt]
         )
 
+    def _record_disease_rank(self) -> None:
+        """Record disease prioritisation rank."""
+        self.run_comparison[self.index][
+            "Disease"
+        ] = self.prioritisation_result.disease.disease_identifier
+
     def record_rank(self) -> None:
         """Records the rank for different runs."""
         self.run_comparison[self.index][
             "Phenopacket"
         ] = self.prioritisation_result.phenopacket_path.name
-        self._record_gene_rank() if type(
-            self.prioritisation_result
-        ) is GenePrioritisationResult else self._record_variant_rank()
+        if type(self.prioritisation_result) is GenePrioritisationResult:
+            self._record_gene_rank()
+        elif type(self.prioritisation_result) is VariantPrioritisationResult:
+            self._record_variant_rank()
+        elif type(self.prioritisation_result) is DiseasePrioritisationResult:
+            self._record_disease_rank()
         self.run_comparison[self.index][self.directory] = self.prioritisation_result.rank
 
 
@@ -194,7 +223,7 @@ class AssessGenePrioritisation:
             for standardised_gene_result in self.standardised_gene_results:
                 if (
                     gene.gene_identifier == standardised_gene_result.gene_identifier
-                    or gene.gene_symbol == standardised_gene_result.gene_identifier
+                    or gene.gene_symbol == standardised_gene_result.gene_symbol
                 ):
                     gene_match = self._record_matched_gene(
                         gene, rank_stats, standardised_gene_result
@@ -306,6 +335,102 @@ class AssessVariantPrioritisation:
             ).record_rank()
 
 
+class AssessDiseasePrioritisation:
+    def __init__(
+        self,
+        phenopacket_path: Path,
+        results_dir: Path,
+        standardised_disease_results: [RankedPhEvalDiseaseResult],
+        threshold: float,
+        score_order: str,
+        proband_diseases: [ProbandDisease],
+    ):
+        self.phenopacket_path = phenopacket_path
+        self.results_dir = results_dir
+        self.standardised_disease_results = standardised_disease_results
+        self.threshold = threshold
+        self.score_order = score_order
+        self.proband_diseases = proband_diseases
+
+    def _record_disease_prioritisation_match(
+        self,
+        disease: ProbandDisease,
+        result_entry: RankedPhEvalDiseaseResult,
+        rank_stats: RankStats,
+    ) -> DiseasePrioritisationResult:
+        """Record the disease prioritisation rank if found within results."""
+        rank = result_entry.rank
+        rank_stats.add_rank(rank)
+        return DiseasePrioritisationResult(self.phenopacket_path, disease, rank)
+
+    def _assess_disease_with_threshold_ascending_order(
+        self,
+        result_entry: RankedPhEvalDiseaseResult,
+        disease: ProbandDisease,
+        rank_stats: RankStats,
+    ) -> DiseasePrioritisationResult:
+        """Record the disease prioritisation rank if it meets the ascending order threshold."""
+        if float(self.threshold) > float(result_entry.score):
+            return self._record_disease_prioritisation_match(disease, result_entry, rank_stats)
+
+    def _assess_disease_with_threshold(
+        self,
+        result_entry: RankedPhEvalDiseaseResult,
+        disease: ProbandDisease,
+        rank_stats: RankStats,
+    ) -> DiseasePrioritisationResult:
+        """Record the disease prioritisation rank if it meets the score threshold."""
+        if float(self.threshold) < float(result_entry.score):
+            return self._record_disease_prioritisation_match(disease, result_entry, rank_stats)
+
+    def _record_matched_disease(
+        self,
+        disease: ProbandDisease,
+        rank_stats: RankStats,
+        standardised_disease_result: RankedPhEvalDiseaseResult,
+    ) -> DiseasePrioritisationResult:
+        """Return the gene rank result - dealing with the specification of a threshold."""
+        if float(self.threshold) == 0.0:
+            return self._record_disease_prioritisation_match(
+                disease, standardised_disease_result, rank_stats
+            )
+        else:
+            return (
+                self._assess_disease_with_threshold(
+                    standardised_disease_result, disease, rank_stats
+                )
+                if self.score_order != "ascending"
+                else self._assess_disease_with_threshold_ascending_order(
+                    standardised_disease_result, disease, rank_stats
+                )
+            )
+
+    def assess_disease_prioritisation(
+        self, rank_stats: RankStats, rank_records: defaultdict
+    ) -> None:
+        """Assess disease prioritisation."""
+        for disease in self.proband_diseases:
+            rank_stats.total += 1
+            disease_match = DiseasePrioritisationResult(self.phenopacket_path, disease)
+            for standardised_disease_result in self.standardised_disease_results:
+                if (
+                    disease.disease_identifier == standardised_disease_result.disease_identifier
+                    or disease.disease_name == standardised_disease_result.disease_name
+                ):
+                    disease_match = self._record_matched_disease(
+                        disease, rank_stats, standardised_disease_result
+                    )
+                    break
+            PrioritisationRankRecorder(
+                rank_stats.total,
+                self.results_dir,
+                DiseasePrioritisationResult(self.phenopacket_path, disease)
+                if disease_match is None
+                else disease_match,
+                rank_records,
+            ).record_rank()
+
+
 def _obtain_causative_genes(phenopacket_path: Path) -> [ProbandCausativeGene]:
     """Obtain causative genes from a phenopacket."""
     phenopacket = phenopacket_reader(phenopacket_path)
@@ -318,6 +443,13 @@ def _obtain_causative_variants(phenopacket_path: Path) -> [GenomicVariant]:
     phenopacket = phenopacket_reader(phenopacket_path)
     phenopacket_util = PhenopacketUtil(phenopacket)
     return phenopacket_util.diagnosed_variants()
+
+
+def _obtain_causative_diseases(phenopacket_path: Path) -> [ProbandDisease]:
+    """Obtain known diseases from a phenopacket."""
+    phenopacket = phenopacket_reader(phenopacket_path)
+    phenopacket_util = PhenopacketUtil(phenopacket)
+    return phenopacket_util.diagnoses()
 
 
 def _assess_phenopacket_gene_prioritisation(
@@ -368,19 +500,46 @@ def _assess_phenopacket_variant_prioritisation(
     ).assess_variant_prioritisation(variant_rank_stats, variant_rank_comparison)
 
 
+def _assess_phenopacket_disease_prioritisation(
+    standardised_disease_result: Path,
+    score_order: str,
+    results_dir_and_input: TrackInputOutputDirectories,
+    threshold: float,
+    disease_rank_stats: RankStats,
+    disease_rank_comparison: defaultdict,
+) -> None:
+    """Assess gene prioritisation for a phenopacket."""
+    phenopacket_path = obtain_closest_file_name(
+        standardised_disease_result, all_files(results_dir_and_input.phenopacket_dir)
+    )
+    pheval_disease_result = _read_standardised_result(standardised_disease_result)
+    proband_diseases = _obtain_causative_diseases(phenopacket_path)
+    AssessDiseasePrioritisation(
+        phenopacket_path,
+        results_dir_and_input.results_dir.joinpath("pheval_disease_results/"),
+        parse_pheval_disease_result(pheval_disease_result),
+        threshold,
+        score_order,
+        proband_diseases,
+    ).assess_disease_prioritisation(disease_rank_stats, disease_rank_comparison)
+
+
 def _assess_prioritisation_for_results_directory(
     results_directory_and_input: TrackInputOutputDirectories,
     score_order: str,
     threshold: float,
     gene_rank_comparison: defaultdict,
     variant_rank_comparison: defaultdict,
+    disease_rank_comparison: defaultdict,
     gene_stats_writer: RankStatsWriter,
     variants_stats_writer: RankStatsWriter,
+    disease_stats_writer: RankStatsWriter,
     gene_analysis: bool,
     variant_analysis: bool,
+    disease_analysis: bool,
 ) -> TrackPrioritisation:
     """Assess prioritisation for a single results directory."""
-    gene_rank_stats, variant_rank_stats = RankStats(), RankStats()
+    gene_rank_stats, variant_rank_stats, disease_rank_stats = RankStats(), RankStats(), RankStats()
     if gene_analysis:
         for standardised_result in files_with_suffix(
             results_directory_and_input.results_dir.joinpath("pheval_gene_results/"), ".tsv"
@@ -406,22 +565,43 @@ def _assess_prioritisation_for_results_directory(
                 variant_rank_stats,
                 variant_rank_comparison,
             )
+    if disease_analysis:
+        for standardised_result in files_with_suffix(
+            results_directory_and_input.results_dir.joinpath("pheval_disease_results/"),
+            ".tsv",
+        ):
+            _assess_phenopacket_disease_prioritisation(
+                standardised_result,
+                score_order,
+                results_directory_and_input,
+                threshold,
+                disease_rank_stats,
+                disease_rank_comparison,
+            )
     gene_stats_writer.write_row(
         results_directory_and_input.results_dir, gene_rank_stats
     ) if gene_analysis else None
     variants_stats_writer.write_row(
         results_directory_and_input.results_dir, variant_rank_stats
     ) if variant_analysis else None
-    return TrackPrioritisation(
-        gene_prioritisation=TrackGenePrioritisation(
+    disease_stats_writer.write_row(
+        results_directory_and_input.results_dir, disease_rank_stats
+    ) if disease_analysis else None
+    return TrackRunPrioritisation(
+        gene_prioritisation=TrackPrioritisation(
             results_dir=results_directory_and_input.results_dir,
             ranks=gene_rank_comparison,
             rank_stats=gene_rank_stats,
         ),
-        variant_prioritisation=TrackVariantPrioritisation(
+        variant_prioritisation=TrackPrioritisation(
             results_dir=results_directory_and_input.results_dir,
             ranks=variant_rank_comparison,
             rank_stats=variant_rank_stats,
+        ),
+        disease_prioritisation=TrackPrioritisation(
+            results_dir=results_directory_and_input.results_dir,
+            ranks=disease_rank_comparison,
+            rank_stats=disease_rank_stats,
         ),
     )
 
@@ -433,6 +613,7 @@ def benchmark_directory(
     threshold: float,
     gene_analysis: bool,
     variant_analysis: bool,
+    disease_analysis: bool,
     plot_type: str,
 ) -> None:
     """Benchmark prioritisation performance for a single directory."""
@@ -442,22 +623,34 @@ def benchmark_directory(
     variants_stats_writer = (
         RankStatsWriter(Path(output_prefix + "-variant_summary.tsv")) if variant_analysis else None
     )
-    gene_rank_comparison, variant_rank_comparison = defaultdict(dict), defaultdict(dict)
+    disease_stats_writer = (
+        RankStatsWriter(Path(output_prefix + "-disease_summary.tsv")) if disease_analysis else None
+    )
+    gene_rank_comparison, variant_rank_comparison, disease_rank_comparison = (
+        defaultdict(dict),
+        defaultdict(dict),
+        defaultdict(dict),
+    )
     prioritisation_data = _assess_prioritisation_for_results_directory(
         results_dir_and_input,
         score_order,
         threshold,
         gene_rank_comparison,
         variant_rank_comparison,
+        disease_rank_comparison,
         gene_stats_writer,
         variants_stats_writer,
+        disease_stats_writer,
         gene_analysis,
         variant_analysis,
+        disease_analysis,
     )
     generate_benchmark_gene_output(prioritisation_data, plot_type) if gene_analysis else None
     generate_benchmark_variant_output(prioritisation_data, plot_type) if variant_analysis else None
+    generate_benchmark_disease_output(prioritisation_data, plot_type) if disease_analysis else None
     gene_stats_writer.close() if gene_analysis else None
     variants_stats_writer.close() if variant_analysis else None
+    disease_stats_writer.close() if disease_analysis else None
 
 
 def benchmark_runs(
@@ -467,6 +660,7 @@ def benchmark_runs(
     threshold: float,
     gene_analysis: bool,
     variant_analysis: bool,
+    disease_analysis: bool,
     plot_type: str,
 ) -> None:
     """Benchmark several result directories."""
@@ -476,19 +670,29 @@ def benchmark_runs(
     variants_stats_writer = (
         RankStatsWriter(Path(output_prefix + "-variant_summary.tsv")) if variant_analysis else None
     )
+    disease_stats_writer = (
+        RankStatsWriter(Path(output_prefix + "-disease_summary.tsv")) if disease_analysis else None
+    )
     prioritisation_stats_for_runs = []
     for results_dir_and_input in results_directories:
-        gene_rank_comparison, variant_rank_comparison = defaultdict(dict), defaultdict(dict)
+        gene_rank_comparison, variant_rank_comparison, disease_rank_comparison = (
+            defaultdict(dict),
+            defaultdict(dict),
+            defaultdict(dict),
+        )
         prioritisation_stats = _assess_prioritisation_for_results_directory(
             results_dir_and_input,
             score_order,
             threshold,
             gene_rank_comparison,
             variant_rank_comparison,
+            disease_rank_comparison,
             gene_stats_writer,
             variants_stats_writer,
+            disease_stats_writer,
             gene_analysis,
             variant_analysis,
+            disease_analysis,
         )
         prioritisation_stats_for_runs.append(prioritisation_stats)
     generate_benchmark_comparison_gene_output(
@@ -497,8 +701,12 @@ def benchmark_runs(
     generate_benchmark_comparison_variant_output(
         prioritisation_stats_for_runs, plot_type
     ) if variant_analysis else None
+    generate_benchmark_comparison_disease_output(
+        prioritisation_stats_for_runs, plot_type
+    ) if disease_analysis else None
     gene_stats_writer.close() if gene_analysis else None
     variants_stats_writer.close() if variant_analysis else None
+    disease_stats_writer.close() if disease_analysis else None
 
 
 @click.command()
@@ -561,8 +769,16 @@ def benchmark_runs(
     help="Specify analysis for variant prioritisation",
 )
 @click.option(
+    "--disease-analysis/--no-disease-analysis",
+    default=False,
+    required=False,
+    type=bool,
+    show_default=True,
+    help="Specify analysis for disease prioritisation",
+)
+@click.option(
     "--plot-type",
-    "-p",
+    "-pt",
     default="bar_stacked",
     show_default=True,
     type=click.Choice(["bar_stacked", "bar_cumulative", "bar_non_cumulative"]),
@@ -576,11 +792,12 @@ def benchmark(
     threshold: float,
     gene_analysis: bool,
     variant_analysis: bool,
+    disease_analysis: bool,
     plot_type: str,
 ):
     """Benchmark the gene/variant prioritisation performance for a single run."""
-    if not gene_analysis and not variant_analysis:
-        raise InputError("Need to specify gene analysis and/or variant analysis.")
+    if not gene_analysis and not variant_analysis and not disease_analysis:
+        raise InputError("Need to specify gene analysis and/or variant and/or disease analysis.")
     benchmark_directory(
         TrackInputOutputDirectories(results_dir=directory, phenopacket_dir=phenopacket_dir),
         score_order,
@@ -588,6 +805,7 @@ def benchmark(
         threshold,
         gene_analysis,
         variant_analysis,
+        disease_analysis,
         plot_type,
     )
 
@@ -645,8 +863,16 @@ def benchmark(
     help="Specify analysis for variant prioritisation",
 )
 @click.option(
+    "--disease-analysis/--no-disease-analysis",
+    default=False,
+    required=False,
+    type=bool,
+    show_default=True,
+    help="Specify analysis for disease prioritisation",
+)
+@click.option(
     "--plot-type",
-    "-p",
+    "-pt",
     default="bar_stacked",
     show_default=True,
     type=click.Choice(["bar_stacked", "bar_cumulative", "bar_non_cumulative"]),
@@ -659,11 +885,12 @@ def benchmark_comparison(
     threshold: float,
     gene_analysis: bool,
     variant_analysis: bool,
+    disease_analysis: bool,
     plot_type: str,
 ):
     """Benchmark the gene/variant prioritisation performance for two runs."""
-    if not gene_analysis and not variant_analysis:
-        raise InputError("Need to specify gene analysis and/or variant analysis.")
+    if not gene_analysis and not variant_analysis and not disease_analysis:
+        raise InputError("Need to specify gene analysis and/or variant and/or disease analysis.")
     benchmark_runs(
         _parse_run_data_text_file(run_data),
         score_order,
@@ -671,5 +898,6 @@ def benchmark_comparison(
         threshold,
         gene_analysis,
         variant_analysis,
+        disease_analysis,
         plot_type,
     )

--- a/src/pheval/analyse/analysis.py
+++ b/src/pheval/analyse/analysis.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import click
 import pandas as pd
 
-from pheval.analyse.generate_plots import TrackPrioritisation, TrackRunPrioritisation
+from pheval.analyse.generate_plots import AnalysisResults, TrackRunPrioritisation
 from pheval.analyse.generate_summary_outputs import (
     RankStatsWriter,
     generate_benchmark_comparison_disease_output,
@@ -537,7 +537,7 @@ def _assess_prioritisation_for_results_directory(
     gene_analysis: bool,
     variant_analysis: bool,
     disease_analysis: bool,
-) -> TrackPrioritisation:
+) -> TrackRunPrioritisation:
     """Assess prioritisation for a single results directory."""
     gene_rank_stats, variant_rank_stats, disease_rank_stats = RankStats(), RankStats(), RankStats()
     if gene_analysis:
@@ -552,6 +552,7 @@ def _assess_prioritisation_for_results_directory(
                 gene_rank_stats,
                 gene_rank_comparison,
             )
+        gene_stats_writer.write_row(results_directory_and_input.results_dir, gene_rank_stats)
     if variant_analysis:
         for standardised_result in files_with_suffix(
             results_directory_and_input.results_dir.joinpath("pheval_variant_results/"),
@@ -565,6 +566,7 @@ def _assess_prioritisation_for_results_directory(
                 variant_rank_stats,
                 variant_rank_comparison,
             )
+        variants_stats_writer.write_row(results_directory_and_input.results_dir, variant_rank_stats)
     if disease_analysis:
         for standardised_result in files_with_suffix(
             results_directory_and_input.results_dir.joinpath("pheval_disease_results/"),
@@ -578,27 +580,19 @@ def _assess_prioritisation_for_results_directory(
                 disease_rank_stats,
                 disease_rank_comparison,
             )
-    gene_stats_writer.write_row(
-        results_directory_and_input.results_dir, gene_rank_stats
-    ) if gene_analysis else None
-    variants_stats_writer.write_row(
-        results_directory_and_input.results_dir, variant_rank_stats
-    ) if variant_analysis else None
-    disease_stats_writer.write_row(
-        results_directory_and_input.results_dir, disease_rank_stats
-    ) if disease_analysis else None
+        disease_stats_writer.write_row(results_directory_and_input.results_dir, disease_rank_stats)
     return TrackRunPrioritisation(
-        gene_prioritisation=TrackPrioritisation(
+        gene_prioritisation=AnalysisResults(
             results_dir=results_directory_and_input.results_dir,
             ranks=gene_rank_comparison,
             rank_stats=gene_rank_stats,
         ),
-        variant_prioritisation=TrackPrioritisation(
+        variant_prioritisation=AnalysisResults(
             results_dir=results_directory_and_input.results_dir,
             ranks=variant_rank_comparison,
             rank_stats=variant_rank_stats,
         ),
-        disease_prioritisation=TrackPrioritisation(
+        disease_prioritisation=AnalysisResults(
             results_dir=results_directory_and_input.results_dir,
             ranks=disease_rank_comparison,
             rank_stats=disease_rank_stats,

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -16,8 +16,8 @@ def trim_corpus_results_directory_suffix(corpus_results_directory: Path) -> Path
 
 
 @dataclass
-class TrackPrioritisation:
-    """Track prioritisation for a run."""
+class AnalysisResults:
+    """Analysis results for a run."""
 
     results_dir: Path
     ranks: dict
@@ -28,43 +28,27 @@ class TrackPrioritisation:
 class TrackRunPrioritisation:
     """Track prioritisation for a run."""
 
-    gene_prioritisation: TrackPrioritisation = None
-    variant_prioritisation: TrackPrioritisation = None
-    disease_prioritisation: TrackPrioritisation = None
+    gene_prioritisation: AnalysisResults = None
+    variant_prioritisation: AnalysisResults = None
+    disease_prioritisation: AnalysisResults = None
 
 
 class PlotGenerator:
     def __init__(
         self,
-        gene_analysis: bool = False,
-        variant_analysis: bool = False,
-        disease_analysis: bool = False,
     ):
-        self.gene_analysis = gene_analysis
-        self.variant_analysis = variant_analysis
-        self.disease_analysis = disease_analysis
         self.stats, self.mrr = [], []
         matplotlib.rcParams["axes.spines.right"] = False
         matplotlib.rcParams["axes.spines.top"] = False
 
-    def _retrieve_prioritisation_data(self, prioritisation_result: TrackRunPrioritisation):
-        """Return prioritisation stats."""
-        if self.gene_analysis:
-            return prioritisation_result.gene_prioritisation
-        if self.variant_analysis:
-            return prioritisation_result.variant_prioritisation
-        if self.disease_analysis:
-            return prioritisation_result.disease_prioritisation
-
-    def _generate_stacked_bar_plot_data(self, prioritisation_result: TrackPrioritisation) -> None:
+    def _generate_stacked_bar_plot_data(self, prioritisation_result: AnalysisResults) -> None:
         """Generate data in correct format for dataframe creation for stacked bar plot."""
-        result = self._retrieve_prioritisation_data(prioritisation_result)
-        rank_stats = result.rank_stats
+        rank_stats = prioritisation_result.rank_stats
         self.stats.append(
             {
-                "Run": f"{result.results_dir.parents[0].name}_"
-                f"{trim_corpus_results_directory_suffix(result.results_dir.name)}",
-                "Top": result.rank_stats.percentage_top(),
+                "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                f"{trim_corpus_results_directory_suffix(prioritisation_result.results_dir.name)}",
+                "Top": prioritisation_result.rank_stats.percentage_top(),
                 "2-3": rank_stats.percentage_difference(
                     rank_stats.percentage_top3(), rank_stats.percentage_top()
                 ),
@@ -81,25 +65,24 @@ class PlotGenerator:
             }
         )
 
-    def _generate_stats_mrr_bar_plot_data(self, prioritisation_result: TrackPrioritisation) -> None:
+    def _generate_stats_mrr_bar_plot_data(self, prioritisation_result: AnalysisResults) -> None:
         """Generate data in correct format for dataframe creation for MRR bar plot."""
-        result = self._retrieve_prioritisation_data(prioritisation_result)
         self.mrr.extend(
             [
                 {
                     "Rank": "MRR",
-                    "Percentage": result.rank_stats.mean_reciprocal_rank(),
-                    "Run": f"{result.results_dir.parents[0].name}_"
-                    f"{trim_corpus_results_directory_suffix(result.results_dir.name)}",
+                    "Percentage": prioritisation_result.rank_stats.mean_reciprocal_rank(),
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trim_corpus_results_directory_suffix(prioritisation_result.results_dir.name)}",
                 }
             ]
         )
 
-    def generate_stacked_bar_gene(self, prioritisation_data: [TrackPrioritisation]) -> None:
+    def generate_stacked_bar_gene(self, prioritisation_data: [TrackRunPrioritisation]) -> None:
         """Generate stacked bar plot and MRR bar plot for gene prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_stacked_bar_plot_data(prioritisation_result)
-            self._generate_stats_mrr_bar_plot_data(prioritisation_result)
+            self._generate_stacked_bar_plot_data(prioritisation_result.gene_prioritisation)
+            self._generate_stats_mrr_bar_plot_data(prioritisation_result.gene_prioritisation)
         gene_prioritisation_stats_df = pd.DataFrame(self.stats)
         gene_prioritisation_stats_df.set_index("Run").plot(
             kind="bar",
@@ -119,11 +102,11 @@ class PlotGenerator:
         )
         plt.savefig("gene_mrr.svg", format="svg", bbox_inches="tight")
 
-    def generate_stacked_bar_variant(self, prioritisation_data: [TrackPrioritisation]):
+    def generate_stacked_bar_variant(self, prioritisation_data: [TrackRunPrioritisation]):
         """Generate stacked bar plot and MRR bar plot for variant prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_stacked_bar_plot_data(prioritisation_result)
-            self._generate_stats_mrr_bar_plot_data(prioritisation_result)
+            self._generate_stacked_bar_plot_data(prioritisation_result.variant_prioritisation)
+            self._generate_stats_mrr_bar_plot_data(prioritisation_result.variant_prioritisation)
         variant_prioritisation_stats_df = pd.DataFrame(self.stats)
 
         variant_prioritisation_stats_df.set_index("Run").plot(
@@ -139,11 +122,11 @@ class PlotGenerator:
         )
         plt.savefig("variant_mrr.svg", format="svg", bbox_inches="tight")
 
-    def generate_stacked_bar_disease(self, prioritisation_data: [TrackPrioritisation]):
+    def generate_stacked_bar_disease(self, prioritisation_data: [TrackRunPrioritisation]):
         """Generate stacked bar plot and MRR bar plot for disease prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_stacked_bar_plot_data(prioritisation_result)
-            self._generate_stats_mrr_bar_plot_data(prioritisation_result)
+            self._generate_stacked_bar_plot_data(prioritisation_result.disease_prioritisation)
+            self._generate_stats_mrr_bar_plot_data(prioritisation_result.disease_prioritisation)
         disease_prioritisation_stats_df = pd.DataFrame(self.stats)
 
         disease_prioritisation_stats_df.set_index("Run").plot(
@@ -159,37 +142,43 @@ class PlotGenerator:
         )
         plt.savefig("disease_mrr.svg", format="svg", bbox_inches="tight")
 
-    def _generate_cumulative_bar_plot_data(self, prioritisation_result: TrackPrioritisation):
+    def _generate_cumulative_bar_plot_data(self, prioritisation_result: AnalysisResults):
         """Generate data in correct format for dataframe creation for cumulative bar plot."""
-        result = self._retrieve_prioritisation_data(prioritisation_result)
-        rank_stats = result.rank_stats
-        trimmed_corpus_results_dir = trim_corpus_results_directory_suffix(result.results_dir.name)
+        rank_stats = prioritisation_result.rank_stats
+        trimmed_corpus_results_dir = trim_corpus_results_directory_suffix(
+            prioritisation_result.results_dir.name
+        )
         self.stats.extend(
             [
                 {
                     "Rank": "Top",
                     "Percentage": rank_stats.percentage_top() / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "Top3",
                     "Percentage": rank_stats.percentage_top3() / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "Top5",
                     "Percentage": rank_stats.percentage_top5() / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "Top10",
                     "Percentage": rank_stats.percentage_top10() / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "Found",
                     "Percentage": rank_stats.percentage_found() / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "FO/NP",
@@ -197,40 +186,42 @@ class PlotGenerator:
                         100, rank_stats.percentage_found()
                     )
                     / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "MRR",
                     "Percentage": rank_stats.mean_reciprocal_rank(),
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
             ]
         )
 
-    def generate_cumulative_bar_gene(self, prioritisation_data: [TrackPrioritisation]):
+    def generate_cumulative_bar_gene(self, prioritisation_data: [TrackRunPrioritisation]):
         """Generate cumulative bar plot for gene prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_cumulative_bar_plot_data(prioritisation_result)
+            self._generate_cumulative_bar_plot_data(prioritisation_result.gene_prioritisation)
         gene_prioritisation_df = pd.DataFrame(self.stats)
         sns.catplot(
             data=gene_prioritisation_df, kind="bar", x="Rank", y="Percentage", hue="Run"
         ).set(xlabel="Rank", ylabel="Disease-causing genes (%)")
         plt.savefig("gene_rank_stats.svg", format="svg", bbox_inches="tight")
 
-    def generate_cumulative_bar_variant(self, prioritisation_data: [TrackPrioritisation]):
+    def generate_cumulative_bar_variant(self, prioritisation_data: [TrackRunPrioritisation]):
         """Generate cumulative bar plot for variant prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_cumulative_bar_plot_data(prioritisation_result)
+            self._generate_cumulative_bar_plot_data(prioritisation_result.variant_prioritisation)
         variant_prioritisation_df = pd.DataFrame(self.stats)
         sns.catplot(
             data=variant_prioritisation_df, kind="bar", x="Rank", y="Percentage", hue="Run"
         ).set(xlabel="Rank", ylabel="Disease-causing variants (%)")
         plt.savefig("variant_rank_stats.svg", format="svg", bbox_inches="tight")
 
-    def generate_cumulative_bar_disease(self, prioritisation_data: [TrackPrioritisation]):
+    def generate_cumulative_bar_disease(self, prioritisation_data: [TrackRunPrioritisation]):
         """Generate cumulative bar plot for disease prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_cumulative_bar_plot_data(prioritisation_result)
+            self._generate_cumulative_bar_plot_data(prioritisation_result.disease_prioritisation)
         disease_prioritisation_df = pd.DataFrame(self.stats)
         sns.catplot(
             data=disease_prioritisation_df, kind="bar", x="Rank", y="Percentage", hue="Run"
@@ -238,18 +229,20 @@ class PlotGenerator:
         plt.savefig("disease_rank_stats.svg", format="svg", bbox_inches="tight")
 
     def _generate_non_cumulative_bar_plot_data(
-        self, prioritisation_result: TrackPrioritisation
+        self, prioritisation_result: AnalysisResults
     ) -> [dict]:
         """Generate data in correct format for dataframe creation for non-cumulative bar plot."""
-        result = self._retrieve_prioritisation_data(prioritisation_result)
-        rank_stats = result.rank_stats
-        trimmed_corpus_results_dir = trim_corpus_results_directory_suffix(result.results_dir.name)
+        rank_stats = prioritisation_result.rank_stats
+        trimmed_corpus_results_dir = trim_corpus_results_directory_suffix(
+            prioritisation_result.results_dir.name
+        )
         self.stats.extend(
             [
                 {
                     "Rank": "Top",
                     "Percentage": rank_stats.percentage_top() / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "2-3",
@@ -257,7 +250,8 @@ class PlotGenerator:
                         rank_stats.percentage_top3(), rank_stats.percentage_top()
                     )
                     / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "4-5",
@@ -265,7 +259,8 @@ class PlotGenerator:
                         rank_stats.percentage_top5(), rank_stats.percentage_top3()
                     )
                     / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "6-10",
@@ -273,7 +268,8 @@ class PlotGenerator:
                         rank_stats.percentage_top10(), rank_stats.percentage_top5()
                     )
                     / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": ">10",
@@ -281,7 +277,8 @@ class PlotGenerator:
                         rank_stats.percentage_found(), rank_stats.percentage_top10()
                     )
                     / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "FO/NP",
@@ -289,40 +286,46 @@ class PlotGenerator:
                         100, rank_stats.percentage_found()
                     )
                     / 100,
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
                 {
                     "Rank": "MRR",
                     "Percentage": rank_stats.mean_reciprocal_rank(),
-                    "Run": f"{result.results_dir.parents[0].name}_" f"{trimmed_corpus_results_dir}",
+                    "Run": f"{prioritisation_result.results_dir.parents[0].name}_"
+                    f"{trimmed_corpus_results_dir}",
                 },
             ]
         )
 
-    def generate_non_cumulative_bar_gene(self, prioritisation_data: [TrackPrioritisation]):
+    def generate_non_cumulative_bar_gene(self, prioritisation_data: [TrackRunPrioritisation]):
         """Generate non-cumulative bar plot for gene prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_non_cumulative_bar_plot_data(prioritisation_result)
+            self._generate_non_cumulative_bar_plot_data(prioritisation_result.gene_prioritisation)
         gene_prioritisation_df = pd.DataFrame(self.stats)
         sns.catplot(
             data=gene_prioritisation_df, kind="bar", x="Rank", y="Percentage", hue="Run"
         ).set(xlabel="Rank", ylabel="Disease-causing genes (%)")
         plt.savefig("gene_rank_stats.svg", format="svg", bbox_inches="tight")
 
-    def generate_non_cumulative_bar_variant(self, prioritisation_data: [TrackPrioritisation]):
+    def generate_non_cumulative_bar_variant(self, prioritisation_data: [TrackRunPrioritisation]):
         """Generate non-cumulative bar plot for variant prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_non_cumulative_bar_plot_data(prioritisation_result)
+            self._generate_non_cumulative_bar_plot_data(
+                prioritisation_result.variant_prioritisation
+            )
         variant_prioritisation_df = pd.DataFrame(self.stats)
         sns.catplot(
             data=variant_prioritisation_df, kind="bar", x="Rank", y="Percentage", hue="Run"
         ).set(xlabel="Rank", ylabel="Disease-causing variants (%)")
         plt.savefig("variant_rank_stats.svg", format="svg", bbox_inches="tight")
 
-    def generate_non_cumulative_bar_disease(self, prioritisation_data: [TrackPrioritisation]):
+    def generate_non_cumulative_bar_disease(self, prioritisation_data: [TrackRunPrioritisation]):
         """Generate non-cumulative bar plot for disease prioritisation stats."""
         for prioritisation_result in prioritisation_data:
-            self._generate_non_cumulative_bar_plot_data(prioritisation_result)
+            self._generate_non_cumulative_bar_plot_data(
+                prioritisation_result.disease_prioritisation
+            )
         disease_prioritisation_df = pd.DataFrame(self.stats)
         sns.catplot(
             data=disease_prioritisation_df, kind="bar", x="Rank", y="Percentage", hue="Run"
@@ -330,9 +333,9 @@ class PlotGenerator:
         plt.savefig("disease_rank_stats.svg", format="svg", bbox_inches="tight")
 
 
-def generate_gene_plots(prioritisation_data: [TrackPrioritisation], plot_type: str) -> None:
+def generate_gene_plots(prioritisation_data: [TrackRunPrioritisation], plot_type: str) -> None:
     """Generate summary stats bar plot for gene prioritisation."""
-    plot_generator = PlotGenerator(gene_analysis=True)
+    plot_generator = PlotGenerator()
     if plot_type == "bar_stacked":
         plot_generator.generate_stacked_bar_gene(prioritisation_data)
     elif plot_type == "bar_cumulative":
@@ -341,9 +344,9 @@ def generate_gene_plots(prioritisation_data: [TrackPrioritisation], plot_type: s
         plot_generator.generate_non_cumulative_bar_gene(prioritisation_data)
 
 
-def generate_variant_plots(prioritisation_data: [TrackPrioritisation], plot_type: str) -> None:
+def generate_variant_plots(prioritisation_data: [TrackRunPrioritisation], plot_type: str) -> None:
     """Generate summary stats bar plot for variant prioritisation."""
-    plot_generator = PlotGenerator(variant_analysis=True)
+    plot_generator = PlotGenerator()
     if plot_type == "bar_stacked":
         plot_generator.generate_stacked_bar_variant(prioritisation_data)
     elif plot_type == "bar_cumulative":
@@ -352,9 +355,9 @@ def generate_variant_plots(prioritisation_data: [TrackPrioritisation], plot_type
         plot_generator.generate_non_cumulative_bar_variant(prioritisation_data)
 
 
-def generate_disease_plots(prioritisation_data: [TrackPrioritisation], plot_type: str) -> None:
+def generate_disease_plots(prioritisation_data: [TrackRunPrioritisation], plot_type: str) -> None:
     """Generate summary stats bar plot for disease prioritisation."""
-    plot_generator = PlotGenerator(disease_analysis=True)
+    plot_generator = PlotGenerator()
     if plot_type == "bar_stacked":
         plot_generator.generate_stacked_bar_disease(prioritisation_data)
     elif plot_type == "bar_cumulative":

--- a/src/pheval/analyse/generate_summary_outputs.py
+++ b/src/pheval/analyse/generate_summary_outputs.py
@@ -8,6 +8,8 @@ import pandas as pd
 
 from pheval.analyse.generate_plots import (
     TrackPrioritisation,
+    TrackRunPrioritisation,
+    generate_disease_plots,
     generate_gene_plots,
     generate_variant_plots,
 )
@@ -38,6 +40,10 @@ class RankComparisonGenerator:
         """Generate the output for variant prioritisation ranks."""
         self._generate_dataframe().to_csv(prefix + "-variant_rank_comparison.tsv", sep="\t")
 
+    def generate_disease_output(self, prefix: str) -> None:
+        """Generate the output for disease prioritisation ranks."""
+        self._generate_dataframe().to_csv(prefix + "-disease_rank_comparison.tsv", sep="\t")
+
     def generate_gene_comparison_output(self, prefix: str) -> None:
         """Generate the output for gene prioritisation rank comparison."""
         self._calculate_rank_difference().to_csv(prefix + "-gene_rank_comparison.tsv", sep="\t")
@@ -45,6 +51,10 @@ class RankComparisonGenerator:
     def generate_variant_comparison_output(self, prefix: str) -> None:
         """Generate the output for variant prioritisation rank comparison."""
         self._calculate_rank_difference().to_csv(prefix + "-variant_rank_comparison.tsv", sep="\t")
+
+    def generate_disease_comparison_output(self, prefix: str) -> None:
+        """Generate the output for disease prioritisation rank comparison."""
+        self._calculate_rank_difference().to_csv(prefix + "-disease_rank_comparison.tsv", sep="\t")
 
 
 class RankStatsWriter:
@@ -103,7 +113,7 @@ class RankStatsWriter:
 
 
 def generate_benchmark_gene_output(
-    prioritisation_data: TrackPrioritisation, plot_type: str
+    prioritisation_data: TrackRunPrioritisation, plot_type: str
 ) -> None:
     """Generate gene prioritisation outputs for benchmarking single run."""
     RankComparisonGenerator(prioritisation_data.gene_prioritisation.ranks).generate_gene_output(
@@ -113,13 +123,23 @@ def generate_benchmark_gene_output(
 
 
 def generate_benchmark_variant_output(
-    prioritisation_data: TrackPrioritisation, plot_type: str
+    prioritisation_data: TrackRunPrioritisation, plot_type: str
 ) -> None:
     """Generate variant prioritisation outputs for benchmarking single run."""
     RankComparisonGenerator(
         prioritisation_data.variant_prioritisation.ranks
-    ).generate_variant_output(f"{prioritisation_data.gene_prioritisation.results_dir.name}")
+    ).generate_variant_output(f"{prioritisation_data.variant_prioritisation.results_dir.name}")
     generate_variant_plots([prioritisation_data], plot_type)
+
+
+def generate_benchmark_disease_output(
+    prioritisation_data: TrackRunPrioritisation, plot_type: str
+) -> None:
+    """Generate disease prioritisation outputs for benchmarking single run."""
+    RankComparisonGenerator(
+        prioritisation_data.disease_prioritisation.ranks
+    ).generate_disease_output(f"{prioritisation_data.disease_prioritisation.results_dir.name}")
+    generate_disease_plots([prioritisation_data], plot_type)
 
 
 def merge_results(result1: dict, result2: dict) -> dict:
@@ -167,6 +187,21 @@ def generate_variant_rank_comparisons(comparison_ranks: [tuple]) -> None:
         )
 
 
+def generate_disease_rank_comparisons(comparison_ranks: [tuple]) -> None:
+    """Generate the disease rank comparison of two result directories."""
+    for pair in comparison_ranks:
+        merged_results = merge_results(
+            deepcopy(pair[0].disease_prioritisation.ranks),
+            deepcopy(pair[1].disease_prioritisation.ranks),
+        )
+        RankComparisonGenerator(merged_results).generate_disease_comparison_output(
+            f"{pair[0].disease_prioritisation.results_dir.parents[0].name}_"
+            f"{pair[0].disease_prioritisation.results_dir.name}"
+            f"_vs_{pair[1].disease_prioritisation.results_dir.parents[0].name}_"
+            f"{pair[1].disease_prioritisation.results_dir.name}"
+        )
+
+
 def generate_benchmark_comparison_gene_output(
     prioritisation_stats_for_runs: [TrackPrioritisation], plot_type: str
 ) -> None:
@@ -183,3 +218,13 @@ def generate_benchmark_comparison_variant_output(
         list(itertools.combinations(prioritisation_stats_for_runs, 2))
     )
     generate_variant_plots(prioritisation_stats_for_runs, plot_type)
+
+
+def generate_benchmark_comparison_disease_output(
+    prioritisation_stats_for_runs: [TrackPrioritisation], plot_type: str
+) -> None:
+    """Generate disease prioritisation outputs for benchmarking multiple runs."""
+    generate_disease_rank_comparisons(
+        list(itertools.combinations(prioritisation_stats_for_runs, 2))
+    )
+    generate_disease_plots(prioritisation_stats_for_runs, plot_type)

--- a/src/pheval/analyse/generate_summary_outputs.py
+++ b/src/pheval/analyse/generate_summary_outputs.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pandas as pd
 
 from pheval.analyse.generate_plots import (
-    AnalysisResults,
     TrackRunPrioritisation,
     generate_disease_plots,
     generate_gene_plots,

--- a/src/pheval/analyse/generate_summary_outputs.py
+++ b/src/pheval/analyse/generate_summary_outputs.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from pheval.analyse.generate_plots import (
-    TrackPrioritisation,
+    AnalysisResults,
     TrackRunPrioritisation,
     generate_disease_plots,
     generate_gene_plots,
@@ -203,7 +203,7 @@ def generate_disease_rank_comparisons(comparison_ranks: [tuple]) -> None:
 
 
 def generate_benchmark_comparison_gene_output(
-    prioritisation_stats_for_runs: [TrackPrioritisation], plot_type: str
+    prioritisation_stats_for_runs: [AnalysisResults], plot_type: str
 ) -> None:
     """Generate gene prioritisation outputs for benchmarking multiple runs."""
     generate_gene_rank_comparisons(list(itertools.combinations(prioritisation_stats_for_runs, 2)))
@@ -211,7 +211,7 @@ def generate_benchmark_comparison_gene_output(
 
 
 def generate_benchmark_comparison_variant_output(
-    prioritisation_stats_for_runs: [TrackPrioritisation], plot_type: str
+    prioritisation_stats_for_runs: [AnalysisResults], plot_type: str
 ) -> None:
     """Generate variant prioritisation outputs for benchmarking multiple runs."""
     generate_variant_rank_comparisons(
@@ -221,7 +221,7 @@ def generate_benchmark_comparison_variant_output(
 
 
 def generate_benchmark_comparison_disease_output(
-    prioritisation_stats_for_runs: [TrackPrioritisation], plot_type: str
+    prioritisation_stats_for_runs: [AnalysisResults], plot_type: str
 ) -> None:
     """Generate disease prioritisation outputs for benchmarking multiple runs."""
     generate_disease_rank_comparisons(

--- a/src/pheval/analyse/generate_summary_outputs.py
+++ b/src/pheval/analyse/generate_summary_outputs.py
@@ -203,7 +203,7 @@ def generate_disease_rank_comparisons(comparison_ranks: [tuple]) -> None:
 
 
 def generate_benchmark_comparison_gene_output(
-    prioritisation_stats_for_runs: [AnalysisResults], plot_type: str
+    prioritisation_stats_for_runs: [TrackRunPrioritisation], plot_type: str
 ) -> None:
     """Generate gene prioritisation outputs for benchmarking multiple runs."""
     generate_gene_rank_comparisons(list(itertools.combinations(prioritisation_stats_for_runs, 2)))
@@ -211,7 +211,7 @@ def generate_benchmark_comparison_gene_output(
 
 
 def generate_benchmark_comparison_variant_output(
-    prioritisation_stats_for_runs: [AnalysisResults], plot_type: str
+    prioritisation_stats_for_runs: [TrackRunPrioritisation], plot_type: str
 ) -> None:
     """Generate variant prioritisation outputs for benchmarking multiple runs."""
     generate_variant_rank_comparisons(
@@ -221,7 +221,7 @@ def generate_benchmark_comparison_variant_output(
 
 
 def generate_benchmark_comparison_disease_output(
-    prioritisation_stats_for_runs: [AnalysisResults], plot_type: str
+    prioritisation_stats_for_runs: [TrackRunPrioritisation], plot_type: str
 ) -> None:
     """Generate disease prioritisation outputs for benchmarking multiple runs."""
     generate_disease_rank_comparisons(

--- a/tests/test_generate_plots.py
+++ b/tests/test_generate_plots.py
@@ -1,17 +1,17 @@
 import unittest
-from pathlib import Path, PosixPath
+from pathlib import Path
 
-from pheval.analyse.generate_plots import PlotGenerator, TrackPrioritisation, TrackRunPrioritisation
+from pheval.analyse.generate_plots import AnalysisResults, PlotGenerator, TrackRunPrioritisation
 from pheval.analyse.rank_stats import RankStats
 
 
 class TestPlotGenerator(unittest.TestCase):
     def setUp(self) -> None:
-        self.gene_plot_generator = PlotGenerator(gene_analysis=True)
-        self.variant_plot_generator = PlotGenerator(variant_analysis=True)
-        self.disease_plot_generator = PlotGenerator(disease_analysis=True)
+        self.gene_plot_generator = PlotGenerator()
+        self.variant_plot_generator = PlotGenerator()
+        self.disease_plot_generator = PlotGenerator()
         self.track_prioritisation = TrackRunPrioritisation(
-            gene_prioritisation=TrackPrioritisation(
+            gene_prioritisation=AnalysisResults(
                 results_dir=Path("/path/to/tool/corpus_results"),
                 ranks={},
                 rank_stats=RankStats(
@@ -24,7 +24,7 @@ class TestPlotGenerator(unittest.TestCase):
                     reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 50],
                 ),
             ),
-            variant_prioritisation=TrackPrioritisation(
+            variant_prioritisation=AnalysisResults(
                 results_dir=Path("/path/to/tool/corpus_results"),
                 ranks={},
                 rank_stats=RankStats(
@@ -37,7 +37,7 @@ class TestPlotGenerator(unittest.TestCase):
                     reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 12],
                 ),
             ),
-            disease_prioritisation=TrackPrioritisation(
+            disease_prioritisation=AnalysisResults(
                 results_dir=Path("/path/to/tool/corpus_results"),
                 ranks={},
                 rank_stats=RankStats(
@@ -48,66 +48,14 @@ class TestPlotGenerator(unittest.TestCase):
                     found=5,
                     total=5,
                     reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 12],
-                ),
-            ),
-        )
-
-    def test__retrieve_prioritisation_data_gene(self):
-        self.assertEqual(
-            self.gene_plot_generator._retrieve_prioritisation_data(self.track_prioritisation),
-            TrackPrioritisation(
-                results_dir=Path("/path/to/tool/corpus_results"),
-                ranks={},
-                rank_stats=RankStats(
-                    top=1,
-                    top3=2,
-                    top5=3,
-                    top10=9,
-                    found=20,
-                    total=30,
-                    reciprocal_ranks=[1, 0.3333333333333333, 0.2, 0.1, 0.02],
-                ),
-            ),
-        )
-
-    def test__retrieve_prioritisation_data_variant(self):
-        self.assertEqual(
-            self.variant_plot_generator._retrieve_prioritisation_data(self.track_prioritisation),
-            TrackPrioritisation(
-                results_dir=PosixPath("/path/to/tool/corpus_results"),
-                ranks={},
-                rank_stats=RankStats(
-                    top=1,
-                    top3=2,
-                    top5=3,
-                    top10=4,
-                    found=5,
-                    total=2,
-                    reciprocal_ranks=[1, 0.3333333333333333, 0.2, 0.1, 0.08333333333333333],
-                ),
-            ),
-        )
-
-    def test__retrieve_prioritisation_data_disease(self):
-        self.assertEqual(
-            self.disease_plot_generator._retrieve_prioritisation_data(self.track_prioritisation),
-            TrackPrioritisation(
-                results_dir=PosixPath("/path/to/tool/corpus_results"),
-                ranks={},
-                rank_stats=RankStats(
-                    top=1,
-                    top3=2,
-                    top5=3,
-                    top10=4,
-                    found=5,
-                    total=5,
-                    reciprocal_ranks=[1, 0.3333333333333333, 0.2, 0.1, 0.08333333333333333],
                 ),
             ),
         )
 
     def test__generate_stacked_bar_plot_data(self):
-        self.gene_plot_generator._generate_stacked_bar_plot_data(self.track_prioritisation)
+        self.gene_plot_generator._generate_stacked_bar_plot_data(
+            self.track_prioritisation.gene_prioritisation
+        )
         self.assertEqual(
             self.gene_plot_generator.stats,
             [
@@ -124,14 +72,18 @@ class TestPlotGenerator(unittest.TestCase):
         )
 
     def test__generate_stats_mrr_bar_plot_data(self):
-        self.gene_plot_generator._generate_stats_mrr_bar_plot_data(self.track_prioritisation)
+        self.gene_plot_generator._generate_stats_mrr_bar_plot_data(
+            self.track_prioritisation.gene_prioritisation
+        )
         self.assertEqual(
             self.gene_plot_generator.mrr,
             [{"Rank": "MRR", "Percentage": 0.33066666666666666, "Run": "tool_corpus"}],
         )
 
     def test__generate_cumulative_bar_plot_data(self):
-        self.gene_plot_generator._generate_cumulative_bar_plot_data(self.track_prioritisation)
+        self.gene_plot_generator._generate_cumulative_bar_plot_data(
+            self.track_prioritisation.gene_prioritisation
+        )
         self.assertEqual(
             self.gene_plot_generator.stats,
             [
@@ -146,7 +98,9 @@ class TestPlotGenerator(unittest.TestCase):
         )
 
     def test__generate_non_cumulative_bar_plot_data(self):
-        self.gene_plot_generator._generate_non_cumulative_bar_plot_data(self.track_prioritisation)
+        self.gene_plot_generator._generate_non_cumulative_bar_plot_data(
+            self.track_prioritisation.gene_prioritisation
+        )
         self.assertEqual(
             self.gene_plot_generator.stats,
             [

--- a/tests/test_generate_plots.py
+++ b/tests/test_generate_plots.py
@@ -37,18 +37,20 @@ class TestPlotGenerator(unittest.TestCase):
                     reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 12],
                 ),
             ),
-            disease_prioritisation=TrackPrioritisation(results_dir=Path("/path/to/tool/corpus_results"),
-                                                       ranks={},
-                                                       rank_stats=RankStats(
-                                                           top=1,
-                                                           top3=2,
-                                                           top5=3,
-                                                           top10=4,
-                                                           found=5,
-                                                           total=5,
-                                                           reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 12],
-                                                       ),
-                                                       ))
+            disease_prioritisation=TrackPrioritisation(
+                results_dir=Path("/path/to/tool/corpus_results"),
+                ranks={},
+                rank_stats=RankStats(
+                    top=1,
+                    top3=2,
+                    top5=3,
+                    top10=4,
+                    found=5,
+                    total=5,
+                    reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 12],
+                ),
+            ),
+        )
 
     def test__retrieve_prioritisation_data_gene(self):
         self.assertEqual(
@@ -103,6 +105,7 @@ class TestPlotGenerator(unittest.TestCase):
                 ),
             ),
         )
+
     def test__generate_stacked_bar_plot_data(self):
         self.gene_plot_generator._generate_stacked_bar_plot_data(self.track_prioritisation)
         self.assertEqual(

--- a/tests/test_generate_plots.py
+++ b/tests/test_generate_plots.py
@@ -1,21 +1,17 @@
 import unittest
 from pathlib import Path, PosixPath
 
-from pheval.analyse.generate_plots import (
-    PlotGenerator,
-    TrackGenePrioritisation,
-    TrackPrioritisation,
-    TrackVariantPrioritisation,
-)
+from pheval.analyse.generate_plots import PlotGenerator, TrackPrioritisation, TrackRunPrioritisation
 from pheval.analyse.rank_stats import RankStats
 
 
 class TestPlotGenerator(unittest.TestCase):
     def setUp(self) -> None:
         self.gene_plot_generator = PlotGenerator(gene_analysis=True)
-        self.variant_plot_generator = PlotGenerator(gene_analysis=False)
-        self.track_prioritisation = TrackPrioritisation(
-            gene_prioritisation=TrackGenePrioritisation(
+        self.variant_plot_generator = PlotGenerator(variant_analysis=True)
+        self.disease_plot_generator = PlotGenerator(disease_analysis=True)
+        self.track_prioritisation = TrackRunPrioritisation(
+            gene_prioritisation=TrackPrioritisation(
                 results_dir=Path("/path/to/tool/corpus_results"),
                 ranks={},
                 rank_stats=RankStats(
@@ -28,7 +24,7 @@ class TestPlotGenerator(unittest.TestCase):
                     reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 50],
                 ),
             ),
-            variant_prioritisation=TrackVariantPrioritisation(
+            variant_prioritisation=TrackPrioritisation(
                 results_dir=Path("/path/to/tool/corpus_results"),
                 ranks={},
                 rank_stats=RankStats(
@@ -41,12 +37,23 @@ class TestPlotGenerator(unittest.TestCase):
                     reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 12],
                 ),
             ),
-        )
+            disease_prioritisation=TrackPrioritisation(results_dir=Path("/path/to/tool/corpus_results"),
+                                                       ranks={},
+                                                       rank_stats=RankStats(
+                                                           top=1,
+                                                           top3=2,
+                                                           top5=3,
+                                                           top10=4,
+                                                           found=5,
+                                                           total=5,
+                                                           reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 12],
+                                                       ),
+                                                       ))
 
     def test__retrieve_prioritisation_data_gene(self):
         self.assertEqual(
             self.gene_plot_generator._retrieve_prioritisation_data(self.track_prioritisation),
-            TrackGenePrioritisation(
+            TrackPrioritisation(
                 results_dir=Path("/path/to/tool/corpus_results"),
                 ranks={},
                 rank_stats=RankStats(
@@ -64,7 +71,7 @@ class TestPlotGenerator(unittest.TestCase):
     def test__retrieve_prioritisation_data_variant(self):
         self.assertEqual(
             self.variant_plot_generator._retrieve_prioritisation_data(self.track_prioritisation),
-            TrackVariantPrioritisation(
+            TrackPrioritisation(
                 results_dir=PosixPath("/path/to/tool/corpus_results"),
                 ranks={},
                 rank_stats=RankStats(
@@ -79,6 +86,23 @@ class TestPlotGenerator(unittest.TestCase):
             ),
         )
 
+    def test__retrieve_prioritisation_data_disease(self):
+        self.assertEqual(
+            self.disease_plot_generator._retrieve_prioritisation_data(self.track_prioritisation),
+            TrackPrioritisation(
+                results_dir=PosixPath("/path/to/tool/corpus_results"),
+                ranks={},
+                rank_stats=RankStats(
+                    top=1,
+                    top3=2,
+                    top5=3,
+                    top10=4,
+                    found=5,
+                    total=5,
+                    reciprocal_ranks=[1, 0.3333333333333333, 0.2, 0.1, 0.08333333333333333],
+                ),
+            ),
+        )
     def test__generate_stacked_bar_plot_data(self):
         self.gene_plot_generator._generate_stacked_bar_plot_data(self.track_prioritisation)
         self.assertEqual(

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from phenopackets import (
     Diagnosis,
+    Disease,
     Family,
     File,
     GeneDescriptor,
@@ -29,6 +30,7 @@ from pheval.utils.phenopacket_utils import (
     PhenopacketUtil,
     ProbandCausativeGene,
     ProbandCausativeVariant,
+    ProbandDisease,
     create_gene_identifier_map,
     create_hgnc_dict,
 )
@@ -38,6 +40,7 @@ interpretations = [
         id="test-subject-1-int",
         progress_status="SOLVED",
         diagnosis=Diagnosis(
+            disease=OntologyClass(id="OMIM:219700", label="Cystic Fibrosis"),
             genomic_interpretations=[
                 GenomicInterpretation(
                     subject_or_biosample_id="test-subject-1",
@@ -82,7 +85,7 @@ interpretations = [
                         ),
                     ),
                 ),
-            ]
+            ],
         ),
     )
 ]
@@ -116,7 +119,7 @@ structural_variant_interpretations = [
                         ),
                     ),
                 ),
-            ]
+            ],
         ),
     )
 ]
@@ -125,6 +128,7 @@ updated_interpretations = [
         id="test-subject-1-int",
         progress_status="SOLVED",
         diagnosis=Diagnosis(
+            disease=OntologyClass(id="OMIM:219700", label="Cystic Fibrosis"),
             genomic_interpretations=[
                 GenomicInterpretation(
                     subject_or_biosample_id="test-subject-1",
@@ -187,7 +191,7 @@ updated_interpretations = [
                         ),
                     ),
                 ),
-            ]
+            ],
         ),
     )
 ]
@@ -264,12 +268,14 @@ phenotypic_features_all_excluded = [
         type=OntologyClass(id="HP:0008494", label="Inferior lens subluxation"), excluded=True
     ),
 ]
+diseases = [Disease(term=OntologyClass(id="OMIM:219700", label="Cystic Fibrosis"))]
 
 proband = Phenopacket(
     id="test-subject",
     subject=Individual(id="test-subject-1", sex=1),
     phenotypic_features=phenotypic_features_none_excluded,
     interpretations=interpretations,
+    diseases=diseases,
 )
 
 phenopacket_files = [
@@ -322,6 +328,7 @@ phenopacket = Phenopacket(
     subject=Individual(id="test-subject-1", sex=1),
     phenotypic_features=phenotypic_features_with_excluded,
     interpretations=interpretations,
+    diseases=diseases,
     files=phenopacket_files,
     meta_data=phenopacket_metadata,
 )
@@ -461,6 +468,36 @@ class TestPhenopacketUtil(unittest.TestCase):
 
     def test_negated_phenotypic_features_none_excluded(self):
         self.assertEqual(self.family.negated_phenotypic_features(), [])
+
+    def test_diseases_phenopacket(self):
+        self.assertEqual(list(self.phenopacket.diseases()), list(diseases))
+
+    def test_diseases_family(self):
+        self.assertEqual(list(self.family.diseases()), list(diseases))
+
+    def test_diagnosis_from_interpretations(self):
+        self.assertEqual(
+            self.phenopacket.diagnosis_from_interpretations(),
+            [ProbandDisease(disease_name="Cystic Fibrosis", disease_identifier="OMIM:219700")],
+        )
+
+    def test_diagnosis_from_interpretations_none(self):
+        self.assertEqual(self.structural_variant_phenopacket.diagnosis_from_interpretations(), [])
+
+    def test_diagnosis_from_disease(self):
+        self.assertEqual(
+            self.family.diagnosis_from_disease(),
+            [ProbandDisease(disease_name="Cystic Fibrosis", disease_identifier="OMIM:219700")],
+        )
+
+    def test_diagnosis_from_disease_none(self):
+        self.assertEqual(self.structural_variant_phenopacket.diagnosis_from_disease(), [])
+
+    def test_diagnoses(self):
+        self.assertEqual(
+            self.phenopacket.diagnoses(),
+            [ProbandDisease(disease_name="Cystic Fibrosis", disease_identifier="OMIM:219700")],
+        )
 
     def test_interpretations_phenopacket(self):
         self.assertEqual(list(self.phenopacket.interpretations()), interpretations)


### PR DESCRIPTION
Implemented methods to assess the performance of disease prioritisation, i.e., this could be used to benchmark the performance of OntoGPT, however, once all the runners have been set up to be able to output this result type, this could result in the comparison of Exomiser vs OntoGPT vs LIRICAL. Apologies for the larger PR, I think this was probably unavoidable.

1. `analysis.py` -> Ultimately where all the analysis for disease prioritisation is happening, i.e., iterating over the pheval disease results and checking if the known disease in the phenopacket is found in the results and recording the summary stats.
2. `generate_plots.py` -> Methods implemented for generating the disease summary plots.
3. `generate_summary_outputs.py` -> Methods implemented for generating disease summary outputs.
4. `phenopacket_utils.py` -> Methods implemented for retrieving  known disease diagnoses from a Phenopacket.