### PR TITLE
changing default plot type to cumulative bar

### DIFF
--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -505,7 +505,7 @@ def benchmark(
 @click.option(
     "--plot-type",
     "-y",
-    default="bar_stacked",
+    default="bar_cumulative",
     show_default=True,
     type=click.Choice(["bar_stacked", "bar_cumulative", "bar_non_cumulative"]),
     help="Bar chart type to output.",
@@ -577,7 +577,7 @@ def benchmark_comparison(
 @click.option(
     "--plot-type",
     "-y",
-    default="bar_stacked",
+    default="bar_cumulative",
     show_default=True,
     type=click.Choice(["bar_stacked", "bar_cumulative", "bar_non_cumulative"]),
     help="Bar chart type to output.",


### PR DESCRIPTION
Changed the default plot type that comes out the benchmarking command to the cumulative bar. 

The labels on the plot will show 'Top, Top3, Top5, Top10'