### PR TITLE
317 add arguments hg19 vcf dir and hg38 vcf dir to spike vcf command

### DIFF
--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -260,6 +260,8 @@ def update_phenopackets_command(
     required=False,
     help="Template hg19 VCF file",
     type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["hg19_vcf_dir"],
 )
 @click.option(
     "--hg38-template-vcf",
@@ -268,6 +270,28 @@ def update_phenopackets_command(
     required=False,
     help="Template hg38 VCF file",
     type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["hg38_vcf_dir"],
+)
+@click.option(
+    "--hg19-vcf-dir",
+    "-hg19-dir",
+    metavar="PATH",
+    required=False,
+    help="Path to directory containing hg19 VCF templates.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["hg19_template_vcf"],
+)
+@click.option(
+    "--hg38-vcf-dir",
+    "-hg38-dir",
+    metavar="PATH",
+    required=False,
+    help="Path to directory containing hg38 VCF templates.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["hg38_template_vcf"],
 )
 @click.option(
     "--output-dir",
@@ -284,6 +308,8 @@ def create_spiked_vcfs_command(
     output_dir: Path,
     hg19_template_vcf: Path = None,
     hg38_template_vcf: Path = None,
+    hg19_vcf_dir: Path = None,
+    hg38_vcf_dir: Path = None,
 ):
     """
     Create spiked VCF from either a Phenopacket or a Phenopacket directory.
@@ -294,10 +320,20 @@ def create_spiked_vcfs_command(
         output_dir (Path): The directory to store the generated spiked VCF file(s).
         hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
         hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
+        hg19_vcf_dir (Path): Path to the directory containing the hg19 VCF files (optional).
+        hg38_vcf_dir (Path): Path to the directory containing the hg38 VCF files (optional).
     """
     if phenopacket_path is None and phenopacket_dir is None:
         raise InputError("Either a phenopacket or phenopacket directory must be specified")
-    spike_vcfs(output_dir, phenopacket_path, phenopacket_dir, hg19_template_vcf, hg38_template_vcf)
+    spike_vcfs(
+        output_dir,
+        phenopacket_path,
+        phenopacket_dir,
+        hg19_template_vcf,
+        hg38_template_vcf,
+        hg19_vcf_dir,
+        hg38_vcf_dir,
+    )
 
 
 @click.command()
@@ -656,6 +692,8 @@ def generate_stats_plot(
     required=False,
     help="Template hg19 VCF file",
     type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["hg19_vcf_dir"],
 )
 @click.option(
     "--hg38-template-vcf",
@@ -664,6 +702,28 @@ def generate_stats_plot(
     required=False,
     help="Template hg38 VCF file",
     type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["hg38_vcf_dir"],
+)
+@click.option(
+    "--hg19-vcf-dir",
+    "-hg19-dir",
+    metavar="PATH",
+    required=False,
+    help="Path to directory containing hg19 VCF templates.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["hg19_template_vcf"],
+)
+@click.option(
+    "--hg38-vcf-dir",
+    "-hg38-dir",
+    metavar="PATH",
+    required=False,
+    help="Path to directory containing hg38 VCF templates.",
+    type=Path,
+    cls=MutuallyExclusiveOptionError,
+    mutually_exclusive=["hg38_template_vcf"],
 )
 @click.option(
     "--output-dir",
@@ -682,23 +742,28 @@ def prepare_corpus_command(
     gene_identifier: str,
     hg19_template_vcf: Path,
     hg38_template_vcf: Path,
+    hg19_vcf_dir: Path,
+    hg38_vcf_dir: Path,
     output_dir: Path,
 ):
     """
     Prepare a corpus of Phenopackets for analysis, optionally checking for complete variant records and updating
     gene identifiers.
 
-        Args:
-            phenopacket_dir (Path): The path to the directory containing Phenopackets.
-            variant_analysis (bool): If True, check for complete variant records in the Phenopackets.
-            gene_analysis (bool): If True, check for complete gene records in the Phenopackets.
-            disease_analysis (bool): If True, check for complete disease records in the Phenopackets.
-            gene_identifier (str): Identifier for updating gene identifiers, if applicable.
-            hg19_template_vcf (Path): Path to the hg19 template VCF file (optional), to spike variants into
-            VCFs for variant-based analysis at least one of hg19_template_vcf or hg38_template_vcf is required.
-            hg38_template_vcf (Path): Path to the hg38 template VCF file (optional), to spike variants into
-            VCFs for variant-based analysis at least one of hg19_template_vcf or hg38_template_vcf is required.
-            output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
+    Args:
+        phenopacket_dir (Path): The path to the directory containing Phenopackets.
+        variant_analysis (bool): If True, check for complete variant records in the Phenopackets.
+        gene_analysis (bool): If True, check for complete gene records in the Phenopackets.
+        disease_analysis (bool): If True, check for complete disease records in the Phenopackets.
+        gene_identifier (str): Identifier for updating gene identifiers, if applicable.
+        hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
+        hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
+        hg19_vcf_dir (Path): Path to the directory containing the hg19 VCF files (optional).
+        hg38_vcf_dir (Path): Path to the directory containing the hg38 VCF files (optional).
+        output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
+    Notes:
+        To spike variants into VCFs for variant-based analysis at least one of hg19_template_vcf, hg38_template_vcf,
+        hg19_vcf_dir or hg38_vcf_dir is required.
     """
     prepare_corpus(
         phenopacket_dir,
@@ -708,5 +773,7 @@ def prepare_corpus_command(
         gene_identifier,
         hg19_template_vcf,
         hg38_template_vcf,
+        hg19_vcf_dir,
+        hg38_vcf_dir,
         output_dir,
     )

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -219,6 +219,8 @@ def select_vcf_template(
         proband_causative_variants (List[ProbandCausativeVariant]): A list of causative variants from the proband.
         hg19_vcf_info (VcfFile): VCF file info for hg19 template vcf.
         hg38_vcf_info (VcfFile): CF file info for hg38 template vcf.
+        hg19_vcf_dir (Path): The directory containing the hg19 VCF files.
+        hg38_vcf_dir (Path): The directory containing the hg38 VCF files.
 
     Returns:
         VcfFile: The selected VCF template file based on the assembly information of the proband causative variants.
@@ -444,6 +446,8 @@ def spike_vcf_contents(
         phenopacket_path (Path): Path to the Phenopacket file.
         hg19_vcf_info (VcfFile): VCF file info for hg19 template vcf.
         hg38_vcf_info (VcfFile): VCF file info for hg38 template vcf.
+        hg19_vcf_dir (Path): The directory containing the hg19 VCF files.
+        hg38_vcf_dir (Path): The directory containing the hg38 VCF files.
 
     Returns:
         A tuple containing:
@@ -490,6 +494,8 @@ def generate_spiked_vcf_file(
         phenopacket_path (Path): Path to the Phenopacket file.
         hg19_vcf_info (VcfFile): VCF file info for hg19 template vcf.
         hg38_vcf_info (VcfFile): VCF file info for hg38 template vcf.
+        hg19_vcf_dir (Path): The directory containing the hg19 VCF files.
+        hg38_vcf_dir (Path): The directory containing the hg38 VCF files.
     Returns:
         File: The generated File object representing the newly created spiked VCF file.
     """
@@ -507,13 +513,28 @@ def generate_spiked_vcf_file(
 
 
 def spike_and_update_phenopacket(
-    hg19_vcf_info,
-    hg38_vcf_info,
+    hg19_vcf_info: VcfFile,
+    hg38_vcf_info: VcfFile,
     hg19_vcf_dir: Path,
     hg38_vcf_dir: Path,
-    output_dir,
-    phenopacket_path,
-):
+    output_dir: Path,
+    phenopacket_path: Path,
+) -> None:
+    """
+    Spike the VCF files with genetic variants relevant to the provided Phenopacket, update the Phenopacket
+    accordingly, and write the updated Phenopacket to the specified output directory.
+
+    Args:
+        hg19_vcf_info (VcfFile): VCF file info for hg19 template vcf.
+        hg38_vcf_info (VcfFile): VCF file info for hg38 template vcf.
+        hg19_vcf_dir (Path): The directory containing the hg19 VCF files.
+        hg38_vcf_dir (Path): The directory containing the hg38 VCF files.
+        output_dir (Path): Directory where the updated Phenopacket will be saved.
+        phenopacket_path (Path): Path to the original Phenopacket file.
+
+    Returns:
+        None
+    """
     phenopacket = phenopacket_reader(phenopacket_path)
     spiked_vcf_file_message = generate_spiked_vcf_file(
         output_dir,
@@ -546,6 +567,8 @@ def create_spiked_vcf(
         phenopacket_path (Path): Path to the Phenopacket file.
         hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
         hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
+        hg19_vcf_dir (Path): The directory containing the hg19 VCF files (optional).
+        hg38_vcf_dir (Path): The directory containing the hg38 VCF files (optional).
 
     Raises:
         InputError: If both hg19_template_vcf and hg38_template_vcf are None.
@@ -575,6 +598,8 @@ def create_spiked_vcfs(
         phenopacket_dir (Path): Path to the Phenopacket directory.
         hg19_template_vcf (Path): Path to the template hg19 VCF file (optional).
         hg38_template_vcf (Path): Path to the template hg19 VCF file (optional).
+        hg19_vcf_dir (Path): The directory containing the hg19 VCF files (optional).
+        hg38_vcf_dir (Path): The directory containing the hg38 VCF files (optional).
 
     Raises:
         InputError: If both hg19_template_vcf and hg38_template_vcf are None.

--- a/src/pheval/prepare/create_spiked_vcf.py
+++ b/src/pheval/prepare/create_spiked_vcf.py
@@ -5,12 +5,13 @@ import urllib.parse
 from copy import copy
 from dataclasses import dataclass
 from pathlib import Path
+import random
 from typing import List, Union
 
 from phenopackets import Family, File, Phenopacket
 
 from pheval.prepare.custom_exceptions import InputError
-from pheval.utils.file_utils import files_with_suffix, is_gzipped
+from pheval.utils.file_utils import files_with_suffix, is_gzipped, all_files
 from pheval.utils.phenopacket_utils import (
     IncompatibleGenomeAssemblyError,
     PhenopacketRebuilder,
@@ -207,6 +208,8 @@ def select_vcf_template(
     proband_causative_variants: List[ProbandCausativeVariant],
     hg19_vcf_info: VcfFile,
     hg38_vcf_info: VcfFile,
+    hg19_vcf_dir: Path,
+    hg38_vcf_dir: Path
 ) -> VcfFile:
     """
     Select the appropriate VCF template based on the assembly information of the proband causative variants.
@@ -224,11 +227,15 @@ def select_vcf_template(
     if proband_causative_variants[0].assembly in ["hg19", "GRCh37"]:
         if hg19_vcf_info:
             return hg19_vcf_info
+        elif hg19_vcf_dir:
+            return VcfFile.populate_fields(random.choice(all_files(hg19_vcf_dir)))
         else:
             raise InputError("Must specify hg19 template VCF!")
     elif proband_causative_variants[0].assembly in ["hg38", "GRCh38"]:
         if hg38_vcf_info:
             return hg38_vcf_info
+        elif hg38_vcf_dir:
+            return VcfFile.populate_fields(random.choice(all_files(hg38_vcf_dir)))
         else:
             raise InputError("Must specify hg38 template VCF!")
     else:
@@ -426,6 +433,8 @@ def spike_vcf_contents(
     phenopacket_path: Path,
     hg19_vcf_info: VcfFile,
     hg38_vcf_info: VcfFile,
+    hg19_vcf_dir: Path,
+    hg38_vcf_dir: Path
 ) -> tuple[str, List[str]]:
     """
     Spike VCF records with variants obtained from a Phenopacket or Family.
@@ -443,7 +452,7 @@ def spike_vcf_contents(
     """
     phenopacket_causative_variants = PhenopacketUtil(phenopacket).causative_variants()
     chosen_template_vcf = select_vcf_template(
-        phenopacket_path, phenopacket_causative_variants, hg19_vcf_info, hg38_vcf_info
+        phenopacket_path, phenopacket_causative_variants, hg19_vcf_info, hg38_vcf_info, hg19_vcf_dir, hg38_vcf_dir
     )
     check_variant_assembly(
         phenopacket_causative_variants, chosen_template_vcf.vcf_header, phenopacket_path
@@ -464,6 +473,8 @@ def generate_spiked_vcf_file(
     phenopacket_path: Path,
     hg19_vcf_info: VcfFile,
     hg38_vcf_info: VcfFile,
+    hg19_vcf_dir: Path,
+    hg38_vcf_dir: Path
 ) -> File:
     """
     Write spiked VCF contents to a new file.
@@ -480,7 +491,7 @@ def generate_spiked_vcf_file(
     output_dir.mkdir(exist_ok=True)
     info_log.info(f" Created a directory {output_dir}")
     vcf_assembly, spiked_vcf = spike_vcf_contents(
-        phenopacket, phenopacket_path, hg19_vcf_info, hg38_vcf_info
+        phenopacket, phenopacket_path, hg19_vcf_info, hg38_vcf_info, hg19_vcf_dir, hg38_vcf_dir
     )
     spiked_vcf_path = output_dir.joinpath(phenopacket_path.name.replace(".json", ".vcf.gz"))
     VcfWriter(spiked_vcf, spiked_vcf_path).write_vcf_file()
@@ -490,10 +501,10 @@ def generate_spiked_vcf_file(
     )
 
 
-def spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, output_dir, phenopacket_path):
+def spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, hg19_vcf_dir: Path, hg38_vcf_dir: Path, output_dir, phenopacket_path):
     phenopacket = phenopacket_reader(phenopacket_path)
     spiked_vcf_file_message = generate_spiked_vcf_file(
-        output_dir, phenopacket, phenopacket_path, hg19_vcf_info, hg38_vcf_info
+        output_dir, phenopacket, phenopacket_path, hg19_vcf_info, hg38_vcf_info, hg19_vcf_dir, hg38_vcf_dir
     )
     updated_phenopacket = PhenopacketRebuilder(phenopacket).add_spiked_vcf_path(
         spiked_vcf_file_message
@@ -502,7 +513,7 @@ def spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, output_dir, pheno
 
 
 def create_spiked_vcf(
-    output_dir: Path, phenopacket_path: Path, hg19_template_vcf: Path, hg38_template_vcf: Path
+    output_dir: Path, phenopacket_path: Path, hg19_template_vcf: Path, hg38_template_vcf: Path, hg19_vcf_dir: Path, hg38_vcf_dir: Path
 ) -> None:
     """
     Create a spiked VCF for a Phenopacket.
@@ -520,11 +531,11 @@ def create_spiked_vcf(
         raise InputError("Either a hg19 template vcf or hg38 template vcf must be specified")
     hg19_vcf_info = VcfFile.populate_fields(hg19_template_vcf) if hg19_template_vcf else None
     hg38_vcf_info = VcfFile.populate_fields(hg38_template_vcf) if hg38_template_vcf else None
-    spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, output_dir, phenopacket_path)
+    spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, hg19_vcf_dir, hg38_vcf_dir, output_dir, phenopacket_path)
 
 
 def create_spiked_vcfs(
-    output_dir: Path, phenopacket_dir: Path, hg19_template_vcf: Path, hg38_template_vcf: Path
+    output_dir: Path, phenopacket_dir: Path, hg19_template_vcf: Path, hg38_template_vcf: Path, hg19_vcf_dir: Path, hg38_vcf_dir: Path
 ) -> None:
     """
     Create a spiked VCF for a directory of Phenopackets.
@@ -538,12 +549,12 @@ def create_spiked_vcfs(
     Raises:
         InputError: If both hg19_template_vcf and hg38_template_vcf are None.
     """
-    if hg19_template_vcf is None and hg38_template_vcf is None:
-        raise InputError("Either a hg19 template vcf or hg38 template vcf must be specified")
+    if hg19_template_vcf is None and hg38_template_vcf is None and hg19_vcf_dir is None and hg38_vcf_dir is None:
+        raise InputError("Need to specify a VCF!")
     hg19_vcf_info = VcfFile.populate_fields(hg19_template_vcf) if hg19_template_vcf else None
     hg38_vcf_info = VcfFile.populate_fields(hg38_template_vcf) if hg38_template_vcf else None
     for phenopacket_path in files_with_suffix(phenopacket_dir, ".json"):
-        spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, output_dir, phenopacket_path)
+        spike_and_update_phenopacket(hg19_vcf_info, hg38_vcf_info, hg19_vcf_dir, hg38_vcf_dir, output_dir, phenopacket_path)
 
 
 def spike_vcfs(
@@ -552,6 +563,8 @@ def spike_vcfs(
     phenopacket_dir: Path,
     hg19_template_vcf: Path,
     hg38_template_vcf: Path,
+    hg19_vcf_dir: Path,
+    hg38_vcf_dir: Path
 ) -> None:
     """
     Create spiked VCF from either a Phenopacket or a Phenopacket directory.
@@ -562,8 +575,10 @@ def spike_vcfs(
         phenopacket_dir (Path): Path to a directory containing Phenopacket files (optional).
         hg19_template_vcf (Path): Path to the hg19 template VCF file (optional).
         hg38_template_vcf (Path): Path to the hg38 template VCF file (optional).
+        hg19_vcf_dir (Path): The directory containing the hg19 VCF files (optional).
+        hg38_vcf_dir (Path): The directory containing the hg38 VCF files (optional).
     """
     if phenopacket_path is not None:
-        create_spiked_vcf(output_dir, phenopacket_path, hg19_template_vcf, hg38_template_vcf)
+        create_spiked_vcf(output_dir, phenopacket_path, hg19_template_vcf, hg38_template_vcf, hg19_vcf_dir, hg38_vcf_dir)
     elif phenopacket_dir is not None:
-        create_spiked_vcfs(output_dir, phenopacket_dir, hg19_template_vcf, hg38_template_vcf)
+        create_spiked_vcfs(output_dir, phenopacket_dir, hg19_template_vcf, hg38_template_vcf, hg19_vcf_dir, hg38_vcf_dir)

--- a/src/pheval/prepare/prepare_corpus.py
+++ b/src/pheval/prepare/prepare_corpus.py
@@ -17,6 +17,8 @@ def prepare_corpus(
     gene_identifier: str,
     hg19_template_vcf: Path,
     hg38_template_vcf: Path,
+    hg19_vcf_dir: Path,
+    hg38_vcf_dir: Path,
     output_dir: Path,
 ) -> None:
     """
@@ -33,7 +35,12 @@ def prepare_corpus(
         VCFs for variant-based analysis at least one of hg19_template_vcf or hg38_template_vcf is required.
         hg38_template_vcf (Path): Path to the hg38 template VCF file (optional), to spike variants into
         VCFs for variant-based analysis at least one of hg19_template_vcf or hg38_template_vcf is required.
+        hg19_vcf_dir (Path): Path to the directory containing hg19 template VCF files (optional).
+        hg38_vcf_dir (Path): Path to the directory containing hg38 template VCF files (optional).
         output_dir (Path): The directory to save the prepared Phenopackets and, optionally, VCF files.
+    Notes:
+        To spike variants into VCFs for variant-based analysis at least one of hg19_template_vcf, hg38_template_vcf,
+        hg19_vcf_dir or hg38_vcf_dir is required.
     """
     output_dir.joinpath("phenopackets").mkdir(exist_ok=True, parents=True)
     for phenopacket_path in all_files(phenopacket_dir):
@@ -63,5 +70,10 @@ def prepare_corpus(
         if hg19_template_vcf or hg38_template_vcf:
             output_dir.joinpath("vcf").mkdir(exist_ok=True)
             create_spiked_vcf(
-                output_dir.joinpath("vcf"), phenopacket_path, hg19_template_vcf, hg38_template_vcf
+                output_dir.joinpath("vcf"),
+                phenopacket_path,
+                hg19_template_vcf,
+                hg38_template_vcf,
+                hg19_vcf_dir,
+                hg38_vcf_dir,
             )


### PR DESCRIPTION
Add arguments for specifying a directory of hg19 or hg38 VCFs to spike variants in for the spike VCFs command.

No changes to code structure - just now adding the option to iterate through a directory of VCFs and select one at random for each phenopacket to spike the variant in. This should help with problems in benchmarking with the same background VCF for all samples