### PR TITLE
302 add roc curves and precision recall curves to benchmarking output

### DIFF
--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -5,7 +5,7 @@ import matplotlib
 import pandas as pd
 import seaborn as sns
 from matplotlib import pyplot as plt
-from sklearn.metrics import auc, roc_curve, precision_recall_curve
+from sklearn.metrics import auc, precision_recall_curve, roc_curve
 
 from pheval.analyse.benchmark_generator import (
     BenchmarkRunOutputGenerator,
@@ -397,9 +397,9 @@ class PlotGenerator:
         )
 
     def generate_precision_recall(
-            self,
-            benchmarking_results: List[BenchmarkRunResults],
-            benchmark_generator: BenchmarkRunOutputGenerator,
+        self,
+        benchmarking_results: List[BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
     ):
         """
         Generate and plot Precision-Recall curves for binary classification benchmark results.
@@ -418,7 +418,8 @@ class PlotGenerator:
             plt.plot(
                 recall,
                 precision,
-                label=f"{self.return_benchmark_name(benchmark_result)} Precision-Recall Curve (AUC = {precision_recall_auc:.2f})",
+                label=f"{self.return_benchmark_name(benchmark_result)} Precision-Recall Curve "
+                f"(AUC = {precision_recall_auc:.2f})",
                 color=self.palette_hex_codes[i],
             )
 

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -367,8 +367,8 @@ class PlotGenerator:
         Generate and plot Receiver Operating Characteristic (ROC) curves for binary classification benchmark results.
 
         Args:
-        benchmarking_results (List[BenchmarkRunResults]): List of benchmarking results for multiple runs.
-        benchmark_generator (BenchmarkRunOutputGenerator): Object containing benchmarking output generation details.
+            benchmarking_results (List[BenchmarkRunResults]): List of benchmarking results for multiple runs.
+            benchmark_generator (BenchmarkRunOutputGenerator): Object containing benchmarking output generation details.
         """
         for i, benchmark_result in enumerate(benchmarking_results):
             fpr, tpr, thresh = roc_curve(
@@ -392,6 +392,43 @@ class PlotGenerator:
         plt.legend(loc="upper center", bbox_to_anchor=(0.5, -0.15))
         plt.savefig(
             f"{benchmark_generator.prioritisation_type_file_prefix}_roc_curve.svg",
+            format="svg",
+            bbox_inches="tight",
+        )
+
+    def generate_precision_recall(
+            self,
+            benchmarking_results: List[BenchmarkRunResults],
+            benchmark_generator: BenchmarkRunOutputGenerator,
+    ):
+        """
+        Generate and plot Precision-Recall curves for binary classification benchmark results.
+
+        Args:
+            benchmarking_results (List[BenchmarkRunResults]): List of benchmarking results for multiple runs.
+            benchmark_generator (BenchmarkRunOutputGenerator): Object containing benchmarking output generation details.
+        """
+        plt.figure()
+        for i, benchmark_result in enumerate(benchmarking_results):
+            precision, recall, thresh = precision_recall_curve(
+                benchmark_result.binary_classification_stats.labels,
+                benchmark_result.binary_classification_stats.scores,
+            )
+            precision_recall_auc = auc(recall, precision)
+            plt.plot(
+                recall,
+                precision,
+                label=f"{self.return_benchmark_name(benchmark_result)} Precision-Recall Curve (AUC = {precision_recall_auc:.2f})",
+                color=self.palette_hex_codes[i],
+            )
+
+        plt.plot(linestyle="--", color="gray")
+        plt.xlabel("Recall")
+        plt.ylabel("Precision")
+        plt.title("Precision-Recall Curve")
+        plt.legend(loc="upper center", bbox_to_anchor=(0.5, -0.15))
+        plt.savefig(
+            f"{benchmark_generator.prioritisation_type_file_prefix}_precision_recall_curve.svg",
             format="svg",
             bbox_inches="tight",
         )
@@ -458,6 +495,7 @@ def generate_plots(
     """
     plot_generator = PlotGenerator()
     plot_generator.generate_roc_curve(benchmarking_results, benchmark_generator)
+    plot_generator.generate_precision_recall(benchmarking_results, benchmark_generator)
     if plot_type == "bar_stacked":
         plot_generator.generate_stacked_bar_plot(benchmarking_results, benchmark_generator, title)
     elif plot_type == "bar_cumulative":

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -5,6 +5,7 @@ import matplotlib
 import pandas as pd
 import seaborn as sns
 from matplotlib import pyplot as plt
+from sklearn.metrics import auc, roc_curve, precision_recall_curve
 
 from pheval.analyse.benchmark_generator import (
     BenchmarkRunOutputGenerator,
@@ -357,6 +358,44 @@ class PlotGenerator:
             ]
         )
 
+    def generate_roc_curve(
+        self,
+        benchmarking_results: List[BenchmarkRunResults],
+        benchmark_generator: BenchmarkRunOutputGenerator,
+    ):
+        """
+        Generate and plot Receiver Operating Characteristic (ROC) curves for binary classification benchmark results.
+
+        Args:
+        benchmarking_results (List[BenchmarkRunResults]): List of benchmarking results for multiple runs.
+        benchmark_generator (BenchmarkRunOutputGenerator): Object containing benchmarking output generation details.
+        """
+        for i, benchmark_result in enumerate(benchmarking_results):
+            fpr, tpr, thresh = roc_curve(
+                benchmark_result.binary_classification_stats.labels,
+                benchmark_result.binary_classification_stats.scores,
+                pos_label=1,
+            )
+            roc_auc = auc(fpr, tpr)
+
+            plt.plot(
+                fpr,
+                tpr,
+                label=f"{self.return_benchmark_name(benchmark_result)} ROC Curve (AUC = {roc_auc:.2f})",
+                color=self.palette_hex_codes[i],
+            )
+
+        plt.plot(linestyle="--", color="gray")
+        plt.xlabel("False Positive Rate")
+        plt.ylabel("True Positive Rate")
+        plt.title("Receiver Operating Characteristic (ROC) Curve")
+        plt.legend(loc="upper center", bbox_to_anchor=(0.5, -0.15))
+        plt.savefig(
+            f"{benchmark_generator.prioritisation_type_file_prefix}_roc_curve.svg",
+            format="svg",
+            bbox_inches="tight",
+        )
+
     def generate_non_cumulative_bar(
         self,
         benchmarking_results: List[BenchmarkRunResults],
@@ -418,6 +457,7 @@ def generate_plots(
         title (str, optional): Title for the generated plot. Defaults to None.
     """
     plot_generator = PlotGenerator()
+    plot_generator.generate_roc_curve(benchmarking_results, benchmark_generator)
     if plot_type == "bar_stacked":
         plot_generator.generate_stacked_bar_plot(benchmarking_results, benchmark_generator, title)
     elif plot_type == "bar_cumulative":

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -579,8 +579,12 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0,  labels=[1, 0, 0, 0],
-                          scores=[0.8764, 0.5777, 0.5777, 0.3765]
+                true_positives=1,
+                true_negatives=3,
+                false_positives=0,
+                false_negatives=0,
+                labels=[1, 0, 0, 0],
+                scores=[0.8764, 0.5777, 0.5777, 0.3765],
             ),
         )
 
@@ -621,8 +625,12 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1, labels=[0, 0, 0, 0],
-                          scores=[0.3765, 0.5777, 0.5777, 0.8764]
+                true_positives=0,
+                true_negatives=3,
+                false_positives=1,
+                false_negatives=1,
+                labels=[0, 0, 0, 0],
+                scores=[0.3765, 0.5777, 0.5777, 0.8764],
             ),
         )
 
