### PR TITLE
300 change rank decrease to rank change in rank comparison summary

### DIFF
--- a/src/pheval/analyse/generate_summary_outputs.py
+++ b/src/pheval/analyse/generate_summary_outputs.py
@@ -41,7 +41,7 @@ class RankComparisonGenerator:
             pd.DataFrame: DataFrame containing the calculated rank differences.
         """
         comparison_df = self._generate_dataframe()
-        comparison_df["rank_change"] = comparison_df.iloc[:, 3] - comparison_df.iloc[:, 2]
+        comparison_df["rank_change"] = comparison_df.iloc[:, 2] - comparison_df.iloc[:, 3]
         comparison_df["rank_change"] = np.where(
             (comparison_df.iloc[:, 2] == 0) & (comparison_df.iloc[:, 3] != 0),
             "GAINED",

--- a/src/pheval/analyse/generate_summary_outputs.py
+++ b/src/pheval/analyse/generate_summary_outputs.py
@@ -51,6 +51,9 @@ class RankComparisonGenerator:
                 comparison_df["rank_change"],
             ),
         )
+        comparison_df["rank_change"] = comparison_df["rank_change"].apply(
+            lambda x: int(x) if str(x).lstrip("-").isdigit() else x
+        )
         return comparison_df
 
     def generate_output(self, prefix: str, suffix: str) -> None:

--- a/src/pheval/analyse/generate_summary_outputs.py
+++ b/src/pheval/analyse/generate_summary_outputs.py
@@ -42,6 +42,15 @@ class RankComparisonGenerator:
         """
         comparison_df = self._generate_dataframe()
         comparison_df["rank_change"] = comparison_df.iloc[:, 3] - comparison_df.iloc[:, 2]
+        comparison_df["rank_change"] = np.where(
+            (comparison_df.iloc[:, 2] == 0) & (comparison_df.iloc[:, 3] != 0),
+            "GAINED",
+            np.where(
+                (comparison_df.iloc[:, 3] == 0) & (comparison_df.iloc[:, 2] != 0),
+                "LOST",
+                comparison_df["rank_change"],
+            ),
+        )
         return comparison_df
 
     def generate_output(self, prefix: str, suffix: str) -> None:
@@ -66,9 +75,9 @@ class RankComparisonGenerator:
 
 
 def generate_benchmark_output(
-        benchmarking_results: BenchmarkRunResults,
-        plot_type: str,
-        benchmark_generator: BenchmarkRunOutputGenerator,
+    benchmarking_results: BenchmarkRunResults,
+    plot_type: str,
+    benchmark_generator: BenchmarkRunOutputGenerator,
 ) -> None:
     """
     Generate prioritisation outputs for a single benchmarking run.
@@ -123,9 +132,9 @@ def merge_results(result1: dict, result2: dict) -> defaultdict:
 
 
 def generate_benchmark_comparison_output(
-        benchmarking_results: List[BenchmarkRunResults],
-        plot_type: str,
-        benchmark_generator: BenchmarkRunOutputGenerator,
+    benchmarking_results: List[BenchmarkRunResults],
+    plot_type: str,
+    benchmark_generator: BenchmarkRunOutputGenerator,
 ) -> None:
     """
     Generate prioritisation outputs for benchmarking multiple runs.

--- a/src/pheval/analyse/generate_summary_outputs.py
+++ b/src/pheval/analyse/generate_summary_outputs.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from copy import deepcopy
 from typing import List
 
+import numpy as np
 import pandas as pd
 
 from pheval.analyse.benchmark_generator import BenchmarkRunOutputGenerator
@@ -40,7 +41,7 @@ class RankComparisonGenerator:
             pd.DataFrame: DataFrame containing the calculated rank differences.
         """
         comparison_df = self._generate_dataframe()
-        comparison_df["rank_decrease"] = comparison_df.iloc[:, 3] - comparison_df.iloc[:, 2]
+        comparison_df["rank_change"] = comparison_df.iloc[:, 3] - comparison_df.iloc[:, 2]
         return comparison_df
 
     def generate_output(self, prefix: str, suffix: str) -> None:
@@ -65,9 +66,9 @@ class RankComparisonGenerator:
 
 
 def generate_benchmark_output(
-    benchmarking_results: BenchmarkRunResults,
-    plot_type: str,
-    benchmark_generator: BenchmarkRunOutputGenerator,
+        benchmarking_results: BenchmarkRunResults,
+        plot_type: str,
+        benchmark_generator: BenchmarkRunOutputGenerator,
 ) -> None:
     """
     Generate prioritisation outputs for a single benchmarking run.
@@ -122,9 +123,9 @@ def merge_results(result1: dict, result2: dict) -> defaultdict:
 
 
 def generate_benchmark_comparison_output(
-    benchmarking_results: List[BenchmarkRunResults],
-    plot_type: str,
-    benchmark_generator: BenchmarkRunOutputGenerator,
+        benchmarking_results: List[BenchmarkRunResults],
+        plot_type: str,
+        benchmark_generator: BenchmarkRunOutputGenerator,
 ) -> None:
     """
     Generate prioritisation outputs for benchmarking multiple runs.

--- a/tests/test_generate_summary_outputs.py
+++ b/tests/test_generate_summary_outputs.py
@@ -102,7 +102,7 @@ class TestRankComparisonGenerator(unittest.TestCase):
                     "Gene": "GCDH",
                     "/path/to/results_directory1": 1,
                     "/path/to/results_directory2": 5,
-                    "rank_change": 4,
+                    "rank_change": -4,
                 }
             ]
         )
@@ -117,7 +117,7 @@ class TestRankComparisonGenerator(unittest.TestCase):
                     "Variant": "3-12563453454-C-T",
                     "/path/to/results_directory1": 9,
                     "/path/to/results_directory2": 3,
-                    "rank_change": -6,
+                    "rank_change": 6,
                 }
             ]
         )

--- a/tests/test_generate_summary_outputs.py
+++ b/tests/test_generate_summary_outputs.py
@@ -102,7 +102,7 @@ class TestRankComparisonGenerator(unittest.TestCase):
                     "Gene": "GCDH",
                     "/path/to/results_directory1": 1,
                     "/path/to/results_directory2": 5,
-                    "rank_decrease": 4,
+                    "rank_change": 4,
                 }
             ]
         )
@@ -117,7 +117,7 @@ class TestRankComparisonGenerator(unittest.TestCase):
                     "Variant": "3-12563453454-C-T",
                     "/path/to/results_directory1": 9,
                     "/path/to/results_directory2": 3,
-                    "rank_decrease": -6,
+                    "rank_change": -6,
                 }
             ]
         )


### PR DESCRIPTION
Changed the `rank_decrease` column to `rank_change` in the rank comparison summary file. In cases where a result is not found this has been replaced by a `GAINED` or `LOST` label.

e.g.,

```tsv
	Phenopacket	Gene	exomiser-13.3.0-2109/lirical-default/pheval_gene_results	GPT-4_turbo/complex_prompt/pheval_gene_results	rank_change
1	Abdul_Wahab-2016-GCDH-Patient_5.json	GCDH	1	1.0	0.0
2	Ajmal-2013-BBS1-IV-5_family_A.json	BBS1	3	0.0	LOST
3	Al-Dosari-2010-TFAP2A-10-year-old_girl.json	TFAP2A	0	66	GAINED
4	Al-Hashmi-2018-SNX14-IV-1.json	SNX14	9	6	-3
```