### PR TITLE
311 implement a prepare corpus command

### DIFF
--- a/src/pheval/cli.py
+++ b/src/pheval/cli.py
@@ -10,6 +10,7 @@ from .cli_pheval_utils import (
     benchmark_comparison,
     create_spiked_vcfs_command,
     generate_stats_plot,
+    prepare_corpus_command,
     scramble_phenopackets_command,
     semsim_scramble_command,
     semsim_to_exomiserdb_command,
@@ -60,6 +61,7 @@ pheval_utils.add_command(benchmark)
 pheval_utils.add_command(benchmark_comparison)
 pheval_utils.add_command(semsim_to_exomiserdb_command)
 pheval_utils.add_command(generate_stats_plot)
+pheval_utils.add_command(prepare_corpus_command)
 
 if __name__ == "__main__":
     main()

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -15,6 +15,7 @@ from pheval.analyse.run_data_parser import parse_run_data_text_file
 from pheval.prepare.create_noisy_phenopackets import scramble_phenopackets
 from pheval.prepare.create_spiked_vcf import spike_vcfs
 from pheval.prepare.custom_exceptions import InputError, MutuallyExclusiveOptionError
+from pheval.prepare.prepare_corpus import prepare_corpus
 from pheval.prepare.update_phenopacket import update_phenopackets
 from pheval.utils.exomiser import semsim_to_exomiserdb
 from pheval.utils.semsim_utils import percentage_diff, semsim_heatmap_plot
@@ -59,7 +60,7 @@ from pheval.utils.utils import semsim_scramble
     that will be applied to semantic similarity score column (e.g. jaccard similarity).""",
 )
 def semsim_scramble_command(
-    input: Path, output: Path, score_column: List[str], scramble_factor: float
+        input: Path, output: Path, score_column: List[str], scramble_factor: float
 ):
     """Scrambles semsim profile multiplying score value by scramble factor
     Args:
@@ -110,10 +111,10 @@ def semsim_scramble_command(
     type=Path,
 )
 def scramble_phenopackets_command(
-    phenopacket_path: Path,
-    phenopacket_dir: Path,
-    scramble_factor: float,
-    output_dir: Path,
+        phenopacket_path: Path,
+        phenopacket_dir: Path,
+        scramble_factor: float,
+        output_dir: Path,
 ):
     """Generate noisy phenopackets from existing ones."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -164,11 +165,11 @@ def scramble_phenopackets_command(
     help="Output path for the difference tsv. Defaults to percentage_diff.semsim.tsv",
 )
 def semsim_comparison(
-    semsim_left: Path,
-    semsim_right: Path,
-    score_column: str,
-    analysis: str,
-    output: Path = "percentage_diff.semsim.tsv",
+        semsim_left: Path,
+        semsim_right: Path,
+        score_column: str,
+        analysis: str,
+        output: Path = "percentage_diff.semsim.tsv",
 ):
     """Compares two semantic similarity profiles
 
@@ -225,7 +226,7 @@ def semsim_comparison(
     type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
 )
 def update_phenopackets_command(
-    phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
+        phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
 ):
     """Update gene symbols and identifiers for phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -281,11 +282,11 @@ def update_phenopackets_command(
     type=Path,
 )
 def create_spiked_vcfs_command(
-    phenopacket_path: Path,
-    phenopacket_dir: Path,
-    output_dir: Path,
-    template_vcf_path: Path = None,
-    vcf_dir: Path = None,
+        phenopacket_path: Path,
+        phenopacket_dir: Path,
+        output_dir: Path,
+        template_vcf_path: Path = None,
+        vcf_dir: Path = None,
 ):
     """Spikes variants into a template VCF file for a directory of phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -300,7 +301,7 @@ def create_spiked_vcfs_command(
     required=True,
     metavar="PATH",
     help="General results directory to be benchmarked, assumes contains subdirectories of pheval_gene_results/,"
-    "pheval_variant_results/ or pheval_disease_results/. ",
+         "pheval_variant_results/ or pheval_disease_results/. ",
     type=Path,
 )
 @click.option(
@@ -369,15 +370,15 @@ def create_spiked_vcfs_command(
     help="Bar chart type to output.",
 )
 def benchmark(
-    directory: Path,
-    phenopacket_dir: Path,
-    score_order: str,
-    output_prefix: str,
-    threshold: float,
-    gene_analysis: bool,
-    variant_analysis: bool,
-    disease_analysis: bool,
-    plot_type: str,
+        directory: Path,
+        phenopacket_dir: Path,
+        score_order: str,
+        output_prefix: str,
+        threshold: float,
+        gene_analysis: bool,
+        variant_analysis: bool,
+        disease_analysis: bool,
+        plot_type: str,
 ):
     """Benchmark the gene/variant/disease prioritisation performance for a single run."""
     if not gene_analysis and not variant_analysis and not disease_analysis:
@@ -401,9 +402,9 @@ def benchmark(
     required=True,
     metavar="PATH",
     help="Path to .txt file containing testdata phenopacket directory "
-    "and corresponding results directory separated by tab."
-    "Each run contained to a new line with the input testdata listed first and on the same line separated by a tab"
-    "the results directory.",
+         "and corresponding results directory separated by tab."
+         "Each run contained to a new line with the input testdata listed first and on the same line separated by a tab"
+         "the results directory.",
     type=Path,
 )
 @click.option(
@@ -464,14 +465,14 @@ def benchmark(
     help="Bar chart type to output.",
 )
 def benchmark_comparison(
-    run_data: Path,
-    score_order: str,
-    output_prefix: str,
-    threshold: float,
-    gene_analysis: bool,
-    variant_analysis: bool,
-    disease_analysis: bool,
-    plot_type: str,
+        run_data: Path,
+        score_order: str,
+        output_prefix: str,
+        threshold: float,
+        gene_analysis: bool,
+        variant_analysis: bool,
+        disease_analysis: bool,
+        plot_type: str,
 ):
     """Benchmark the gene/variant/disease prioritisation performance for two runs."""
     if not gene_analysis and not variant_analysis and not disease_analysis:
@@ -522,7 +523,7 @@ def benchmark_comparison(
     type=Path,
 )
 def semsim_to_exomiserdb_command(
-    input_file: Path, object_prefix: str, subject_prefix: str, db_path: Path
+        input_file: Path, object_prefix: str, subject_prefix: str, db_path: Path
 ):
     """ingests semsim file into exomiser phenotypic database
 
@@ -589,14 +590,99 @@ def semsim_to_exomiserdb_command(
     help='Title for plot, specify the title on the CLI enclosed with ""',
 )
 def generate_stats_plot(
-    benchmarking_tsv: Path,
-    gene_analysis: bool,
-    variant_analysis: bool,
-    disease_analysis: bool,
-    plot_type: str,
-    title: str = None,
+        benchmarking_tsv: Path,
+        gene_analysis: bool,
+        variant_analysis: bool,
+        disease_analysis: bool,
+        plot_type: str,
+        title: str = None,
 ):
     """Generate bar plot from benchmark stats summary tsv."""
     generate_plots_from_benchmark_summary_tsv(
         benchmarking_tsv, gene_analysis, variant_analysis, disease_analysis, plot_type, title
+    )
+
+
+@click.command("prepare-corpus")
+@click.option(
+    "--phenopacket-dir",
+    "-p",
+    required=True,
+    metavar="PATH",
+    help="Path to phenopacket corpus directory..",
+    type=Path,
+)
+@click.option(
+    "--variant-analysis/--no-variant-analysis",
+    default=False,
+    required=False,
+    type=bool,
+    show_default=True,
+    help="Specify whether to check for complete variant records in the phenopackets.",
+)
+@click.option(
+    "--gene-analysis/--no-gene-analysis",
+    default=False,
+    required=False,
+    type=bool,
+    show_default=True,
+    help="Specify whether to check for complete gene records in the phenopackets.",
+)
+@click.option(
+    "--disease-analysis/--no-disease-analysis",
+    default=False,
+    required=False,
+    type=bool,
+    show_default=True,
+    help="Specify whether to check for complete disease records in the phenopackets.",
+)
+@click.option(
+    "--gene-identifier",
+    "-g",
+    required=False,
+    help="Gene identifier to update in phenopacket",
+    type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
+)
+@click.option(
+    "--template-vcf-path",
+    "-t",
+    metavar="PATH",
+    required=False,
+    help="Path to template VCF file",
+    type=Path,
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    metavar="PATH",
+    required=True,
+    help="Path to output prepared corpus.",
+    default="prepared_corpus",
+    type=Path,
+)
+def prepare_corpus_command(
+        phenopacket_dir: Path,
+        variant_analysis: bool,
+        gene_analysis: bool,
+        disease_analysis: bool,
+        gene_identifier: str,
+        template_vcf_path: Path,
+        output_dir: Path,
+):
+    """
+    Prepare a corpus of Phenopackets for analysis, optionally checking for complete variant records and updating
+    gene identifiers.
+
+        Args:
+            phenopacket_dir (Path): The path to the directory containing Phenopackets.
+            variant_analysis (bool): If True, check for complete variant records in the Phenopackets.
+            gene_analysis (bool): If True, check for complete gene records in the Phenopackets.
+            disease_analysis (bool): If True, check for complete disease records in the Phenopackets.
+            gene_identifier (str): Identifier for updating gene identifiers, if applicable.
+            template_vcf_path (Path): The path to the template VCF file.
+            output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
+    """
+    prepare_corpus(
+        phenopacket_dir, variant_analysis, gene_analysis, disease_analysis, gene_identifier, template_vcf_path,
+        output_dir
     )

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -694,8 +694,10 @@ def prepare_corpus_command(
             gene_analysis (bool): If True, check for complete gene records in the Phenopackets.
             disease_analysis (bool): If True, check for complete disease records in the Phenopackets.
             gene_identifier (str): Identifier for updating gene identifiers, if applicable.
-            hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
-            hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
+            hg19_template_vcf (Path): Path to the hg19 template VCF file (optional), to spike variants into
+            VCFs for variant-based analysis at least one of hg19_template_vcf or hg38_template_vcf is required.
+            hg38_template_vcf (Path): Path to the hg38 template VCF file (optional), to spike variants into
+            VCFs for variant-based analysis at least one of hg19_template_vcf or hg38_template_vcf is required.
             output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
     """
     prepare_corpus(

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -650,11 +650,19 @@ def generate_stats_plot(
     type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
 )
 @click.option(
-    "--template-vcf-path",
-    "-t",
+    "--hg19-template-vcf",
+    "-hg19",
     metavar="PATH",
     required=False,
-    help="Path to template VCF file",
+    help="Template hg19 VCF file",
+    type=Path,
+)
+@click.option(
+    "--hg38-template-vcf",
+    "-hg38",
+    metavar="PATH",
+    required=False,
+    help="Template hg38 VCF file",
     type=Path,
 )
 @click.option(
@@ -672,7 +680,8 @@ def prepare_corpus_command(
     gene_analysis: bool,
     disease_analysis: bool,
     gene_identifier: str,
-    template_vcf_path: Path,
+    hg19_template_vcf: Path,
+    hg38_template_vcf: Path,
     output_dir: Path,
 ):
     """
@@ -685,7 +694,8 @@ def prepare_corpus_command(
             gene_analysis (bool): If True, check for complete gene records in the Phenopackets.
             disease_analysis (bool): If True, check for complete disease records in the Phenopackets.
             gene_identifier (str): Identifier for updating gene identifiers, if applicable.
-            template_vcf_path (Path): The path to the template VCF file.
+            hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
+            hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
             output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
     """
     prepare_corpus(
@@ -694,6 +704,7 @@ def prepare_corpus_command(
         gene_analysis,
         disease_analysis,
         gene_identifier,
-        template_vcf_path,
+        hg19_template_vcf,
+        hg38_template_vcf,
         output_dir,
     )

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -60,7 +60,7 @@ from pheval.utils.utils import semsim_scramble
     that will be applied to semantic similarity score column (e.g. jaccard similarity).""",
 )
 def semsim_scramble_command(
-        input: Path, output: Path, score_column: List[str], scramble_factor: float
+    input: Path, output: Path, score_column: List[str], scramble_factor: float
 ):
     """Scrambles semsim profile multiplying score value by scramble factor
     Args:
@@ -111,10 +111,10 @@ def semsim_scramble_command(
     type=Path,
 )
 def scramble_phenopackets_command(
-        phenopacket_path: Path,
-        phenopacket_dir: Path,
-        scramble_factor: float,
-        output_dir: Path,
+    phenopacket_path: Path,
+    phenopacket_dir: Path,
+    scramble_factor: float,
+    output_dir: Path,
 ):
     """Generate noisy phenopackets from existing ones."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -165,11 +165,11 @@ def scramble_phenopackets_command(
     help="Output path for the difference tsv. Defaults to percentage_diff.semsim.tsv",
 )
 def semsim_comparison(
-        semsim_left: Path,
-        semsim_right: Path,
-        score_column: str,
-        analysis: str,
-        output: Path = "percentage_diff.semsim.tsv",
+    semsim_left: Path,
+    semsim_right: Path,
+    score_column: str,
+    analysis: str,
+    output: Path = "percentage_diff.semsim.tsv",
 ):
     """Compares two semantic similarity profiles
 
@@ -226,7 +226,7 @@ def semsim_comparison(
     type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
 )
 def update_phenopackets_command(
-        phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
+    phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
 ):
     """Update gene symbols and identifiers for phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -282,11 +282,11 @@ def update_phenopackets_command(
     type=Path,
 )
 def create_spiked_vcfs_command(
-        phenopacket_path: Path,
-        phenopacket_dir: Path,
-        output_dir: Path,
-        template_vcf_path: Path = None,
-        vcf_dir: Path = None,
+    phenopacket_path: Path,
+    phenopacket_dir: Path,
+    output_dir: Path,
+    template_vcf_path: Path = None,
+    vcf_dir: Path = None,
 ):
     """Spikes variants into a template VCF file for a directory of phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
@@ -301,7 +301,7 @@ def create_spiked_vcfs_command(
     required=True,
     metavar="PATH",
     help="General results directory to be benchmarked, assumes contains subdirectories of pheval_gene_results/,"
-         "pheval_variant_results/ or pheval_disease_results/. ",
+    "pheval_variant_results/ or pheval_disease_results/. ",
     type=Path,
 )
 @click.option(
@@ -370,15 +370,15 @@ def create_spiked_vcfs_command(
     help="Bar chart type to output.",
 )
 def benchmark(
-        directory: Path,
-        phenopacket_dir: Path,
-        score_order: str,
-        output_prefix: str,
-        threshold: float,
-        gene_analysis: bool,
-        variant_analysis: bool,
-        disease_analysis: bool,
-        plot_type: str,
+    directory: Path,
+    phenopacket_dir: Path,
+    score_order: str,
+    output_prefix: str,
+    threshold: float,
+    gene_analysis: bool,
+    variant_analysis: bool,
+    disease_analysis: bool,
+    plot_type: str,
 ):
     """Benchmark the gene/variant/disease prioritisation performance for a single run."""
     if not gene_analysis and not variant_analysis and not disease_analysis:
@@ -402,9 +402,9 @@ def benchmark(
     required=True,
     metavar="PATH",
     help="Path to .txt file containing testdata phenopacket directory "
-         "and corresponding results directory separated by tab."
-         "Each run contained to a new line with the input testdata listed first and on the same line separated by a tab"
-         "the results directory.",
+    "and corresponding results directory separated by tab."
+    "Each run contained to a new line with the input testdata listed first and on the same line separated by a tab"
+    "the results directory.",
     type=Path,
 )
 @click.option(
@@ -465,14 +465,14 @@ def benchmark(
     help="Bar chart type to output.",
 )
 def benchmark_comparison(
-        run_data: Path,
-        score_order: str,
-        output_prefix: str,
-        threshold: float,
-        gene_analysis: bool,
-        variant_analysis: bool,
-        disease_analysis: bool,
-        plot_type: str,
+    run_data: Path,
+    score_order: str,
+    output_prefix: str,
+    threshold: float,
+    gene_analysis: bool,
+    variant_analysis: bool,
+    disease_analysis: bool,
+    plot_type: str,
 ):
     """Benchmark the gene/variant/disease prioritisation performance for two runs."""
     if not gene_analysis and not variant_analysis and not disease_analysis:
@@ -523,7 +523,7 @@ def benchmark_comparison(
     type=Path,
 )
 def semsim_to_exomiserdb_command(
-        input_file: Path, object_prefix: str, subject_prefix: str, db_path: Path
+    input_file: Path, object_prefix: str, subject_prefix: str, db_path: Path
 ):
     """ingests semsim file into exomiser phenotypic database
 
@@ -590,12 +590,12 @@ def semsim_to_exomiserdb_command(
     help='Title for plot, specify the title on the CLI enclosed with ""',
 )
 def generate_stats_plot(
-        benchmarking_tsv: Path,
-        gene_analysis: bool,
-        variant_analysis: bool,
-        disease_analysis: bool,
-        plot_type: str,
-        title: str = None,
+    benchmarking_tsv: Path,
+    gene_analysis: bool,
+    variant_analysis: bool,
+    disease_analysis: bool,
+    plot_type: str,
+    title: str = None,
 ):
     """Generate bar plot from benchmark stats summary tsv."""
     generate_plots_from_benchmark_summary_tsv(
@@ -661,13 +661,13 @@ def generate_stats_plot(
     type=Path,
 )
 def prepare_corpus_command(
-        phenopacket_dir: Path,
-        variant_analysis: bool,
-        gene_analysis: bool,
-        disease_analysis: bool,
-        gene_identifier: str,
-        template_vcf_path: Path,
-        output_dir: Path,
+    phenopacket_dir: Path,
+    variant_analysis: bool,
+    gene_analysis: bool,
+    disease_analysis: bool,
+    gene_identifier: str,
+    template_vcf_path: Path,
+    output_dir: Path,
 ):
     """
     Prepare a corpus of Phenopackets for analysis, optionally checking for complete variant records and updating
@@ -683,6 +683,11 @@ def prepare_corpus_command(
             output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
     """
     prepare_corpus(
-        phenopacket_dir, variant_analysis, gene_analysis, disease_analysis, gene_identifier, template_vcf_path,
-        output_dir
+        phenopacket_dir,
+        variant_analysis,
+        gene_analysis,
+        disease_analysis,
+        gene_identifier,
+        template_vcf_path,
+        output_dir,
     )

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -229,7 +229,13 @@ def check_variant_assembly(
         raise ValueError("Too many genome assemblies!")
     if phenopacket_assembly[0] not in compatible_genome_assembly:
         raise IncompatibleGenomeAssemblyError(phenopacket_assembly, phenopacket_path)
-    if phenopacket_assembly[0] != vcf_header.assembly:
+    if (
+        phenopacket_assembly[0] in {"hg19", "GRCh37"}
+        and vcf_header.assembly not in {"hg19", "GRCh37"}
+    ) or (
+        phenopacket_assembly[0] in {"hg38", "GRCh38"}
+        and vcf_header.assembly not in {"hg38", "GRCh38"}
+    ):
         raise IncompatibleGenomeAssemblyError(
             assembly=phenopacket_assembly, phenopacket=phenopacket_path
         )

--- a/src/pheval/prepare/prepare_corpus.py
+++ b/src/pheval/prepare/prepare_corpus.py
@@ -15,7 +15,8 @@ def prepare_corpus(
     gene_analysis: bool,
     disease_analysis: bool,
     gene_identifier: str,
-    template_vcf_path: Path,
+    hg19_template_vcf: Path,
+    hg38_template_vcf: Path,
     output_dir: Path,
 ) -> None:
     """
@@ -28,7 +29,8 @@ def prepare_corpus(
         gene_analysis (bool): If True, check for complete gene records in the Phenopackets.
         disease_analysis (bool): If True, check for complete disease records in the Phenopackets.
         gene_identifier (str): Identifier for updating gene identifiers, if applicable.
-        template_vcf_path (Path): The path to the template VCF file.
+        hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
+        hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
         output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
     """
     output_dir.joinpath("phenopackets").mkdir(exist_ok=True, parents=True)
@@ -56,6 +58,8 @@ def prepare_corpus(
             create_updated_phenopacket(
                 gene_identifier, phenopacket_path, output_dir.joinpath("phenopackets")
             )
-        if template_vcf_path:
+        if hg19_template_vcf or hg38_template_vcf:
             output_dir.joinpath("vcf").mkdir(exist_ok=True)
-            create_spiked_vcf(output_dir.joinpath("vcf"), phenopacket_path, template_vcf_path, None)
+            create_spiked_vcf(
+                output_dir.joinpath("vcf"), phenopacket_path, hg19_template_vcf, hg38_template_vcf
+            )

--- a/src/pheval/prepare/prepare_corpus.py
+++ b/src/pheval/prepare/prepare_corpus.py
@@ -1,0 +1,61 @@
+import logging
+from pathlib import Path
+
+from pheval.prepare.create_spiked_vcf import create_spiked_vcf
+from pheval.prepare.update_phenopacket import create_updated_phenopacket
+from pheval.utils.file_utils import all_files
+from pheval.utils.phenopacket_utils import PhenopacketUtil, phenopacket_reader
+
+info_log = logging.getLogger("info")
+
+
+def prepare_corpus(
+    phenopacket_dir: Path,
+    variant_analysis: bool,
+    gene_analysis: bool,
+    disease_analysis: bool,
+    gene_identifier: str,
+    template_vcf_path: Path,
+    output_dir: Path,
+) -> None:
+    """
+    Prepare a corpus of Phenopackets for analysis, optionally checking for complete variant records and updating
+    gene identifiers.
+
+    Args:
+        phenopacket_dir (Path): The path to the directory containing Phenopackets.
+        variant_analysis (bool): If True, check for complete variant records in the Phenopackets.
+        gene_analysis (bool): If True, check for complete gene records in the Phenopackets.
+        disease_analysis (bool): If True, check for complete disease records in the Phenopackets.
+        gene_identifier (str): Identifier for updating gene identifiers, if applicable.
+        template_vcf_path (Path): The path to the template VCF file.
+        output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
+    """
+    output_dir.joinpath("phenopackets").mkdir(exist_ok=True, parents=True)
+    for phenopacket_path in all_files(phenopacket_dir):
+        phenopacket_util = PhenopacketUtil(phenopacket_reader(phenopacket_path))
+        if variant_analysis:
+            if phenopacket_util.check_incomplete_variant_record():
+                info_log.warning(
+                    f"Removed {phenopacket_path.name} from the corpus due to missing variant fields."
+                )
+                continue
+        if gene_analysis:
+            if phenopacket_util.check_incomplete_gene_record():
+                info_log.warning(
+                    f"Removed {phenopacket_path.name} from the corpus due to missing gene fields."
+                )
+                continue
+        if disease_analysis:
+            if phenopacket_util.check_incomplete_disease_record():
+                info_log.warning(
+                    f"Removed {phenopacket_path.name} from the corpus due to missing disease fields."
+                )
+                continue
+        if gene_identifier:
+            create_updated_phenopacket(
+                    gene_identifier, phenopacket_path, output_dir.joinpath("phenopackets")
+                )
+        if template_vcf_path:
+            output_dir.joinpath("vcf").mkdir(exist_ok=True)
+            create_spiked_vcf(output_dir.joinpath("vcf"), phenopacket_path, template_vcf_path, None)

--- a/src/pheval/prepare/prepare_corpus.py
+++ b/src/pheval/prepare/prepare_corpus.py
@@ -54,8 +54,8 @@ def prepare_corpus(
                 continue
         if gene_identifier:
             create_updated_phenopacket(
-                    gene_identifier, phenopacket_path, output_dir.joinpath("phenopackets")
-                )
+                gene_identifier, phenopacket_path, output_dir.joinpath("phenopackets")
+            )
         if template_vcf_path:
             output_dir.joinpath("vcf").mkdir(exist_ok=True)
             create_spiked_vcf(output_dir.joinpath("vcf"), phenopacket_path, template_vcf_path, None)

--- a/src/pheval/prepare/prepare_corpus.py
+++ b/src/pheval/prepare/prepare_corpus.py
@@ -29,8 +29,10 @@ def prepare_corpus(
         gene_analysis (bool): If True, check for complete gene records in the Phenopackets.
         disease_analysis (bool): If True, check for complete disease records in the Phenopackets.
         gene_identifier (str): Identifier for updating gene identifiers, if applicable.
-        hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
-        hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
+        hg19_template_vcf (Path): Path to the hg19 template VCF file (optional), to spike variants into
+        VCFs for variant-based analysis at least one of hg19_template_vcf or hg38_template_vcf is required.
+        hg38_template_vcf (Path): Path to the hg38 template VCF file (optional), to spike variants into
+        VCFs for variant-based analysis at least one of hg19_template_vcf or hg38_template_vcf is required.
         output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
     """
     output_dir.joinpath("phenopackets").mkdir(exist_ok=True, parents=True)

--- a/src/pheval/prepare/update_phenopacket.py
+++ b/src/pheval/prepare/update_phenopacket.py
@@ -38,8 +38,7 @@ def update_outdated_gene_context(
     interpretations = PhenopacketUtil(phenopacket).interpretations()
     updated_interpretations = GeneIdentifierUpdater(
         hgnc_data=hgnc_data, gene_identifier=gene_identifier
-    ).update_genomic_interpretations_gene_identifier(interpretations)
-
+    ).update_genomic_interpretations_gene_identifier(interpretations, phenopacket_path)
     return PhenopacketRebuilder(phenopacket).update_interpretations(updated_interpretations)
 
 

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -503,13 +503,13 @@ class PhenopacketUtil:
 
     def check_incomplete_gene_record(self) -> bool:
         """
-            Check if any gene record in the phenopacket has incomplete information.
+        Check if any gene record in the phenopacket has incomplete information.
 
-            This method iterates through the diagnosed gene records and checks if any of them
-            have missing or incomplete information such as gene name, or gene identifier.
+        This method iterates through the diagnosed gene records and checks if any of them
+        have missing or incomplete information such as gene name, or gene identifier.
 
-            Returns:
-                bool: True if any gene record is incomplete, False otherwise.
+        Returns:
+            bool: True if any gene record is incomplete, False otherwise.
         """
         genes = self.diagnosed_genes()
         for gene in genes:
@@ -519,13 +519,13 @@ class PhenopacketUtil:
 
     def check_incomplete_disease_record(self) -> bool:
         """
-            Check if any disease record in the phenopacket has incomplete information.
+        Check if any disease record in the phenopacket has incomplete information.
 
-            This method iterates through the diagnosed disease records and checks if any of them
-            have missing or incomplete information such as empty disease name, or disease identifier.
+        This method iterates through the diagnosed disease records and checks if any of them
+        have missing or incomplete information such as empty disease name, or disease identifier.
 
-            Returns:
-                bool: True if any disease record is incomplete, False otherwise.
+        Returns:
+            bool: True if any disease record is incomplete, False otherwise.
         """
         if len(self.diagnoses()) == 0:
             return True

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -1,6 +1,5 @@
 import json
-
-# import logging
+import logging
 import os
 from collections import defaultdict
 from copy import copy
@@ -21,6 +20,8 @@ from phenopackets import (
 )
 
 from pheval.prepare.custom_exceptions import IncorrectFileFormatError
+
+info_log = logging.getLogger("info")
 
 
 class IncompatibleGenomeAssemblyError(Exception):
@@ -708,7 +709,7 @@ class GeneIdentifierUpdater:
                         ]
 
     def update_genomic_interpretations_gene_identifier(
-        self, interpretations: List[Interpretation]
+        self, interpretations: List[Interpretation], phenopacket_path: Path
     ) -> List[Interpretation]:
         """
         Update the genomic interpretations of a Phenopacket.
@@ -722,10 +723,16 @@ class GeneIdentifierUpdater:
         updated_interpretations = copy(list(interpretations))
         for updated_interpretation in updated_interpretations:
             for g in updated_interpretation.diagnosis.genomic_interpretations:
+                updated_gene_identifier = self.find_identifier(
+                    g.variant_interpretation.variation_descriptor.gene_context.symbol
+                )
+                info_log.info(
+                    f"Updating gene identifier in {phenopacket_path} from "
+                    f"{g.variant_interpretation.variation_descriptor.gene_context.value_id}"
+                    f"to {updated_gene_identifier}"
+                )
                 g.variant_interpretation.variation_descriptor.gene_context.value_id = (
-                    self.find_identifier(
-                        g.variant_interpretation.variation_descriptor.gene_context.symbol
-                    )
+                    updated_gene_identifier
                 )
                 del g.variant_interpretation.variation_descriptor.gene_context.alternate_ids[:]
                 g.variant_interpretation.variation_descriptor.gene_context.alternate_ids.extend(

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -477,6 +477,59 @@ class PhenopacketUtil:
                 variants.append(variant)
         return variants
 
+    def check_incomplete_variant_record(self) -> bool:
+        """
+        Check if any variant record in the phenopacket has incomplete information.
+
+        This method iterates through the diagnosed variant records and checks if any of them
+        have missing or incomplete information such as empty chromosome, position, reference,
+        or alternate allele.
+
+        Returns:
+            bool: True if any variant record is incomplete, False otherwise.
+        """
+        variants = self.diagnosed_variants()
+        for variant in variants:
+            if (
+                variant.chrom == ""
+                or variant.pos == 0
+                or variant.pos == ""
+                or variant.ref == ""
+                or variant.alt == ""
+            ):
+                return True
+        return False
+
+    def check_incomplete_gene_record(self) -> bool:
+        """
+            Check if any gene record in the phenopacket has incomplete information.
+
+            This method iterates through the diagnosed gene records and checks if any of them
+            have missing or incomplete information such as gene name, or gene identifier.
+
+            Returns:
+                bool: True if any gene record is incomplete, False otherwise.
+        """
+        genes = self.diagnosed_genes()
+        for gene in genes:
+            if gene.gene_symbol == "" or gene.gene_identifier == "":
+                return True
+        return False
+
+    def check_incomplete_disease_record(self) -> bool:
+        """
+            Check if any disease record in the phenopacket has incomplete information.
+
+            This method iterates through the diagnosed disease records and checks if any of them
+            have missing or incomplete information such as empty disease name, or disease identifier.
+
+            Returns:
+                bool: True if any disease record is incomplete, False otherwise.
+        """
+        if len(self.diagnoses()) == 0:
+            return True
+        return False
+
 
 class PhenopacketRebuilder:
     """Class for rebuilding a Phenopacket"""

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -103,7 +103,7 @@ structural_variant_interpretations = [
                         acmg_pathogenicity_classification="NOT_PROVIDED",
                         therapeutic_actionability="UNKNOWN_ACTIONABILITY",
                         variation_descriptor=VariationDescriptor(
-                            gene_context=GeneDescriptor(value_id="ENSG00000069011", symbol="PITX1"),
+                            gene_context=GeneDescriptor(value_id="", symbol=""),
                             vcf_record=VcfRecord(
                                 genome_assembly="GRCh38",
                                 chrom="5",
@@ -220,10 +220,10 @@ interpretations_no_variant_data = [
                             ),
                             vcf_record=VcfRecord(
                                 genome_assembly="GRCh37",
-                                chrom="X",
-                                pos=54492285,
-                                ref="C",
-                                alt="T",
+                                chrom="",
+                                pos=0,
+                                ref="",
+                                alt="",
                             ),
                             allelic_state=OntologyClass(
                                 id="GENO:0000134",
@@ -595,6 +595,25 @@ class TestPhenopacketUtil(unittest.TestCase):
                 GenomicVariant(chrom="18", pos=67691994, ref="G", alt="A"),
             ],
         )
+
+    def test_check_incomplete_variant_record(self):
+        self.assertFalse(self.phenopacket.check_incomplete_variant_record())
+
+    def test_check_incomplete_variant_records_missing_records(self):
+        print(self.phenopacket_no_variants.diagnosed_variants())
+        self.assertTrue(self.phenopacket_no_variants.check_incomplete_variant_record())
+
+    def test_check_incomplete_gene_record(self):
+        self.assertFalse(self.phenopacket.check_incomplete_gene_record())
+
+    def test_check_incomplete_gene_records_missing_records(self):
+        self.assertTrue(self.structural_variant_phenopacket.check_incomplete_gene_record())
+
+    def test_check_incomplete_disease_record(self):
+        self.assertFalse(self.phenopacket.check_incomplete_disease_record())
+
+    def test_check_incomplete_disease_record_missing_records(self):
+        self.assertTrue(self.structural_variant_phenopacket.check_incomplete_disease_record())
 
 
 class TestPhenopacketRebuilder(unittest.TestCase):

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -736,7 +736,7 @@ class TestGeneIdentifierUpdater(unittest.TestCase):
         self.assertEqual(
             list(
                 self.gene_identifier_updater_ens.update_genomic_interpretations_gene_identifier(
-                    phenopacket.interpretations
+                    phenopacket.interpretations, Path("/phenopacket_path.json")
                 )
             ),
             updated_interpretations,

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -592,7 +592,6 @@ class TestPhenopacketUtil(unittest.TestCase):
         self.assertFalse(self.phenopacket.check_incomplete_variant_record())
 
     def test_check_incomplete_variant_records_missing_records(self):
-        print(self.phenopacket_no_variants.diagnosed_variants())
         self.assertTrue(self.phenopacket_no_variants.check_incomplete_variant_record())
 
     def test_check_incomplete_gene_record(self):

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -103,7 +103,6 @@ structural_variant_interpretations = [
                         acmg_pathogenicity_classification="NOT_PROVIDED",
                         therapeutic_actionability="UNKNOWN_ACTIONABILITY",
                         variation_descriptor=VariationDescriptor(
-                            gene_context=GeneDescriptor(value_id="", symbol=""),
                             vcf_record=VcfRecord(
                                 genome_assembly="GRCh38",
                                 chrom="5",
@@ -217,13 +216,6 @@ interpretations_no_variant_data = [
                                     "ensembl:ENSG00000102302",
                                     "symbol:FGD1",
                                 ],
-                            ),
-                            vcf_record=VcfRecord(
-                                genome_assembly="GRCh37",
-                                chrom="",
-                                pos=0,
-                                ref="",
-                                alt="",
                             ),
                             allelic_state=OntologyClass(
                                 id="GENO:0000134",


### PR DESCRIPTION
Implemented a `prepare-corpus` command.

A user can specify if they intend to carry out variant, gene, and/or disease analysis with their prepared corpus. The command will check the corpora and ensure that all required fields in the phenopacket are filled (required for matching results to known entities in the benchmarking). When a phenopacket is removed from the final corpus a warning message is logged, informing of the phenopacket that was removed.

There is also the option of spiking VCF with variant information from a phenopacket and updating the gene identifiers.

For example, to prepare the phenopacket-store corpus for our use (variant analysis only) we would use the command:

```bash
pheval-utils prepare-corpus --phenopacket-dir /path/to/phenopacket-store --gene-identifier ensembl_id --variant-analysis --template-vcf /path/to/template.vcf --output-dir /path/to/output_dir
```

This will:

1. Check that all vcf fields in the phenopacket are filled and remove those with missing values from the final corpus.
2. Update all the identifiers in the remaining phenopackets to ensembl
3. Spike variants into the template VCF