@@ -663,8 +671,12 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=2, false_positives=1, false_negatives=1, labels=[0, 0, 0, 1],
-                          scores=[0.3765, 0.5777, 0.5777, 0.8764]
+                true_positives=0,
+                true_negatives=2,
+                false_positives=1,
+                false_negatives=1,
+                labels=[0, 0, 0, 1],
+                scores=[0.3765, 0.5777, 0.5777, 0.8764],
             ),
         )
 
@@ -705,8 +717,12 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1, labels=[0, 0, 0, 0],
-                          scores=[0.8764, 0.5777, 0.5777, 0.3765]
+                true_positives=0,
+                true_negatives=3,
+                false_positives=1,
+                false_negatives=1,
+                labels=[0, 0, 0, 0],
+                scores=[0.8764, 0.5777, 0.5777, 0.3765],
             ),
         )
 
@@ -747,8 +763,12 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0, labels=[1, 0, 0, 0],
-                          scores=[0.8764, 0.5777, 0.5777, 0.3765]
+                true_positives=1,
+                true_negatives=3,
+                false_positives=0,
+                false_negatives=0,
+                labels=[1, 0, 0, 0],
+                scores=[0.8764, 0.5777, 0.5777, 0.3765],
             ),
         )
 
@@ -967,8 +987,12 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0, labels=[1, 0, 0],
-                          scores=[0.0484, 0.0484, 0.0484]
+                true_positives=1,
+                true_negatives=0,
+                false_positives=2,
+                false_negatives=0,
+                labels=[1, 0, 0],
+                scores=[0.0484, 0.0484, 0.0484],
             ),
         )
 
