### PR TITLE
199 add command to generate stats plot

### DIFF
--- a/src/pheval/analyse/benchmarking_data.py
+++ b/src/pheval/analyse/benchmarking_data.py
@@ -6,8 +6,9 @@ from pheval.analyse.rank_stats import RankStats
 
 @dataclass
 class BenchmarkRunResults:
-    """Analysis results for a run."""
+    """Benchmarking results for a run."""
 
-    results_dir: Path
     ranks: dict
     rank_stats: RankStats
+    results_dir: Path = None
+    benchmark_name: str = None

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -6,11 +6,16 @@ import seaborn as sns
 from matplotlib import pyplot as plt
 
 from pheval.analyse.benchmark_generator import (
-    BenchmarkRunOutputGenerator, GeneBenchmarkRunOutputGenerator,
-    VariantBenchmarkRunOutputGenerator, DiseaseBenchmarkRunOutputGenerator
+    BenchmarkRunOutputGenerator,
+    DiseaseBenchmarkRunOutputGenerator,
+    GeneBenchmarkRunOutputGenerator,
+    VariantBenchmarkRunOutputGenerator,
 )
 from pheval.analyse.benchmarking_data import BenchmarkRunResults
-from pheval.analyse.parse_benchmark_summary import read_benchmark_tsv_result_summary, parse_benchmark_result_summary
+from pheval.analyse.parse_benchmark_summary import (
+    parse_benchmark_result_summary,
+    read_benchmark_tsv_result_summary,
+)
 from pheval.constants import PHEVAL_RESULTS_DIRECTORY_SUFFIX
 
 
@@ -21,7 +26,7 @@ def trim_corpus_results_directory_suffix(corpus_results_directory: Path) -> Path
 
 class PlotGenerator:
     def __init__(
-            self,
+        self,
     ):
         self.stats, self.mrr = [], []
         matplotlib.rcParams["axes.spines.right"] = False
@@ -65,16 +70,15 @@ class PlotGenerator:
                     "Rank": "MRR",
                     "Percentage": benchmark_result.rank_stats.return_mean_reciprocal_rank(),
                     "Run": self.create_run_identifier(benchmark_result.results_dir),
-
                 }
             ]
         )
 
     def generate_stacked_bar_plot(
-            self,
-            benchmarking_results: [BenchmarkRunResults],
-            benchmark_generator: BenchmarkRunOutputGenerator,
-            title: str = None
+        self,
+        benchmarking_results: [BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+        title: str = None,
     ) -> None:
         """Generate stacked bar plot."""
         for benchmark_result in benchmarking_results:
@@ -124,55 +128,48 @@ class PlotGenerator:
                     "Rank": "Top",
                     "Percentage": rank_stats.percentage_top() / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "Top3",
                     "Percentage": rank_stats.percentage_top3() / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "Top5",
                     "Percentage": rank_stats.percentage_top5() / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "Top10",
                     "Percentage": rank_stats.percentage_top10() / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "Found",
                     "Percentage": rank_stats.percentage_found() / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "Missed",
                     "Percentage": rank_stats.percentage_difference(
                         100, rank_stats.percentage_found()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "MRR",
                     "Percentage": rank_stats.return_mean_reciprocal_rank(),
                     "Run": run_identifier,
-
                 },
             ]
         )
 
     def generate_cumulative_bar(
-            self,
-            benchmarking_results: [BenchmarkRunResults],
-            benchmark_generator: BenchmarkRunOutputGenerator,
-            title: str = None
+        self,
+        benchmarking_results: [BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+        title: str = None,
     ) -> None:
         """Generate cumulative bar plot."""
         for benchmark_result in benchmarking_results:
@@ -195,7 +192,7 @@ class PlotGenerator:
         )
 
     def _generate_non_cumulative_bar_plot_data(
-            self, benchmark_result: BenchmarkRunResults
+        self, benchmark_result: BenchmarkRunResults
     ) -> [dict]:
         """Generate data in correct format for dataframe creation for non-cumulative bar plot."""
         rank_stats = benchmark_result.rank_stats
