### PR TITLE
313 add option for hg19 and hg38 vcf for spiking command

### DIFF
--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -253,22 +253,19 @@ def update_phenopackets_command(
     mutually_exclusive=["phenopacket_path"],
 )
 @click.option(
-    "--template-vcf-path",
-    "-t",
-    cls=MutuallyExclusiveOptionError,
+    "--hg19-template-vcf",
+    "-hg19",
     metavar="PATH",
     required=False,
-    help="Template VCF file",
-    mutually_exclusive=["vcf_dir"],
+    help="Template hg19 VCF file",
     type=Path,
 )
 @click.option(
-    "--vcf-dir",
-    "-v",
-    cls=MutuallyExclusiveOptionError,
+    "--hg38-template-vcf",
+    "-hg38",
     metavar="PATH",
-    help="Directory containing template VCF files",
-    mutually_exclusive=["template_vcf"],
+    required=False,
+    help="Template hg38 VCF file",
     type=Path,
 )
 @click.option(
@@ -284,13 +281,13 @@ def create_spiked_vcfs_command(
     phenopacket_path: Path,
     phenopacket_dir: Path,
     output_dir: Path,
-    template_vcf_path: Path = None,
-    vcf_dir: Path = None,
+    hg19_template_vcf: Path = None,
+    hg38_template_vcf: Path = None,
 ):
     """Spikes variants into a template VCF file for a directory of phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
         raise InputError("Either a phenopacket or phenopacket directory must be specified")
-    spike_vcfs(output_dir, phenopacket_path, phenopacket_dir, template_vcf_path, vcf_dir)
+    spike_vcfs(output_dir, phenopacket_path, phenopacket_dir, hg19_template_vcf, hg38_template_vcf)
 
 
 @click.command()

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -284,7 +284,16 @@ def create_spiked_vcfs_command(
     hg19_template_vcf: Path = None,
     hg38_template_vcf: Path = None,
 ):
-    """Spikes variants into a template VCF file for a directory of phenopackets."""
+    """
+    Create spiked VCF from either a Phenopacket or a Phenopacket directory.
+
+    Args:
+        phenopacket_path (Path): Path to a single Phenopacket file (optional).
+        phenopacket_dir (Path): Path to a directory containing Phenopacket files (optional).
+        output_dir (Path): The directory to store the generated spiked VCF file(s).
+        hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
+        hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
+    """
     if phenopacket_path is None and phenopacket_dir is None:
         raise InputError("Either a phenopacket or phenopacket directory must be specified")
     spike_vcfs(output_dir, phenopacket_path, phenopacket_dir, hg19_template_vcf, hg38_template_vcf)

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -1,7 +1,6 @@
 import gzip
 import logging
 import re
-import secrets
 import urllib.parse
 from copy import copy
 from dataclasses import dataclass
@@ -20,7 +19,7 @@ from pheval.utils.phenopacket_utils import (
 )
 
 from .custom_exceptions import InputError
-from ..utils.file_utils import all_files, files_with_suffix, is_gzipped
+from ..utils.file_utils import files_with_suffix, is_gzipped
 
 info_log = logging.getLogger("info")
 
@@ -89,39 +88,6 @@ class VcfHeader:
     sample_id: str
     assembly: str
     chr_status: bool
-
-
-class VcfPicker:
-    """Choose a VCF file randomly from a directory if provided, otherwise selects the single template."""
-
-    def __init__(self, template_vcf: Path or None, vcf_dir: Path or None):
-        """
-        Initialise the VcfPicker.
-
-        Args:
-            template_vcf (Path or None): The path to a template VCF file, or None if not provided.
-            vcf_dir (Path or None): The directory containing VCF files, or None if not provided.
-        """
-        self.template_vcf = template_vcf
-        self.vcf_dir = vcf_dir
-
-    def pick_file_from_dir(self) -> Path:
-        """
-        Selects a VCF file from a directory at random.
-
-        Returns:
-            Path: The randomly selected VCF file path from the directory.
-        """
-        return secrets.choice(all_files(self.vcf_dir))
-
-    def pick_file(self) -> Path:
-        """
-        Select a VCF file randomly when given a directory; if not, the template VCF is assigned.
-
-        Returns:
-            Path: The selected VCF file path.
-        """
-        return self.pick_file_from_dir() if self.vcf_dir is not None else self.template_vcf
 
 
 def read_vcf(vcf_file: Path) -> List[str]:
@@ -206,10 +172,30 @@ class VcfHeaderParser:
         return VcfHeader(sample_id, assembly, chr_status)
 
 
+@dataclass
+class VcfFile:
+    vcf_file_name: str = None
+    vcf_contents: List[str] = None
+    vcf_header: VcfHeader = None
+
+    @staticmethod
+    def populate_fields(template_vcf: Path):
+        contents = read_vcf(template_vcf)
+        return VcfFile(template_vcf.name, contents, VcfHeaderParser(contents).parse_vcf_header())
+
+
+def select_vcf_template(proband_causative_variants: List[ProbandCausativeVariant], hg19_vcf_info: VcfFile,
+                        hg38_vcf_info: VcfFile) -> VcfFile:
+    if proband_causative_variants[0].assembly in ["hg19", "GRCh37"]:
+        return hg19_vcf_info
+    elif proband_causative_variants[0].assembly in ["hg38", "GRCh38"]:
+        return hg38_vcf_info
+
+
 def check_variant_assembly(
-    proband_causative_variants: list[ProbandCausativeVariant],
-    vcf_header: VcfHeader,
-    phenopacket_path: Path,
+        proband_causative_variants: list[ProbandCausativeVariant],
+        vcf_header: VcfHeader,
+        phenopacket_path: Path,
 ) -> None:
     """
     Check the assembly of the variant assembly against the VCF.
@@ -239,10 +225,10 @@ class VcfSpiker:
     """Class for spiking proband variants into template VCF file contents."""
 
     def __init__(
-        self,
-        vcf_contents: list[str],
-        proband_causative_variants: list[ProbandCausativeVariant],
-        vcf_header: VcfHeader,
+            self,
+            vcf_contents: list[str],
+            proband_causative_variants: list[ProbandCausativeVariant],
+            vcf_header: VcfHeader,
     ):
         """
         Initialise the VcfSpiker.
@@ -302,10 +288,11 @@ class VcfSpiker:
         for variant in self.proband_causative_variants:
             variant = self.construct_variant_entry(variant)
             variant_entry_position = [
-                i
-                for i, val in enumerate(updated_vcf_records)
-                if val.split("\t")[0] == variant[0] and int(val.split("\t")[1]) < int(variant[1])
-            ][-1] + 1
+                                         i
+                                         for i, val in enumerate(updated_vcf_records)
+                                         if
+                                         val.split("\t")[0] == variant[0] and int(val.split("\t")[1]) < int(variant[1])
+                                     ][-1] + 1
             updated_vcf_records.insert(variant_entry_position, "\t".join(variant))
         return updated_vcf_records
 
@@ -342,9 +329,9 @@ class VcfWriter:
     """Class for writing VCF file."""
 
     def __init__(
-        self,
-        vcf_contents: List[str],
-        spiked_vcf_file_path: Path,
+            self,
+            vcf_contents: List[str],
+            spiked_vcf_file_path: Path,
     ):
         """
         Initialise the VcfWriter class.
@@ -385,9 +372,10 @@ class VcfWriter:
 
 
 def spike_vcf_contents(
-    phenopacket: Union[Phenopacket, Family],
-    phenopacket_path: Path,
-    chosen_template_vcf: Path,
+        phenopacket: Union[Phenopacket, Family],
+        phenopacket_path: Path,
+        hg19_vcf_info: VcfFile,
+        hg38_vcf_info: VcfFile
 ) -> tuple[str, List[str]]:
     """
     Spike VCF records with variants obtained from a Phenopacket or Family.
@@ -395,7 +383,6 @@ def spike_vcf_contents(
     Args:
         phenopacket (Union[Phenopacket, Family]): Phenopacket or Family containing causative variants.
         phenopacket_path (Path): Path to the Phenopacket file.
-        chosen_template_vcf (Path): Path to the chosen template VCF file.
 
     Returns:
         A tuple containing:
@@ -403,20 +390,21 @@ def spike_vcf_contents(
             modified_vcf_contents (List[str]): Modified VCF records with spiked variants.
     """
     phenopacket_causative_variants = PhenopacketUtil(phenopacket).causative_variants()
-    vcf_contents = read_vcf(chosen_template_vcf)
-    vcf_header = VcfHeaderParser(vcf_contents).parse_vcf_header()
-    check_variant_assembly(phenopacket_causative_variants, vcf_header, phenopacket_path)
+    chosen_template_vcf = select_vcf_template(phenopacket_causative_variants, hg19_vcf_info, hg38_vcf_info)
+    check_variant_assembly(phenopacket_causative_variants, chosen_template_vcf.vcf_header, phenopacket_path)
     return (
-        vcf_header.assembly,
-        VcfSpiker(vcf_contents, phenopacket_causative_variants, vcf_header).construct_vcf(),
+        chosen_template_vcf.vcf_header.assembly,
+        VcfSpiker(chosen_template_vcf.vcf_contents, phenopacket_causative_variants,
+                  chosen_template_vcf.vcf_header).construct_vcf(),
     )
 
 
 def generate_spiked_vcf_file(
-    output_dir: Path,
-    phenopacket: Union[Phenopacket, Family],
-    phenopacket_path: Path,
-    chosen_template_vcf: Path,
+        output_dir: Path,
+        phenopacket: Union[Phenopacket, Family],
+        phenopacket_path: Path,
+        hg19_vcf_info: VcfFile,
+        hg38_vcf_info: VcfFile
 ) -> File:
     """
     Write spiked VCF contents to a new file.
@@ -425,21 +413,17 @@ def generate_spiked_vcf_file(
         output_dir (Path): Path to the directory to store the generated file.
         phenopacket (Union[Phenopacket, Family]): Phenopacket or Family containing causative variants.
         phenopacket_path (Path): Path to the Phenopacket file.
-        chosen_template_vcf (Path): Path to the chosen template VCF file.
-
+        hg19_vcf_info (Path): Path to the hg19 template VCF file (optional).
+        hg38_vcf_info (Path): Path to the hg38 template VCF file (optional).
     Returns:
         File: The generated File object representing the newly created spiked VCF file.
     """
     output_dir.mkdir(exist_ok=True)
     info_log.info(f" Created a directory {output_dir}")
     vcf_assembly, spiked_vcf = spike_vcf_contents(
-        phenopacket, phenopacket_path, chosen_template_vcf
+        phenopacket, phenopacket_path, hg19_vcf_info, hg38_vcf_info
     )
-    spiked_vcf_path = (
-        output_dir.joinpath(phenopacket_path.name.replace(".json", ".vcf.gz"))
-        if is_gzipped(chosen_template_vcf)
-        else output_dir.joinpath(phenopacket_path.name.replace(".json", ".vcf"))
-    )
+    spiked_vcf_path = output_dir.joinpath(phenopacket_path.name.replace(".json", ".vcf"))
     VcfWriter(spiked_vcf, spiked_vcf_path).write_vcf_file()
     return File(
         uri=urllib.parse.unquote(spiked_vcf_path.as_uri()),
@@ -447,25 +431,10 @@ def generate_spiked_vcf_file(
     )
 
 
-def create_spiked_vcf(
-    output_dir: Path, phenopacket_path: Path, template_vcf_path: Path
-) -> None:
-    """
-    Create a spiked VCF for a Phenopacket.
-
-    Args:
-        output_dir (Path): The directory to store the generated spiked VCF file.
-        phenopacket_path (Path): Path to the Phenopacket file.
-        template_vcf_path (Path): Path to the template VCF file (optional).
-
-    Raises:
-        InputError: If both template_vcf_path are None.
-    """
-    if template_vcf_path is None:
-        raise InputError("Either a template_vcf must be specified")
+def spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, output_dir, phenopacket_path):
     phenopacket = phenopacket_reader(phenopacket_path)
     spiked_vcf_file_message = generate_spiked_vcf_file(
-        output_dir, phenopacket, phenopacket_path, template_vcf_path
+        output_dir, phenopacket, phenopacket_path, hg19_vcf_info, hg38_vcf_info
     )
     updated_phenopacket = PhenopacketRebuilder(phenopacket).add_spiked_vcf_path(
         spiked_vcf_file_message
@@ -473,8 +442,30 @@ def create_spiked_vcf(
     write_phenopacket(updated_phenopacket, phenopacket_path)
 
 
+def create_spiked_vcf(
+        output_dir: Path, phenopacket_path: Path, hg19_template_vcf: Path, hg38_template_vcf: Path
+) -> None:
+    """
+    Create a spiked VCF for a Phenopacket.
+
+    Args:
+        output_dir (Path): The directory to store the generated spiked VCF file.
+        phenopacket_path (Path): Path to the Phenopacket file.
+        hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
+        hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
+
+    Raises:
+        InputError: If both hg19_template_vcf and hg38_template_vcf are None.
+    """
+    if hg19_template_vcf and hg38_template_vcf is None:
+        raise InputError("Either a hg19 template vcf or hg38 template vcf must be specified")
+    hg19_vcf_info = VcfFile.populate_fields(hg19_template_vcf) if hg19_template_vcf else None
+    hg38_vcf_info = VcfFile.populate_fields(hg38_template_vcf) if hg38_template_vcf else None
+    spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, output_dir, phenopacket_path)
+
+
 def create_spiked_vcfs(
-    output_dir: Path, phenopacket_dir: Path, template_vcf_path: Path
+        output_dir: Path, phenopacket_dir: Path, hg19_template_vcf: Path, hg38_template_vcf: Path
 ) -> None:
     """
     Create a spiked VCF for a directory of Phenopackets.
@@ -482,32 +473,25 @@ def create_spiked_vcfs(
     Args:
         output_dir (Path): The directory to store the generated spiked VCF file.
         phenopacket_dir (Path): Path to the Phenopacket directory.
-        template_vcf_path (Path): Path to the template VCF file (optional).
+        hg19_template_vcf (Path): Path to the template VCF file (optional).
 
     Raises:
         InputError: If both template_vcf_path are None.
     """
-    if template_vcf_path is None:
-        raise InputError("Either a template_vcf must be specified")
+    if hg19_template_vcf and hg38_template_vcf is None:
+        raise InputError("Either a hg19 template vcf or hg38 template vcf must be specified")
+    hg19_vcf_info = VcfFile(hg19_template_vcf.name, read_vcf(hg19_template_vcf)) if hg19_template_vcf else None
+    hg38_vcf_info = VcfFile(hg38_template_vcf.name, read_vcf(hg38_template_vcf)) if hg38_template_vcf else None
     for phenopacket_path in files_with_suffix(phenopacket_dir, ".json"):
-        phenopacket = phenopacket_reader(phenopacket_path)
-        spiked_vcf_file_message = generate_spiked_vcf_file(
-            output_dir, phenopacket, phenopacket_path, template_vcf_path
-        )
-        updated_phenopacket = PhenopacketRebuilder(phenopacket).add_spiked_vcf_path(
-            spiked_vcf_file_message
-        )
-        write_phenopacket(updated_phenopacket, phenopacket_path)
-    # or made a lambda one-liner for maximum wtf...
-    # [spike_vcf(path, output_dir, template_vcf, vcf_dir) for path in phenopacket_dir.iterdir() if path.suffix ==
-    # ".json"]
+        spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, output_dir, phenopacket_path)
 
 
 def spike_vcfs(
-    output_dir: Path,
-    phenopacket_path: Path,
-    phenopacket_dir: Path,
-    template_vcf_path: Path,
+        output_dir: Path,
+        phenopacket_path: Path,
+        phenopacket_dir: Path,
+        hg19_template_vcf: Path,
+        hg38_template_vcf: Path,
 ) -> None:
     """
     Create spiked VCF from either a Phenopacket or a Phenopacket directory.
@@ -516,9 +500,10 @@ def spike_vcfs(
         output_dir (Path): The directory to store the generated spiked VCF file(s).
         phenopacket_path (Path): Path to a single Phenopacket file (optional).
         phenopacket_dir (Path): Path to a directory containing Phenopacket files (optional).
-        template_vcf_path (Path): Path to the template VCF file (optional).
+        hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
+        hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
     """
     if phenopacket_path is not None:
-        create_spiked_vcf(output_dir, phenopacket_path, template_vcf_path)
+        create_spiked_vcf(output_dir, phenopacket_path, hg19_template_vcf, hg38_template_vcf)
     elif phenopacket_dir is not None:
-        create_spiked_vcfs(output_dir, phenopacket_dir, template_vcf_path)
+        create_spiked_vcfs(output_dir, phenopacket_dir, hg19_template_vcf, hg38_template_vcf)

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -402,8 +402,6 @@ def spike_vcf_contents(
             assembly (str): The genome assembly information extracted from VCF header.
             modified_vcf_contents (List[str]): Modified VCF records with spiked variants.
     """
-    # this is a separate function to a click command as it will fail if annotated with click annotations
-    # and referenced from another click command
     phenopacket_causative_variants = PhenopacketUtil(phenopacket).causative_variants()
     vcf_contents = read_vcf(chosen_template_vcf)
     vcf_header = VcfHeaderParser(vcf_contents).parse_vcf_header()
@@ -450,7 +448,7 @@ def generate_spiked_vcf_file(
 
 
 def create_spiked_vcf(
-    output_dir: Path, phenopacket_path: Path, template_vcf_path: Path, vcf_dir: Path
+    output_dir: Path, phenopacket_path: Path, template_vcf_path: Path
 ) -> None:
     """
     Create a spiked VCF for a Phenopacket.
@@ -459,17 +457,15 @@ def create_spiked_vcf(
         output_dir (Path): The directory to store the generated spiked VCF file.
         phenopacket_path (Path): Path to the Phenopacket file.
         template_vcf_path (Path): Path to the template VCF file (optional).
-        vcf_dir (Path): Path to the directory containing VCF files (optional).
 
     Raises:
-        InputError: If both template_vcf_path and vcf_dir are None.
+        InputError: If both template_vcf_path are None.
     """
-    if template_vcf_path is None and vcf_dir is None:
-        raise InputError("Either a template_vcf or vcf_dir must be specified")
-    vcf_file_path = VcfPicker(template_vcf_path, vcf_dir).pick_file()
+    if template_vcf_path is None:
+        raise InputError("Either a template_vcf must be specified")
     phenopacket = phenopacket_reader(phenopacket_path)
     spiked_vcf_file_message = generate_spiked_vcf_file(
-        output_dir, phenopacket, phenopacket_path, vcf_file_path
+        output_dir, phenopacket, phenopacket_path, template_vcf_path
     )
     updated_phenopacket = PhenopacketRebuilder(phenopacket).add_spiked_vcf_path(
         spiked_vcf_file_message
@@ -478,7 +474,7 @@ def create_spiked_vcf(
 
 
 def create_spiked_vcfs(
-    output_dir: Path, phenopacket_dir: Path, template_vcf_path: Path, vcf_dir: Path
+    output_dir: Path, phenopacket_dir: Path, template_vcf_path: Path
 ) -> None:
     """
     Create a spiked VCF for a directory of Phenopackets.
@@ -487,18 +483,16 @@ def create_spiked_vcfs(
         output_dir (Path): The directory to store the generated spiked VCF file.
         phenopacket_dir (Path): Path to the Phenopacket directory.
         template_vcf_path (Path): Path to the template VCF file (optional).
-        vcf_dir (Path): Path to the directory containing VCF files (optional).
 
     Raises:
-        InputError: If both template_vcf_path and vcf_dir are None.
+        InputError: If both template_vcf_path are None.
     """
-    if template_vcf_path is None and vcf_dir is None:
-        raise InputError("Either a template_vcf or vcf_dir must be specified")
+    if template_vcf_path is None:
+        raise InputError("Either a template_vcf must be specified")
     for phenopacket_path in files_with_suffix(phenopacket_dir, ".json"):
-        vcf_file_path = VcfPicker(template_vcf_path, vcf_dir).pick_file()
         phenopacket = phenopacket_reader(phenopacket_path)
         spiked_vcf_file_message = generate_spiked_vcf_file(
-            output_dir, phenopacket, phenopacket_path, vcf_file_path
+            output_dir, phenopacket, phenopacket_path, template_vcf_path
         )
         updated_phenopacket = PhenopacketRebuilder(phenopacket).add_spiked_vcf_path(
             spiked_vcf_file_message
@@ -514,7 +508,6 @@ def spike_vcfs(
     phenopacket_path: Path,
     phenopacket_dir: Path,
     template_vcf_path: Path,
-    vcf_dir: Path,
 ) -> None:
     """
     Create spiked VCF from either a Phenopacket or a Phenopacket directory.
@@ -524,9 +517,8 @@ def spike_vcfs(
         phenopacket_path (Path): Path to a single Phenopacket file (optional).
         phenopacket_dir (Path): Path to a directory containing Phenopacket files (optional).
         template_vcf_path (Path): Path to the template VCF file (optional).
-        vcf_dir (Path): Path to the directory containing VCF files (optional).
     """
     if phenopacket_path is not None:
-        create_spiked_vcf(output_dir, phenopacket_path, template_vcf_path, vcf_dir)
+        create_spiked_vcf(output_dir, phenopacket_path, template_vcf_path)
     elif phenopacket_dir is not None:
-        create_spiked_vcfs(output_dir, phenopacket_dir, template_vcf_path, vcf_dir)
+        create_spiked_vcfs(output_dir, phenopacket_dir, template_vcf_path)

--- a/tests/test_create_spiked_vcf.py
+++ b/tests/test_create_spiked_vcf.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from pheval.prepare.create_spiked_vcf import (
     VcfHeader,
     VcfHeaderParser,
-    VcfPicker,
     VcfSpiker,
     check_variant_assembly,
     read_vcf,
@@ -129,21 +128,6 @@ hg38_vcf = [
     "difficultregion=GRCh38_AllHomopolymers_gt6bp_imperfectgt10bp_slop5,GRCh38_SimpleRepeat_imperfecthomopolgt10_slop5"
     "\tGT:PS:DP:ADALL:AD:GQ\t1/1:.:575:30,271:7,237:128",
 ]
-
-
-class TestVcfPicker(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.vcf_file = Path("./tests/input_dir/test_vcf_dir/test_1.vcf")
-        cls.vcf_dir = Path("./tests/input_dir/test_vcf_dir/")
-
-    def test_pick_file_from_dir(self):
-        self.assertTrue(
-            "test_1.vcf" or "test_2.vcf.gz" == VcfPicker(None, self.vcf_dir).pick_file_from_dir()
-        )
-
-    def test_pick_file(self):
-        self.assertEqual("test_1.vcf", VcfPicker(self.vcf_file, None).pick_file().name)
 
 
 class TestReadVcf(unittest.TestCase):


### PR DESCRIPTION
Added separate `--hg19-template-vcf` and `--hg38-template-vcf` arguments to the spike vcf command. This allows a corpus of phenopackets with mixed assemblies to be spiked into vcfs.

There is also a refactoring of the methods so that each VCF (if specified) is only read and parsed once during the workflow - this is to improve efficiency and cut down the time taken to carry out the command.