@@ -1009,8 +1033,12 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=0, false_positives=3, false_negatives=1, labels=[0, 0, 0],
-                          scores=[0.0484, 0.0484, 0.0484]
+                true_positives=0,
+                true_negatives=0,
+                false_positives=3,
+                false_negatives=1,
+                labels=[0, 0, 0],
+                scores=[0.0484, 0.0484, 0.0484],
             ),
         )
 
@@ -1051,8 +1079,12 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0, labels=[1, 0, 0],
-                          scores=[0.0484, 0.0484, 0.0484]
+                true_positives=1,
+                true_negatives=0,
+                false_positives=2,
+                false_negatives=0,
+                labels=[1, 0, 0],
+                scores=[0.0484, 0.0484, 0.0484],
             ),
         )
 
@@ -1093,8 +1125,12 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=0, false_positives=3, false_negatives=1, labels=[0, 0, 0],
-                          scores=[0.0484, 0.0484, 0.0484]
+                true_positives=0,
+                true_negatives=0,
+                false_positives=3,
+                false_negatives=1,
+                labels=[0, 0, 0],
+                scores=[0.0484, 0.0484, 0.0484],
             ),
         )
 
@@ -1135,8 +1171,12 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0, labels=[1, 0, 0],
-                          scores=[0.0484, 0.0484, 0.0484]
+                true_positives=1,
+                true_negatives=0,
+                false_positives=2,
+                false_negatives=0,
+                labels=[1, 0, 0],
+                scores=[0.0484, 0.0484, 0.0484],
             ),
         )
 
@@ -1378,8 +1418,12 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0, labels=[1, 0, 0, 0],
-                          scores=[1.0, 0.5, 0.5, 0.3]
+                true_positives=1,
+                true_negatives=3,
+                false_positives=0,
+                false_negatives=0,
+                labels=[1, 0, 0, 0],
+                scores=[1.0, 0.5, 0.5, 0.3],
             ),
         )
 
@@ -1415,8 +1459,12 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1, labels=[0, 0, 0, 0],
-                          scores=[0.3765, 0.5777, 0.5777, 0.8764]
+                true_positives=0,
+                true_negatives=3,
+                false_positives=1,
+                false_negatives=1,
+                labels=[0, 0, 0, 0],
+                scores=[0.3765, 0.5777, 0.5777, 0.8764],
             ),
         )
 
@@ -1452,8 +1500,12 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=2, false_positives=1, false_negatives=1, labels=[0, 0, 0, 1],
-                          scores=[0.3765, 0.5777, 0.5777, 0.8764]
+                true_positives=0,
+                true_negatives=2,
+                false_positives=1,
+                false_negatives=1,
+                labels=[0, 0, 0, 1],
+                scores=[0.3765, 0.5777, 0.5777, 0.8764],
             ),
         )
 
@@ -1489,8 +1541,12 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1, labels=[0, 0, 0, 0],
-                          scores=[1.0, 0.5, 0.5, 0.3]
+                true_positives=0,
+                true_negatives=3,
+                false_positives=1,
+                false_negatives=1,
+                labels=[0, 0, 0, 0],
+                scores=[1.0, 0.5, 0.5, 0.3],
             ),
         )
 