@@ -206,67 +203,60 @@ class PlotGenerator:
                     "Rank": "Top",
                     "Percentage": rank_stats.percentage_top() / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "2-3",
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top3(), rank_stats.percentage_top()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "4-5",
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top5(), rank_stats.percentage_top3()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "6-10",
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top10(), rank_stats.percentage_top5()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": ">10",
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_found(), rank_stats.percentage_top10()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "Missed",
                     "Percentage": rank_stats.percentage_difference(
                         100, rank_stats.percentage_found()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
-
                 },
                 {
                     "Rank": "MRR",
                     "Percentage": rank_stats.return_mean_reciprocal_rank(),
                     "Run": run_identifier,
-
                 },
             ]
         )
 
     def generate_non_cumulative_bar(
-            self,
-            benchmarking_results: [BenchmarkRunResults],
-            benchmark_generator: BenchmarkRunOutputGenerator,
-            title: str = None
+        self,
+        benchmarking_results: [BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+        title: str = None,
     ) -> None:
         """Generate non-cumulative bar plot."""
         for benchmark_result in benchmarking_results:
@@ -291,40 +281,28 @@ class PlotGenerator:
 
 
 def generate_plots(
-        benchmarking_results: [BenchmarkRunResults],
-        benchmark_generator: BenchmarkRunOutputGenerator,
-        plot_type: str,
-        title: str = None
+    benchmarking_results: [BenchmarkRunResults],
+    benchmark_generator: BenchmarkRunOutputGenerator,
+    plot_type: str,
+    title: str = None,
 ) -> None:
     """Generate summary stats bar plots for prioritisation."""
     plot_generator = PlotGenerator()
     if plot_type == "bar_stacked":
-        plot_generator.generate_stacked_bar_plot(
-            benchmarking_results,
-            benchmark_generator,
-            title
-        )
+        plot_generator.generate_stacked_bar_plot(benchmarking_results, benchmark_generator, title)
     elif plot_type == "bar_cumulative":
-        plot_generator.generate_cumulative_bar(
-            benchmarking_results,
-            benchmark_generator,
-            title
-        )
+        plot_generator.generate_cumulative_bar(benchmarking_results, benchmark_generator, title)
     elif plot_type == "bar_non_cumulative":
-        plot_generator.generate_non_cumulative_bar(
-            benchmarking_results,
-            benchmark_generator,
-            title
-        )
+        plot_generator.generate_non_cumulative_bar(benchmarking_results, benchmark_generator, title)
 
 
 def generate_plots_from_benchmark_summary_tsv(
-        benchmark_summary_tsv: Path,
-        gene_analysis: bool,
-        variant_analysis: bool,
-        disease_analysis: bool,
-        plot_type: str,
-        title: str,
+    benchmark_summary_tsv: Path,
+    gene_analysis: bool,
+    variant_analysis: bool,
+    disease_analysis: bool,
+    plot_type: str,
+    title: str,
 ):
     """Generate bar plot from summary benchmark results."""
     benchmark_stats_summary = read_benchmark_tsv_result_summary(benchmark_summary_tsv)

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -17,19 +17,25 @@ def trim_corpus_results_directory_suffix(corpus_results_directory: Path) -> Path
 
 class PlotGenerator:
     def __init__(
-        self,
+            self,
     ):
         self.stats, self.mrr = [], []
         matplotlib.rcParams["axes.spines.right"] = False
         matplotlib.rcParams["axes.spines.top"] = False
+
+    @staticmethod
+    def create_run_identifier(results_dir: Path) -> str:
+        """Create a run identifier from a path."""
+        if Path(results_dir).exists():
+            return f"{Path(results_dir).parents[0].name}_{trim_corpus_results_directory_suffix(Path(results_dir).name)}"
+        return results_dir
 
     def _generate_stacked_bar_plot_data(self, benchmark_result: BenchmarkRunResults) -> None:
         """Generate data in correct format for dataframe creation for stacked bar plot."""
         rank_stats = benchmark_result.rank_stats
         self.stats.append(
             {
-                "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                f"{trim_corpus_results_directory_suffix(benchmark_result.results_dir.name)}",
+                "Run": self.create_run_identifier(benchmark_result.results_dir),
                 "Top": benchmark_result.rank_stats.percentage_top(),
                 "2-3": rank_stats.percentage_difference(
                     rank_stats.percentage_top3(), rank_stats.percentage_top()
@@ -54,16 +60,16 @@ class PlotGenerator:
                 {
                     "Rank": "MRR",
                     "Percentage": benchmark_result.rank_stats.mean_reciprocal_rank(),
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trim_corpus_results_directory_suffix(benchmark_result.results_dir.name)}",
+                    "Run": self.create_run_identifier(benchmark_result.results_dir),
+
                 }
             ]
         )
 
     def generate_stacked_bar_plot(
-        self,
-        benchmarking_results: [BenchmarkRunResults],
-        benchmark_generator: BenchmarkRunOutputGenerator,
+            self,
+            benchmarking_results: [BenchmarkRunResults],
+            benchmark_generator: BenchmarkRunOutputGenerator,
     ) -> None:
         """Generate stacked bar plot."""
         for benchmark_result in benchmarking_results:
@@ -95,63 +101,61 @@ class PlotGenerator:
     def _generate_cumulative_bar_plot_data(self, benchmark_result: BenchmarkRunResults):
         """Generate data in correct format for dataframe creation for cumulative bar plot."""
         rank_stats = benchmark_result.rank_stats
-        trimmed_corpus_results_dir = trim_corpus_results_directory_suffix(
-            benchmark_result.results_dir.name
-        )
+        run_identifier = self.create_run_identifier(benchmark_result.results_dir)
         self.stats.extend(
             [
                 {
                     "Rank": "Top",
                     "Percentage": rank_stats.percentage_top() / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "Top3",
                     "Percentage": rank_stats.percentage_top3() / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "Top5",
                     "Percentage": rank_stats.percentage_top5() / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "Top10",
                     "Percentage": rank_stats.percentage_top10() / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "Found",
                     "Percentage": rank_stats.percentage_found() / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "Missed",
                     "Percentage": rank_stats.percentage_difference(
                         100, rank_stats.percentage_found()
                     )
-                    / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                                  / 100,
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "MRR",
                     "Percentage": rank_stats.mean_reciprocal_rank(),
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                    "Run": run_identifier,
+
                 },
             ]
         )
 
     def generate_cumulative_bar(
-        self,
-        benchmarking_results: [BenchmarkRunResults],
-        benchmark_generator: BenchmarkRunOutputGenerator,
+            self,
+            benchmarking_results: [BenchmarkRunResults],
+            benchmark_generator: BenchmarkRunOutputGenerator,
     ) -> None:
         """Generate cumulative bar plot."""
         for benchmark_result in benchmarking_results:
@@ -170,79 +174,77 @@ class PlotGenerator:
         )
 
     def _generate_non_cumulative_bar_plot_data(
-        self, benchmark_result: BenchmarkRunResults
+            self, benchmark_result: BenchmarkRunResults
     ) -> [dict]:
         """Generate data in correct format for dataframe creation for non-cumulative bar plot."""
         rank_stats = benchmark_result.rank_stats
-        trimmed_corpus_results_dir = trim_corpus_results_directory_suffix(
-            benchmark_result.results_dir.name
-        )
+        run_identifier = self.create_run_identifier(benchmark_result.results_dir)
         self.stats.extend(
             [
                 {
                     "Rank": "Top",
                     "Percentage": rank_stats.percentage_top() / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "2-3",
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top3(), rank_stats.percentage_top()
                     )
-                    / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                                  / 100,
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "4-5",
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top5(), rank_stats.percentage_top3()
                     )
-                    / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                                  / 100,
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "6-10",
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top10(), rank_stats.percentage_top5()
                     )
-                    / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                                  / 100,
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": ">10",
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_found(), rank_stats.percentage_top10()
                     )
-                    / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                                  / 100,
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "Missed",
                     "Percentage": rank_stats.percentage_difference(
                         100, rank_stats.percentage_found()
                     )
-                    / 100,
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                                  / 100,
+                    "Run": run_identifier,
+
                 },
                 {
                     "Rank": "MRR",
                     "Percentage": rank_stats.mean_reciprocal_rank(),
-                    "Run": f"{benchmark_result.results_dir.parents[0].name}_"
-                    f"{trimmed_corpus_results_dir}",
+                    "Run": run_identifier,
+
                 },
             ]
         )
 
     def generate_non_cumulative_bar(
-        self,
-        benchmarking_results: [BenchmarkRunResults],
-        benchmark_generator: BenchmarkRunOutputGenerator,
+            self,
+            benchmarking_results: [BenchmarkRunResults],
+            benchmark_generator: BenchmarkRunOutputGenerator,
     ) -> None:
         """Generate non-cumulative bar plot."""
         for benchmark_result in benchmarking_results:
