### PR TITLE
164 split configyaml phenotype only into gene and variant fields

### DIFF
--- a/src/pheval/config_parser.py
+++ b/src/pheval/config_parser.py
@@ -16,7 +16,8 @@ class InputDirConfig:
     Args:
         tool (str): Name of the tool implementation (e.g. exomiser/phen2gene)
         tool_version (str): Version of the tool implementation
-        phenotype_only (bool): Whether the tool is run with HPO terms only (True) or with variant data (False)
+        variant_analysis (bool): Whether to extract prioritised variants from results.
+        gene_analysis (bool): Whether to extract prioritised genes from results.
         disease_analysis (bool): Whether to extract prioritised diseases from results.
         tool_specific_configuration_options (Any): Tool specific configurations
 
@@ -25,7 +26,8 @@ class InputDirConfig:
 
     tool: str
     tool_version: str
-    phenotype_only: bool
+    variant_analysis: bool
+    gene_analysis: bool
     disease_analysis: bool
     tool_specific_configuration_options: Any
 

--- a/src/pheval/runners/runner.py
+++ b/src/pheval/runners/runner.py
@@ -34,8 +34,11 @@ class PhEvalRunner(ABC):
     def _get_tool(self):
         return self.input_dir_config.tool
 
-    def _get_phenotype_only(self):
-        return self.input_dir_config.phenotype_only
+    def _get_variant_analysis(self):
+        return self.input_dir_config.variant_analysis
+
+    def _get_gene_analysis(self):
+        return self.input_dir_config.gene_analysis
 
     def _get_disease_analysis(self):
         return self.input_dir_config.disease_analysis
@@ -85,8 +88,10 @@ class PhEvalRunner(ABC):
         self.tool_input_commands_dir.mkdir(exist_ok=True)
         self.raw_results_dir.mkdir(exist_ok=True)
         self.pheval_gene_results_dir.mkdir(exist_ok=True)
-        if not self._get_phenotype_only():
+        if self._get_variant_analysis():
             self.pheval_variant_results_dir.mkdir(exist_ok=True)
+        if self._get_gene_analysis():
+            self.pheval_gene_results_dir.mkdir(exist_ok=True)
         if self._get_disease_analysis():
             self.pheval_disease_results_dir.mkdir(exist_ok=True)
 

--- a/tests/input_dir/configs/default/config.yaml
+++ b/tests/input_dir/configs/default/config.yaml
@@ -1,5 +1,6 @@
 tool: defaultrunner
 tool_version: 1.0.0
-phenotype_only: False
+variant_analysis: True
+gene_analysis: True
 disease_analysis: True
 tool_specific_configuration_options: None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -19,8 +19,11 @@ class TestDefaultPhEvalRunner(unittest.TestCase):
     def test__get_tool(self):
         self.assertEqual(self.pheval_runner._get_tool(), "defaultrunner")
 
-    def test__get_phenotype_only(self):
-        self.assertEqual(self.pheval_runner._get_phenotype_only(), False)
+    def test__get_variant_analysis(self):
+        self.assertEqual(self.pheval_runner._get_variant_analysis(), True)
+
+    def test__get_gene_analysis(self):
+        self.assertEqual(self.pheval_runner._get_gene_analysis(), True)
 
     def test__get_disease_analysis(self):
         self.assertEqual(self.pheval_runner._get_disease_analysis(), True)


### PR DESCRIPTION
Split the `phenotype_only` variable in the config to `gene_analysis` and `variant_analysis`