@@ -1526,7 +1582,11 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0, labels=[1, 0, 0, 0],
-                          scores=[1.0, 0.5, 0.5, 0.3]
+                true_positives=1,
+                true_negatives=3,
+                false_positives=0,
+                false_negatives=0,
+                labels=[1, 0, 0, 0],
+                scores=[1.0, 0.5, 0.5, 0.3],
             ),
         )

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -579,7 +579,8 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0
+                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0,  labels=[1, 0, 0, 0],
+                          scores=[0.8764, 0.5777, 0.5777, 0.3765]
             ),
         )
 
@@ -620,7 +621,8 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1
+                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1, labels=[0, 0, 0, 0],
+                          scores=[0.3765, 0.5777, 0.5777, 0.8764]
             ),
         )
 
@@ -661,7 +663,8 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=2, false_positives=1, false_negatives=1
+                true_positives=0, true_negatives=2, false_positives=1, false_negatives=1, labels=[0, 0, 0, 1],
+                          scores=[0.3765, 0.5777, 0.5777, 0.8764]
             ),
         )
 
@@ -702,7 +705,8 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1
+                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1, labels=[0, 0, 0, 0],
+                          scores=[0.8764, 0.5777, 0.5777, 0.3765]
             ),
         )
 
@@ -743,7 +747,8 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0
+                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0, labels=[1, 0, 0, 0],
+                          scores=[0.8764, 0.5777, 0.5777, 0.3765]
             ),
         )
 
@@ -962,7 +967,8 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0
+                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0, labels=[1, 0, 0],
+                          scores=[0.0484, 0.0484, 0.0484]
             ),
         )
 
@@ -1003,7 +1009,8 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=0, false_positives=3, false_negatives=1
+                true_positives=0, true_negatives=0, false_positives=3, false_negatives=1, labels=[0, 0, 0],
+                          scores=[0.0484, 0.0484, 0.0484]
             ),
         )
 
@@ -1044,7 +1051,8 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0
+                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0, labels=[1, 0, 0],
+                          scores=[0.0484, 0.0484, 0.0484]
             ),
         )
 
@@ -1085,7 +1093,8 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=0, false_positives=3, false_negatives=1
+                true_positives=0, true_negatives=0, false_positives=3, false_negatives=1, labels=[0, 0, 0],
+                          scores=[0.0484, 0.0484, 0.0484]
             ),
         )
 
@@ -1126,7 +1135,8 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0
+                true_positives=1, true_negatives=0, false_positives=2, false_negatives=0, labels=[1, 0, 0],
+                          scores=[0.0484, 0.0484, 0.0484]
             ),
         )
 
@@ -1368,7 +1378,8 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0
+                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0, labels=[1, 0, 0, 0],
+                          scores=[1.0, 0.5, 0.5, 0.3]
             ),
         )
 
@@ -1404,7 +1415,8 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1
+                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1, labels=[0, 0, 0, 0],
+                          scores=[0.3765, 0.5777, 0.5777, 0.8764]
             ),
         )
 
@@ -1440,7 +1452,8 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=2, false_positives=1, false_negatives=1
+                true_positives=0, true_negatives=2, false_positives=1, false_negatives=1, labels=[0, 0, 0, 1],
+                          scores=[0.3765, 0.5777, 0.5777, 0.8764]
             ),
         )
 
@@ -1476,7 +1489,8 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1
+                true_positives=0, true_negatives=3, false_positives=1, false_negatives=1, labels=[0, 0, 0, 0],
+                          scores=[1.0, 0.5, 0.5, 0.3]
             ),
         )
 
@@ -1512,6 +1526,7 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0
+                true_positives=1, true_negatives=3, false_positives=0, false_negatives=0, labels=[1, 0, 0, 0],
+                          scores=[1.0, 0.5, 0.5, 0.3]
             ),
         )

--- a/tests/test_binary_classification_stats.py
+++ b/tests/test_binary_classification_stats.py
@@ -100,7 +100,12 @@ class TestBinaryClassificationStats(unittest.TestCase):
         self.assertEqual(
             self.binary_classification_stats,
             BinaryClassificationStats(
-                true_positives=1, true_negatives=2, false_positives=0, false_negatives=1
+                true_positives=1,
+                true_negatives=2,
+                false_positives=0,
+                false_negatives=1,
+                labels=[1, 1, 0, 0],
+                scores=[1.0, 0.5, 0.5, 0.3],
             ),
         )
 


### PR DESCRIPTION
Added methods for generating ROC curves and precision-recall curves from the binary classification stats during the benchmarking