@@ -263,9 +265,9 @@ class PlotGenerator:
 
 
 def generate_plots(
-    benchmarking_results: [BenchmarkRunResults],
-    benchmark_generator: BenchmarkRunOutputGenerator,
-    plot_type: str,
+        benchmarking_results: [BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+        plot_type: str,
 ) -> None:
     """Generate summary stats bar plots for prioritisation."""
     plot_generator = PlotGenerator()

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -26,7 +26,7 @@ def trim_corpus_results_directory_suffix(corpus_results_directory: Path) -> Path
 
 class PlotGenerator:
     def __init__(
-            self,
+        self,
     ):
         self.stats, self.mrr = [], []
         matplotlib.rcParams["axes.spines.right"] = False
@@ -39,8 +39,11 @@ class PlotGenerator:
 
     def return_benchmark_name(self, benchmark_result: BenchmarkRunResults) -> str:
         """Return the benchmark name for a run."""
-        return benchmark_result.benchmark_name if benchmark_result.results_dir is None else self._create_run_identifier(
-            benchmark_result.results_dir)
+        return (
+            benchmark_result.benchmark_name
+            if benchmark_result.results_dir is None
+            else self._create_run_identifier(benchmark_result.results_dir)
+        )
 
     def _generate_stacked_bar_plot_data(self, benchmark_result: BenchmarkRunResults) -> None:
         """Generate data in correct format for dataframe creation for stacked bar plot."""
@@ -78,10 +81,10 @@ class PlotGenerator:
         )
 
     def generate_stacked_bar_plot(
-            self,
-            benchmarking_results: [BenchmarkRunResults],
-            benchmark_generator: BenchmarkRunOutputGenerator,
-            title: str = None,
+        self,
+        benchmarking_results: [BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+        title: str = None,
     ) -> None:
         """Generate stacked bar plot."""
         for benchmark_result in benchmarking_results:
@@ -157,7 +160,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         100, rank_stats.percentage_found()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -169,10 +172,10 @@ class PlotGenerator:
         )
 
     def generate_cumulative_bar(
-            self,
-            benchmarking_results: [BenchmarkRunResults],
-            benchmark_generator: BenchmarkRunOutputGenerator,
-            title: str = None,
+        self,
+        benchmarking_results: [BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+        title: str = None,
     ) -> None:
         """Generate cumulative bar plot."""
         for benchmark_result in benchmarking_results:
@@ -195,7 +198,7 @@ class PlotGenerator:
         )
 
     def _generate_non_cumulative_bar_plot_data(
-            self, benchmark_result: BenchmarkRunResults
+        self, benchmark_result: BenchmarkRunResults
     ) -> [dict]:
         """Generate data in correct format for dataframe creation for non-cumulative bar plot."""
         rank_stats = benchmark_result.rank_stats
@@ -212,7 +215,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top3(), rank_stats.percentage_top()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -220,7 +223,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top5(), rank_stats.percentage_top3()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -228,7 +231,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top10(), rank_stats.percentage_top5()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -236,7 +239,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_found(), rank_stats.percentage_top10()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -244,7 +247,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         100, rank_stats.percentage_found()
                     )
