### PR TITLE
Update PhEval dependency installation instruction

### DIFF
--- a/docs/developing_a_pheval_plugin.md
+++ b/docs/developing_a_pheval_plugin.md
@@ -54,7 +54,7 @@ poetry install
 #### Add PhEval dependency
 
 ```
-poetry add pheval
+poetry add git+https://github.com/monarch-initiative/pheval.git
 ```
 
 #### Run tox to see if the setup works


### PR DESCRIPTION
For now, for developers who want to create a PhEval plugin they should add the PhEval dependency with poetry with the GitHub repo link. This will change once there is a solid release for PhEval on PyPi