-                                  / 100,
+                    / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -256,10 +259,10 @@ class PlotGenerator:
         )
 
     def generate_non_cumulative_bar(
-            self,
-            benchmarking_results: [BenchmarkRunResults],
-            benchmark_generator: BenchmarkRunOutputGenerator,
-            title: str = None,
+        self,
+        benchmarking_results: [BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+        title: str = None,
     ) -> None:
         """Generate non-cumulative bar plot."""
         for benchmark_result in benchmarking_results:
@@ -284,10 +287,10 @@ class PlotGenerator:
 
 
 def generate_plots(
-        benchmarking_results: [BenchmarkRunResults],
-        benchmark_generator: BenchmarkRunOutputGenerator,
-        plot_type: str,
-        title: str = None,
+    benchmarking_results: [BenchmarkRunResults],
+    benchmark_generator: BenchmarkRunOutputGenerator,
+    plot_type: str,
+    title: str = None,
 ) -> None:
     """Generate summary stats bar plots for prioritisation."""
     plot_generator = PlotGenerator()
@@ -300,12 +303,12 @@ def generate_plots(
 
 
 def generate_plots_from_benchmark_summary_tsv(
-        benchmark_summary_tsv: Path,
-        gene_analysis: bool,
-        variant_analysis: bool,
-        disease_analysis: bool,
-        plot_type: str,
-        title: str,
+    benchmark_summary_tsv: Path,
+    gene_analysis: bool,
+    variant_analysis: bool,
+    disease_analysis: bool,
+    plot_type: str,
+    title: str,
 ):
     """Generate bar plot from summary benchmark results."""
     benchmark_stats_summary = read_benchmark_tsv_result_summary(benchmark_summary_tsv)

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -90,6 +90,7 @@ class PlotGenerator:
             )
         else:
             plt.title(title, loc="center", fontsize=15)
+        plt.ylim(0, 100)
         plt.savefig(
             f"{benchmark_generator.prioritisation_type_file_prefix}_rank_stats.svg",
             format="svg",
@@ -106,6 +107,7 @@ class PlotGenerator:
         plt.title(
             f"{benchmark_generator.prioritisation_type_file_prefix.capitalize()} results - mean reciprocal rank"
         )
+        plt.ylim(0, 1)
         plt.savefig(
             f"{benchmark_generator.prioritisation_type_file_prefix}_mrr.svg",
             format="svg",
@@ -185,6 +187,7 @@ class PlotGenerator:
             )
         else:
             plt.title(title, loc="center", fontsize=15)
+        plt.ylim(0, 1)
         plt.savefig(
             f"{benchmark_generator.prioritisation_type_file_prefix}_rank_stats.svg",
             format="svg",
@@ -279,6 +282,7 @@ class PlotGenerator:
             )
         else:
             plt.title(title, loc="center", fontsize=15)
+        plt.ylim(0, 1)
         plt.savefig(
             f"{benchmark_generator.prioritisation_type_file_prefix}_rank_stats.svg",
             format="svg",

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -63,7 +63,7 @@ class PlotGenerator:
             [
                 {
                     "Rank": "MRR",
-                    "Percentage": benchmark_result.rank_stats.mean_reciprocal_rank(),
+                    "Percentage": benchmark_result.rank_stats.return_mean_reciprocal_rank(),
                     "Run": self.create_run_identifier(benchmark_result.results_dir),
 
                 }
@@ -159,7 +159,7 @@ class PlotGenerator:
                 },
                 {
                     "Rank": "MRR",
-                    "Percentage": rank_stats.mean_reciprocal_rank(),
+                    "Percentage": rank_stats.return_mean_reciprocal_rank(),
                     "Run": run_identifier,
 
                 },
@@ -252,7 +252,7 @@ class PlotGenerator:
                 },
                 {
                     "Rank": "MRR",
-                    "Percentage": rank_stats.mean_reciprocal_rank(),
+                    "Percentage": rank_stats.return_mean_reciprocal_rank(),
                     "Run": run_identifier,
 
                 },

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -26,25 +26,28 @@ def trim_corpus_results_directory_suffix(corpus_results_directory: Path) -> Path
 
 class PlotGenerator:
     def __init__(
-        self,
+            self,
     ):
         self.stats, self.mrr = [], []
         matplotlib.rcParams["axes.spines.right"] = False
         matplotlib.rcParams["axes.spines.top"] = False
 
     @staticmethod
-    def create_run_identifier(results_dir: Path) -> str:
+    def _create_run_identifier(results_dir: Path) -> str:
         """Create a run identifier from a path."""
-        if Path(results_dir).exists():
-            return f"{Path(results_dir).parents[0].name}_{trim_corpus_results_directory_suffix(Path(results_dir).name)}"
-        return results_dir
+        return f"{Path(results_dir).parents[0].name}_{trim_corpus_results_directory_suffix(Path(results_dir).name)}"
+
+    def return_benchmark_name(self, benchmark_result: BenchmarkRunResults) -> str:
+        """Return the benchmark name for a run."""
+        return benchmark_result.benchmark_name if benchmark_result.results_dir is None else self._create_run_identifier(
+            benchmark_result.results_dir)
 
     def _generate_stacked_bar_plot_data(self, benchmark_result: BenchmarkRunResults) -> None:
         """Generate data in correct format for dataframe creation for stacked bar plot."""
         rank_stats = benchmark_result.rank_stats
         self.stats.append(
             {
-                "Run": self.create_run_identifier(benchmark_result.results_dir),
+                "Run": self.return_benchmark_name(benchmark_result),
                 "Top": benchmark_result.rank_stats.percentage_top(),
                 "2-3": rank_stats.percentage_difference(
                     rank_stats.percentage_top3(), rank_stats.percentage_top()
@@ -69,16 +72,16 @@ class PlotGenerator:
                 {
                     "Rank": "MRR",
                     "Percentage": benchmark_result.rank_stats.return_mean_reciprocal_rank(),
-                    "Run": self.create_run_identifier(benchmark_result.results_dir),
+                    "Run": self.return_benchmark_name(benchmark_result),
                 }
             ]
         )
 
     def generate_stacked_bar_plot(
-        self,
-        benchmarking_results: [BenchmarkRunResults],
-        benchmark_generator: BenchmarkRunOutputGenerator,
-        title: str = None,
+            self,
+            benchmarking_results: [BenchmarkRunResults],
+            benchmark_generator: BenchmarkRunOutputGenerator,
+            title: str = None,
     ) -> None:
         """Generate stacked bar plot."""
         for benchmark_result in benchmarking_results:
@@ -121,7 +124,7 @@ class PlotGenerator:
     def _generate_cumulative_bar_plot_data(self, benchmark_result: BenchmarkRunResults):
         """Generate data in correct format for dataframe creation for cumulative bar plot."""
         rank_stats = benchmark_result.rank_stats
-        run_identifier = self.create_run_identifier(benchmark_result.results_dir)
+        run_identifier = self.return_benchmark_name(benchmark_result)
         self.stats.extend(
             [
                 {
@@ -154,7 +157,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         100, rank_stats.percentage_found()
                     )
-                    / 100,
+                                  / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -166,10 +169,10 @@ class PlotGenerator:
         )
 
     def generate_cumulative_bar(
-        self,
-        benchmarking_results: [BenchmarkRunResults],
-        benchmark_generator: BenchmarkRunOutputGenerator,
-        title: str = None,
+            self,
+            benchmarking_results: [BenchmarkRunResults],
+            benchmark_generator: BenchmarkRunOutputGenerator,
+            title: str = None,
     ) -> None:
         """Generate cumulative bar plot."""
         for benchmark_result in benchmarking_results:
@@ -192,11 +195,11 @@ class PlotGenerator:
         )
 
     def _generate_non_cumulative_bar_plot_data(
-        self, benchmark_result: BenchmarkRunResults
+            self, benchmark_result: BenchmarkRunResults
     ) -> [dict]:
         """Generate data in correct format for dataframe creation for non-cumulative bar plot."""
         rank_stats = benchmark_result.rank_stats
-        run_identifier = self.create_run_identifier(benchmark_result.results_dir)
+        run_identifier = self.return_benchmark_name(benchmark_result)
         self.stats.extend(
             [
                 {
@@ -209,7 +212,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top3(), rank_stats.percentage_top()
                     )
-                    / 100,
+                                  / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -217,7 +220,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top5(), rank_stats.percentage_top3()
                     )
-                    / 100,
+                                  / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -225,7 +228,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_top10(), rank_stats.percentage_top5()
                     )
-                    / 100,
+                                  / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -233,7 +236,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         rank_stats.percentage_found(), rank_stats.percentage_top10()
                     )
-                    / 100,
+                                  / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -241,7 +244,7 @@ class PlotGenerator:
                     "Percentage": rank_stats.percentage_difference(
                         100, rank_stats.percentage_found()
                     )
-                    / 100,
+                                  / 100,
                     "Run": run_identifier,
                 },
                 {
@@ -253,10 +256,10 @@ class PlotGenerator:
         )
 
     def generate_non_cumulative_bar(
-        self,
-        benchmarking_results: [BenchmarkRunResults],
-        benchmark_generator: BenchmarkRunOutputGenerator,
-        title: str = None,
+            self,
+            benchmarking_results: [BenchmarkRunResults],
+            benchmark_generator: BenchmarkRunOutputGenerator,
+            title: str = None,
     ) -> None:
         """Generate non-cumulative bar plot."""
         for benchmark_result in benchmarking_results:
@@ -281,10 +284,10 @@ class PlotGenerator:
 
 
 def generate_plots(
-    benchmarking_results: [BenchmarkRunResults],
-    benchmark_generator: BenchmarkRunOutputGenerator,
-    plot_type: str,
-    title: str = None,
+        benchmarking_results: [BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+        plot_type: str,
+        title: str = None,
 ) -> None:
     """Generate summary stats bar plots for prioritisation."""
     plot_generator = PlotGenerator()
@@ -297,12 +300,12 @@ def generate_plots(
 
 
 def generate_plots_from_benchmark_summary_tsv(
-    benchmark_summary_tsv: Path,
-    gene_analysis: bool,
-    variant_analysis: bool,
-    disease_analysis: bool,
-    plot_type: str,
-    title: str,
+        benchmark_summary_tsv: Path,
+        gene_analysis: bool,
+        variant_analysis: bool,
+        disease_analysis: bool,
+        plot_type: str,
+        title: str,
 ):
     """Generate bar plot from summary benchmark results."""
     benchmark_stats_summary = read_benchmark_tsv_result_summary(benchmark_summary_tsv)

--- a/src/pheval/analyse/parse_benchmark_summary.py
+++ b/src/pheval/analyse/parse_benchmark_summary.py
@@ -29,7 +29,6 @@ def parse_benchmark_result_summary(benchmarking_df: pd.DataFrame) -> [BenchmarkR
     benchmarking_results = []
     for _, row in benchmarking_df.iterrows():
         benchmarking_result = BenchmarkRunResults(
-            row["results_directory_path"],
             rank_stats=RankStats(
                 top=row["top"],
                 top3=row["top3"],
@@ -40,6 +39,8 @@ def parse_benchmark_result_summary(benchmarking_df: pd.DataFrame) -> [BenchmarkR
                 mrr=row["mean_reciprocal_rank"],
             ),
             ranks={},
+            benchmark_name=row["results_directory_path"],
+
         )
         benchmarking_results.append(benchmarking_result)
     return benchmarking_results

--- a/src/pheval/analyse/parse_benchmark_summary.py
+++ b/src/pheval/analyse/parse_benchmark_summary.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pandas as pd
+
+from pheval.analyse.benchmarking_data import BenchmarkRunResults
+from pheval.analyse.rank_stats import RankStats
+
+
+def read_benchmark_tsv_result_summary(benchmarking_tsv: Path) -> pd.DataFrame:
+    """Read the summary benchmark tsv output from the benchmark-comparison command."""
+    return pd.read_csv(
+        benchmarking_tsv,
+        delimiter="\t",
+        usecols=[
+            "results_directory_path",
+            "top",
+            "top3",
+            "top5",
+            "top10",
+            "found",
+            "total",
+            "mean_reciprocal_rank",
+        ],
+    )
+
+
+def parse_benchmark_result_summary(benchmarking_df: pd.DataFrame) -> [BenchmarkRunResults]:
+    """Parse the summary benchmark dataframe into BenchmarkRunResults."""
+    benchmarking_results = []
+    for _, row in benchmarking_df.iterrows():
+        benchmarking_result = BenchmarkRunResults(
+            row["results_directory_path"],
+            rank_stats=RankStats(
+                top=row["top"],
+                top3=row["top3"],
+                top5=row["top5"],
+                top10=row["top10"],
+                found=row["found"],
+                total=row["total"],
+                mrr=row["mean_reciprocal_rank"],
+            ),
+            ranks={},
+        )
+        benchmarking_results.append(benchmarking_result)
+    return benchmarking_results

--- a/src/pheval/analyse/parse_benchmark_summary.py
+++ b/src/pheval/analyse/parse_benchmark_summary.py
@@ -40,7 +40,6 @@ def parse_benchmark_result_summary(benchmarking_df: pd.DataFrame) -> [BenchmarkR
             ),
             ranks={},
             benchmark_name=row["results_directory_path"],
-
         )
         benchmarking_results.append(benchmarking_result)
     return benchmarking_results

--- a/src/pheval/analyse/rank_stats.py
+++ b/src/pheval/analyse/rank_stats.py
@@ -67,6 +67,12 @@ class RankStats:
             return mean(self.reciprocal_ranks)
         return mean(self.reciprocal_ranks)
 
+    def return_mean_reciprocal_rank(self) -> float:
+        if self.mrr is not None:
+            return self.mrr
+        else:
+            return self.mean_reciprocal_rank()
+
 
 class RankStatsWriter:
     """Write the rank stats for each run."""

--- a/src/pheval/analyse/rank_stats.py
+++ b/src/pheval/analyse/rank_stats.py
@@ -15,6 +15,7 @@ class RankStats:
     found: int = 0
     total: int = 0
     reciprocal_ranks: list = field(default_factory=list)
+    mrr: float = None
 
     def add_rank(self, rank: int) -> None:
         """Add rank for phenopacket."""
@@ -60,6 +61,10 @@ class RankStats:
 
     def mean_reciprocal_rank(self) -> float:
         """Return the mean reciprocal rank."""
+        if len(self.reciprocal_ranks) != self.total:
+            missing_cases = self.total - self.found
+            self.reciprocal_ranks.extend([0] * missing_cases)
+            return mean(self.reciprocal_ranks)
         return mean(self.reciprocal_ranks)
 
 

--- a/src/pheval/analyse/rank_stats.py
+++ b/src/pheval/analyse/rank_stats.py
@@ -60,7 +60,7 @@ class RankStats:
         return percentage_value_1 - percentage_value_2
 
     def mean_reciprocal_rank(self) -> float:
-        """Return the mean reciprocal rank."""
+        """Calculate the mean reciprocal rank."""
         if len(self.reciprocal_ranks) != self.total:
             missing_cases = self.total - self.found
             self.reciprocal_ranks.extend([0] * missing_cases)
@@ -68,6 +68,7 @@ class RankStats:
         return mean(self.reciprocal_ranks)
 
     def return_mean_reciprocal_rank(self) -> float:
+        """Return the mean reciprocal rank."""
         if self.mrr is not None:
             return self.mrr
         else:

--- a/src/pheval/cli.py
+++ b/src/pheval/cli.py
@@ -8,10 +8,11 @@ from .cli_pheval_utils import (
     benchmark,
     benchmark_comparison,
     create_spiked_vcfs_command,
+    generate_stats_plot,
     scramble_phenopackets_command,
     semsim_convert_command,
     semsim_scramble_command,
-    update_phenopackets_command, generate_stats_plot,
+    update_phenopackets_command,
 )
 
 info_log = logging.getLogger("info")

--- a/src/pheval/cli.py
+++ b/src/pheval/cli.py
@@ -11,7 +11,7 @@ from .cli_pheval_utils import (
     scramble_phenopackets_command,
     semsim_convert_command,
     semsim_scramble_command,
-    update_phenopackets_command,
+    update_phenopackets_command, generate_stats_plot,
 )
 
 info_log = logging.getLogger("info")
@@ -57,7 +57,7 @@ pheval_utils.add_command(update_phenopackets_command)
 pheval_utils.add_command(create_spiked_vcfs_command)
 pheval_utils.add_command(benchmark)
 pheval_utils.add_command(benchmark_comparison)
-
+pheval_utils.add_command(generate_stats_plot)
 
 if __name__ == "__main__":
     main()

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -10,6 +10,7 @@ from pheval.analyse.analysis import (
     benchmark_directory,
     benchmark_run_comparisons,
 )
+from pheval.analyse.generate_plots import generate_plots_from_benchmark_summary_tsv
 from pheval.analyse.run_data_parser import parse_run_data_text_file
 from pheval.prepare.create_noisy_phenopackets import scramble_phenopackets
 from pheval.prepare.create_spiked_vcf import spike_vcfs
@@ -57,7 +58,7 @@ from pheval.utils.utils import semsim_convert, semsim_scramble
     that will be applied to semantic similarity score column (e.g. jaccard similarity).""",
 )
 def semsim_scramble_command(
-    input: Path, output: Path, score_column: List[str], scramble_factor: float
+        input: Path, output: Path, score_column: List[str], scramble_factor: float
 ):
     """Scrambles semsim profile multiplying score value by scramble factor
     Args:
@@ -108,10 +109,10 @@ def semsim_scramble_command(
     type=Path,
 )
 def scramble_phenopackets_command(
-    phenopacket_path: Path,
-    phenopacket_dir: Path,
-    scramble_factor: float,
-    output_dir: Path,
+        phenopacket_path: Path,
+        phenopacket_dir: Path,
+        scramble_factor: float,
+        output_dir: Path,
 ):
     """Generate noisy phenopackets from existing ones."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -162,11 +163,11 @@ def scramble_phenopackets_command(
     help="Output path for the difference tsv. Defaults to percentage_diff.semsim.tsv",
 )
 def semsim_comparison(
-    semsim_left: Path,
-    semsim_right: Path,
-    score_column: str,
-    analysis: str,
-    output: Path = "percentage_diff.semsim.tsv",
+        semsim_left: Path,
+        semsim_right: Path,
+        score_column: str,
+        analysis: str,
+        output: Path = "percentage_diff.semsim.tsv",
 ):
     """Compares two semantic similarity profiles
 
@@ -223,7 +224,7 @@ def semsim_comparison(
     type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
 )
 def update_phenopackets_command(
-    phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
+        phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
 ):
     """Update gene symbols and identifiers for phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -279,11 +280,11 @@ def update_phenopackets_command(
     type=Path,
 )
 def create_spiked_vcfs_command(
-    phenopacket_path: Path,
-    phenopacket_dir: Path,
-    output_dir: Path,
-    template_vcf_path: Path = None,
-    vcf_dir: Path = None,
+        phenopacket_path: Path,
+        phenopacket_dir: Path,
+        output_dir: Path,
+        template_vcf_path: Path = None,
+        vcf_dir: Path = None,
 ):
     """Spikes variants into a template VCF file for a directory of phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -333,7 +334,7 @@ def create_spiked_vcfs_command(
     type=click.Choice(["exomiserdb"], case_sensitive=False),
 )
 def semsim_convert_command(
-    input: Path, output: Path, subject_prefix: str, object_prefix: str, output_format: str
+        input: Path, output: Path, subject_prefix: str, object_prefix: str, output_format: str
 ):
     """convert semsim profile to an exomiser database file"""
     semsim_convert(input, output, subject_prefix, object_prefix, output_format)
@@ -346,7 +347,7 @@ def semsim_convert_command(
     required=True,
     metavar="PATH",
     help="General results directory to be benchmarked, assumes contains subdirectories of pheval_gene_results/,"
-    "pheval_variant_results/ or pheval_disease_results/. ",
+         "pheval_variant_results/ or pheval_disease_results/. ",
     type=Path,
 )
 @click.option(
@@ -415,15 +416,15 @@ def semsim_convert_command(
     help="Bar chart type to output.",
 )
 def benchmark(
-    directory: Path,
-    phenopacket_dir: Path,
-    score_order: str,
-    output_prefix: str,
-    threshold: float,
-    gene_analysis: bool,
-    variant_analysis: bool,
-    disease_analysis: bool,
-    plot_type: str,
+        directory: Path,
+        phenopacket_dir: Path,
+        score_order: str,
+        output_prefix: str,
+        threshold: float,
+        gene_analysis: bool,
+        variant_analysis: bool,
+        disease_analysis: bool,
+        plot_type: str,
 ):
     """Benchmark the gene/variant/disease prioritisation performance for a single run."""
     if not gene_analysis and not variant_analysis and not disease_analysis:
@@ -447,9 +448,9 @@ def benchmark(
     required=True,
     metavar="PATH",
     help="Path to .txt file containing testdata phenopacket directory "
-    "and corresponding results directory separated by tab."
-    "Each run contained to a new line with the input testdata listed first and on the same line separated by a tab"
-    "the results directory.",
+         "and corresponding results directory separated by tab."
+         "Each run contained to a new line with the input testdata listed first and on the same line separated by a tab"
+         "the results directory.",
     type=Path,
 )
 @click.option(
@@ -510,14 +511,14 @@ def benchmark(
     help="Bar chart type to output.",
 )
 def benchmark_comparison(
-    run_data: Path,
-    score_order: str,
-    output_prefix: str,
-    threshold: float,
-    gene_analysis: bool,
-    variant_analysis: bool,
-    disease_analysis: bool,
-    plot_type: str,
+        run_data: Path,
+        score_order: str,
+        output_prefix: str,
+        threshold: float,
+        gene_analysis: bool,
+        variant_analysis: bool,
+        disease_analysis: bool,
+        plot_type: str,
 ):
     """Benchmark the gene/variant/disease prioritisation performance for two runs."""
     if not gene_analysis and not variant_analysis and not disease_analysis:
@@ -531,4 +532,67 @@ def benchmark_comparison(
         variant_analysis,
         disease_analysis,
         plot_type,
+    )
+
+
+@click.command()
+@click.option(
+    "--benchmarking-tsv",
+    "-b",
+    required=True,
+    metavar="PATH",
+    help="Path to benchmark summary tsv output by PhEval benchmark commands.",
+    type=Path,
+)
+@click.option(
+    "--gene-analysis/--no-gene-analysis",
+    default=False,
+    required=False,
+    type=bool,
+    show_default=True,
+    help="Specify analysis for gene prioritisation",
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["variant_analysis", "disease_analysis"],
+)
+@click.option(
+    "--variant-analysis/--no-variant-analysis",
+    default=False,
+    required=False,
+    type=bool,
+    show_default=True,
+    help="Specify analysis for variant prioritisation",
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["gene_analysis", "disease_analysis"],
+)
+@click.option(
+    "--disease-analysis/--no-disease-analysis",
+    default=False,
+    required=False,
+    type=bool,
+    show_default=True,
+    help="Specify analysis for disease prioritisation",
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["gene_analysis", "variant_analysis"],
+)
+@click.option(
+    "--plot-type",
+    "-y",
+    default="bar_stacked",
+    show_default=True,
+    type=click.Choice(["bar_stacked", "bar_cumulative", "bar_non_cumulative"]),
+    help="Bar chart type to output.",
+)
+@click.option(
+    "--title",
+    "-t",
+    type=str,
+    help='Title for plot, specify the title on the CLI enclosed with ""',
+)
+def generate_stats_plot(
+        benchmarking_tsv: Path, gene_analysis: bool, variant_analysis: bool, disease_analysis: bool, plot_type: str,
+        title: str = None
+):
+    """Generate bar plot from benchmark stats summary tsv."""
+    generate_plots_from_benchmark_summary_tsv(
+        benchmarking_tsv, gene_analysis, variant_analysis, disease_analysis, plot_type, title
     )

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -58,7 +58,7 @@ from pheval.utils.utils import semsim_convert, semsim_scramble
     that will be applied to semantic similarity score column (e.g. jaccard similarity).""",
 )
 def semsim_scramble_command(
-        input: Path, output: Path, score_column: List[str], scramble_factor: float
+    input: Path, output: Path, score_column: List[str], scramble_factor: float
 ):
     """Scrambles semsim profile multiplying score value by scramble factor
     Args:
@@ -109,10 +109,10 @@ def semsim_scramble_command(
     type=Path,
 )
 def scramble_phenopackets_command(
-        phenopacket_path: Path,
-        phenopacket_dir: Path,
-        scramble_factor: float,
-        output_dir: Path,
+    phenopacket_path: Path,
+    phenopacket_dir: Path,
+    scramble_factor: float,
+    output_dir: Path,
 ):
     """Generate noisy phenopackets from existing ones."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -163,11 +163,11 @@ def scramble_phenopackets_command(
     help="Output path for the difference tsv. Defaults to percentage_diff.semsim.tsv",
 )
 def semsim_comparison(
-        semsim_left: Path,
-        semsim_right: Path,
-        score_column: str,
-        analysis: str,
-        output: Path = "percentage_diff.semsim.tsv",
+    semsim_left: Path,
+    semsim_right: Path,
+    score_column: str,
+    analysis: str,
+    output: Path = "percentage_diff.semsim.tsv",
 ):
     """Compares two semantic similarity profiles
 
@@ -224,7 +224,7 @@ def semsim_comparison(
     type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
 )
 def update_phenopackets_command(
-        phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
+    phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
 ):
     """Update gene symbols and identifiers for phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -280,11 +280,11 @@ def update_phenopackets_command(
     type=Path,
 )
 def create_spiked_vcfs_command(
-        phenopacket_path: Path,
-        phenopacket_dir: Path,
-        output_dir: Path,
-        template_vcf_path: Path = None,
-        vcf_dir: Path = None,
+    phenopacket_path: Path,
+    phenopacket_dir: Path,
+    output_dir: Path,
+    template_vcf_path: Path = None,
+    vcf_dir: Path = None,
 ):
     """Spikes variants into a template VCF file for a directory of phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -334,7 +334,7 @@ def create_spiked_vcfs_command(
     type=click.Choice(["exomiserdb"], case_sensitive=False),
 )
 def semsim_convert_command(
-        input: Path, output: Path, subject_prefix: str, object_prefix: str, output_format: str
+    input: Path, output: Path, subject_prefix: str, object_prefix: str, output_format: str
 ):
     """convert semsim profile to an exomiser database file"""
     semsim_convert(input, output, subject_prefix, object_prefix, output_format)
@@ -347,7 +347,7 @@ def semsim_convert_command(
     required=True,
     metavar="PATH",
     help="General results directory to be benchmarked, assumes contains subdirectories of pheval_gene_results/,"
-         "pheval_variant_results/ or pheval_disease_results/. ",
+    "pheval_variant_results/ or pheval_disease_results/. ",
     type=Path,
 )
 @click.option(
@@ -416,15 +416,15 @@ def semsim_convert_command(
     help="Bar chart type to output.",
 )
 def benchmark(
-        directory: Path,
-        phenopacket_dir: Path,
-        score_order: str,
-        output_prefix: str,
-        threshold: float,
-        gene_analysis: bool,
-        variant_analysis: bool,
-        disease_analysis: bool,
-        plot_type: str,
+    directory: Path,
+    phenopacket_dir: Path,
+    score_order: str,
+    output_prefix: str,
+    threshold: float,
+    gene_analysis: bool,
+    variant_analysis: bool,
+    disease_analysis: bool,
+    plot_type: str,
 ):
     """Benchmark the gene/variant/disease prioritisation performance for a single run."""
     if not gene_analysis and not variant_analysis and not disease_analysis:
@@ -448,9 +448,9 @@ def benchmark(
     required=True,
     metavar="PATH",
     help="Path to .txt file containing testdata phenopacket directory "
-         "and corresponding results directory separated by tab."
-         "Each run contained to a new line with the input testdata listed first and on the same line separated by a tab"
-         "the results directory.",
+    "and corresponding results directory separated by tab."
+    "Each run contained to a new line with the input testdata listed first and on the same line separated by a tab"
+    "the results directory.",
     type=Path,
 )
 @click.option(
@@ -511,14 +511,14 @@ def benchmark(
     help="Bar chart type to output.",
 )
 def benchmark_comparison(
-        run_data: Path,
-        score_order: str,
-        output_prefix: str,
-        threshold: float,
-        gene_analysis: bool,
-        variant_analysis: bool,
-        disease_analysis: bool,
-        plot_type: str,
+    run_data: Path,
+    score_order: str,
+    output_prefix: str,
+    threshold: float,
+    gene_analysis: bool,
+    variant_analysis: bool,
+    disease_analysis: bool,
+    plot_type: str,
 ):
     """Benchmark the gene/variant/disease prioritisation performance for two runs."""
     if not gene_analysis and not variant_analysis and not disease_analysis:
@@ -589,8 +589,12 @@ def benchmark_comparison(
     help='Title for plot, specify the title on the CLI enclosed with ""',
 )
 def generate_stats_plot(
-        benchmarking_tsv: Path, gene_analysis: bool, variant_analysis: bool, disease_analysis: bool, plot_type: str,
-        title: str = None
+    benchmarking_tsv: Path,
+    gene_analysis: bool,
+    variant_analysis: bool,
+    disease_analysis: bool,
+    plot_type: str,
+    title: str = None,
 ):
     """Generate bar plot from benchmark stats summary tsv."""
     generate_plots_from_benchmark_summary_tsv(

--- a/tests/test_generate_plots.py
+++ b/tests/test_generate_plots.py
@@ -11,7 +11,7 @@ class TestPlotGenerator(unittest.TestCase):
         self.variant_plot_generator = PlotGenerator()
         self.disease_plot_generator = PlotGenerator()
         self.track_prioritisation = BenchmarkRunResults(
-            results_dir=Path("/path/to/tool/corpus_results"),
+            results_dir="tool_corpus",
             ranks={},
             rank_stats=RankStats(
                 top=1,
@@ -45,7 +45,7 @@ class TestPlotGenerator(unittest.TestCase):
         self.gene_plot_generator._generate_stats_mrr_bar_plot_data(self.track_prioritisation)
         self.assertEqual(
             self.gene_plot_generator.mrr,
-            [{"Rank": "MRR", "Percentage": 0.33066666666666666, "Run": "tool_corpus"}],
+            [{"Rank": "MRR", "Percentage": 0.11022222222222222, "Run": "tool_corpus"}],
         )
 
     def test__generate_cumulative_bar_plot_data(self):
@@ -59,7 +59,7 @@ class TestPlotGenerator(unittest.TestCase):
                 {"Percentage": 0.4, "Rank": "Top10", "Run": "tool_corpus"},
                 {"Percentage": 0.5, "Rank": "Found", "Run": "tool_corpus"},
                 {"Percentage": 0.5, "Rank": "Missed", "Run": "tool_corpus"},
-                {"Percentage": 0.33066666666666666, "Rank": "MRR", "Run": "tool_corpus"},
+                {"Percentage": 0.11022222222222222, "Rank": "MRR", "Run": "tool_corpus"},
             ],
         )
 
@@ -74,6 +74,6 @@ class TestPlotGenerator(unittest.TestCase):
                 {"Percentage": 0.2, "Rank": "6-10", "Run": "tool_corpus"},
                 {"Percentage": 0.1, "Rank": ">10", "Run": "tool_corpus"},
                 {"Percentage": 0.5, "Rank": "Missed", "Run": "tool_corpus"},
-                {"Percentage": 0.33066666666666666, "Rank": "MRR", "Run": "tool_corpus"},
+                {"Percentage": 0.11022222222222222, "Rank": "MRR", "Run": "tool_corpus"},
             ],
         )

--- a/tests/test_generate_plots.py
+++ b/tests/test_generate_plots.py
@@ -13,7 +13,7 @@ class TestPlotGenerator(unittest.TestCase):
         self.variant_plot_generator = PlotGenerator()
         self.disease_plot_generator = PlotGenerator()
         self.benchmarking_result = BenchmarkRunResults(
-            results_dir="tool_corpus",
+            benchmark_name="tool_corpus",
             ranks={},
             rank_stats=RankStats(
                 top=1,
@@ -34,7 +34,7 @@ class TestPlotGenerator(unittest.TestCase):
 
     def test_create_run_identifier(self):
         self.assertEqual(
-            self.gene_plot_generator.create_run_identifier(self.results_dir),
+            self.gene_plot_generator._create_run_identifier(self.results_dir),
             "tool1-default_corpus1-default",
         )
 

--- a/tests/test_generate_plots.py
+++ b/tests/test_generate_plots.py
@@ -1,3 +1,5 @@
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -10,7 +12,7 @@ class TestPlotGenerator(unittest.TestCase):
         self.gene_plot_generator = PlotGenerator()
         self.variant_plot_generator = PlotGenerator()
         self.disease_plot_generator = PlotGenerator()
-        self.track_prioritisation = BenchmarkRunResults(
+        self.benchmarking_result = BenchmarkRunResults(
             results_dir="tool_corpus",
             ranks={},
             rank_stats=RankStats(
@@ -23,9 +25,19 @@ class TestPlotGenerator(unittest.TestCase):
                 reciprocal_ranks=[1, 1 / 3, 1 / 5, 1 / 10, 1 / 50],
             ),
         )
+        self.test_dir = tempfile.mkdtemp()
+        self.results_dir = Path(self.test_dir).joinpath("tool1-default/corpus1-default")
+        self.results_dir.mkdir(exist_ok=True, parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_create_run_identifier(self):
+        self.assertEqual(self.gene_plot_generator.create_run_identifier(self.results_dir),
+                         "tool1-default_corpus1-default")
 
     def test__generate_stacked_bar_plot_data(self):
-        self.gene_plot_generator._generate_stacked_bar_plot_data(self.track_prioritisation)
+        self.gene_plot_generator._generate_stacked_bar_plot_data(self.benchmarking_result)
         self.assertEqual(
             self.gene_plot_generator.stats,
             [
@@ -42,14 +54,14 @@ class TestPlotGenerator(unittest.TestCase):
         )
 
     def test__generate_stats_mrr_bar_plot_data(self):
-        self.gene_plot_generator._generate_stats_mrr_bar_plot_data(self.track_prioritisation)
+        self.gene_plot_generator._generate_stats_mrr_bar_plot_data(self.benchmarking_result)
         self.assertEqual(
             self.gene_plot_generator.mrr,
             [{"Rank": "MRR", "Percentage": 0.11022222222222222, "Run": "tool_corpus"}],
         )
 
     def test__generate_cumulative_bar_plot_data(self):
-        self.gene_plot_generator._generate_cumulative_bar_plot_data(self.track_prioritisation)
+        self.gene_plot_generator._generate_cumulative_bar_plot_data(self.benchmarking_result)
         self.assertEqual(
             self.gene_plot_generator.stats,
             [
@@ -64,7 +76,7 @@ class TestPlotGenerator(unittest.TestCase):
         )
 
     def test__generate_non_cumulative_bar_plot_data(self):
-        self.gene_plot_generator._generate_non_cumulative_bar_plot_data(self.track_prioritisation)
+        self.gene_plot_generator._generate_non_cumulative_bar_plot_data(self.benchmarking_result)
         self.assertEqual(
             self.gene_plot_generator.stats,
             [

--- a/tests/test_generate_plots.py
+++ b/tests/test_generate_plots.py
@@ -33,8 +33,10 @@ class TestPlotGenerator(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_create_run_identifier(self):
-        self.assertEqual(self.gene_plot_generator.create_run_identifier(self.results_dir),
-                         "tool1-default_corpus1-default")
+        self.assertEqual(
+            self.gene_plot_generator.create_run_identifier(self.results_dir),
+            "tool1-default_corpus1-default",
+        )
 
     def test__generate_stacked_bar_plot_data(self):
         self.gene_plot_generator._generate_stacked_bar_plot_data(self.benchmarking_result)

--- a/tests/test_rank_stats.py
+++ b/tests/test_rank_stats.py
@@ -55,4 +55,18 @@ class TestRankStats(unittest.TestCase):
 
     def test_mean_reciprocal_rank(self):
         self.rank_stats.reciprocal_ranks = [0.2, 0.4, 0.5, 0.6, 0.8]
+        self.rank_stats.total = 5
         self.assertEqual(self.rank_stats.mean_reciprocal_rank(), 0.5)
+
+    def test_mean_reciprocal_rank_missing_cases(self):
+        self.rank_stats.reciprocal_ranks = [0.2, 0.4, 0.5, 0.6, 0.8]
+        self.rank_stats.total = 20
+        self.assertEqual(self.rank_stats.mean_reciprocal_rank(), 0.1)
+
+    def test_return_mean_reciprocal_rank(self):
+        self.rank_stats.reciprocal_ranks = [0.2, 0.4, 0.5, 0.6, 0.8]
+        self.assertEqual(self.rank_stats.return_mean_reciprocal_rank(), 0.5)
+
+    def test_return_mean_reciprocal_rank_from_mrr_variable(self):
+        self.rank_stats.mrr = 0.1
+        self.assertEqual(self.rank_stats.return_mean_reciprocal_rank(), 0.1)


### PR DESCRIPTION
Implemented a command to generate a stats bar plot from the summary benchmark TSV output from the `benchmark` or `benchmark-comparison` command. This allows further customisation to the plot output, there is specification for a title and the summary TSV `results_directory_path` column values can be altered to provide a more specific run identifier. 