### PR TITLE
331 iterate over corpus directory and check for corresponding results when benchmarking

### DIFF
--- a/src/pheval/analyse/disease_prioritisation_analysis.py
+++ b/src/pheval/analyse/disease_prioritisation_analysis.py
@@ -10,11 +10,7 @@ from pheval.analyse.prioritisation_result_types import DiseasePrioritisationResu
 from pheval.analyse.rank_stats import RankStats
 from pheval.analyse.run_data_parser import TrackInputOutputDirectories
 from pheval.post_processing.post_processing import RankedPhEvalDiseaseResult
-from pheval.utils.file_utils import (
-    all_files,
-    files_with_suffix,
-    obtain_phenopacket_path_from_pheval_result,
-)
+from pheval.utils.file_utils import all_files
 from pheval.utils.phenopacket_utils import PhenopacketUtil, ProbandDisease, phenopacket_reader
 
 
@@ -217,7 +213,7 @@ def _obtain_causative_diseases(phenopacket_path: Path) -> List[ProbandDisease]:
 
 
 def assess_phenopacket_disease_prioritisation(
-    standardised_disease_result: Path,
+    phenopacket_path: Path,
     score_order: str,
     results_dir_and_input: TrackInputOutputDirectories,
     threshold: float,
@@ -230,7 +226,7 @@ def assess_phenopacket_disease_prioritisation(
     against the recorded causative diseases for a proband in the Phenopacket.
 
     Args:
-        standardised_disease_result (Path): Path to the PhEval standardised disease result file.
+        phenopacket_path (Path): Path to the Phenopacket.
         score_order (str): The order in which scores are arranged, either ascending or descending.
         results_dir_and_input (TrackInputOutputDirectories): Input and output directories.
         threshold (float): Threshold for assessment.
@@ -238,8 +234,8 @@ def assess_phenopacket_disease_prioritisation(
         disease_rank_comparison (defaultdict): Default dictionary for disease rank comparisons.
         disease_binary_classification_stats (BinaryClassificationStats): BinaryClassificationStats class instance.
     """
-    phenopacket_path = obtain_phenopacket_path_from_pheval_result(
-        standardised_disease_result, all_files(results_dir_and_input.phenopacket_dir)
+    standardised_disease_result = results_dir_and_input.results_dir.joinpath(
+        f"pheval_disease_results/{phenopacket_path.stem}-pheval_disease_result.tsv"
     )
     pheval_disease_result = read_standardised_result(standardised_disease_result)
     proband_diseases = _obtain_causative_diseases(phenopacket_path)
@@ -276,12 +272,9 @@ def benchmark_disease_prioritisation(
     """
     disease_rank_stats = RankStats()
     disease_binary_classification_stats = BinaryClassificationStats()
-    for standardised_result in files_with_suffix(
-        results_directory_and_input.results_dir.joinpath("pheval_disease_results/"),
-        ".tsv",
-    ):
+    for phenopacket_path in all_files(results_directory_and_input.phenopacket_dir):
         assess_phenopacket_disease_prioritisation(
-            standardised_result,
+            phenopacket_path,
             score_order,
             results_directory_and_input,
             threshold,

--- a/src/pheval/analyse/gene_prioritisation_analysis.py
+++ b/src/pheval/analyse/gene_prioritisation_analysis.py
@@ -10,11 +10,7 @@ from pheval.analyse.prioritisation_result_types import GenePrioritisationResult
 from pheval.analyse.rank_stats import RankStats
 from pheval.analyse.run_data_parser import TrackInputOutputDirectories
 from pheval.post_processing.post_processing import RankedPhEvalGeneResult
-from pheval.utils.file_utils import (
-    all_files,
-    files_with_suffix,
-    obtain_phenopacket_path_from_pheval_result,
-)
+from pheval.utils.file_utils import all_files
 from pheval.utils.phenopacket_utils import PhenopacketUtil, ProbandCausativeGene, phenopacket_reader
 
 
@@ -209,7 +205,7 @@ def _obtain_causative_genes(phenopacket_path: Path) -> List[ProbandCausativeGene
 
 
 def assess_phenopacket_gene_prioritisation(
-    standardised_gene_result: Path,
+    phenopacket_path: Path,
     score_order: str,
     results_dir_and_input: TrackInputOutputDirectories,
     threshold: float,
@@ -222,7 +218,7 @@ def assess_phenopacket_gene_prioritisation(
     against the recorded causative genes for a proband in the Phenopacket.
 
     Args:
-        standardised_gene_result (Path): Path to the PhEval standardised gene result file.
+        phenopacket_path (Path): Path to the Phenopacket.
         score_order (str): The order in which scores are arranged, either ascending or descending.
         results_dir_and_input (TrackInputOutputDirectories): Input and output directories.
         threshold (float): Threshold for assessment.
@@ -230,8 +226,8 @@ def assess_phenopacket_gene_prioritisation(
         gene_rank_comparison (defaultdict): Default dictionary for gene rank comparisons.
         gene_binary_classification_stats (BinaryClassificationStats): BinaryClassificationStats class instance.
     """
-    phenopacket_path = obtain_phenopacket_path_from_pheval_result(
-        standardised_gene_result, all_files(results_dir_and_input.phenopacket_dir)
+    standardised_gene_result = results_dir_and_input.results_dir.joinpath(
+        f"pheval_gene_results/{phenopacket_path.stem}-pheval_gene_result.tsv"
     )
     pheval_gene_result = read_standardised_result(standardised_gene_result)
     proband_causative_genes = _obtain_causative_genes(phenopacket_path)
@@ -266,11 +262,9 @@ def benchmark_gene_prioritisation(
     """
     gene_rank_stats = RankStats()
     gene_binary_classification_stats = BinaryClassificationStats()
-    for standardised_result in files_with_suffix(
-        results_directory_and_input.results_dir.joinpath("pheval_gene_results/"), ".tsv"
-    ):
+    for phenopacket_path in all_files(results_directory_and_input.phenopacket_dir):
         assess_phenopacket_gene_prioritisation(
-            standardised_result,
+            phenopacket_path,
             score_order,
             results_directory_and_input,
             threshold,

--- a/src/pheval/analyse/parse_pheval_result.py
+++ b/src/pheval/analyse/parse_pheval_result.py
@@ -1,9 +1,12 @@
+import logging
 from pathlib import Path
 from typing import List
 
 import pandas as pd
 
 from pheval.post_processing.post_processing import PhEvalResult
+
+info_log = logging.getLogger("info")
 
 
 def read_standardised_result(standardised_result_path: Path) -> List[dict]:
@@ -16,7 +19,11 @@ def read_standardised_result(standardised_result_path: Path) -> List[dict]:
     Returns:
         List[dict]: A list of dictionaries representing the content of the standardised result file.
     """
-    return pd.read_csv(standardised_result_path, delimiter="\t").to_dict("records")
+    if standardised_result_path.is_file():
+        return pd.read_csv(standardised_result_path, delimiter="\t").to_dict("records")
+    else:
+        info_log.info(f"Could not find {standardised_result_path}")
+        return pd.DataFrame().to_dict("records")
 
 
 def parse_pheval_result(

--- a/src/pheval/analyse/variant_prioritisation_analysis.py
+++ b/src/pheval/analyse/variant_prioritisation_analysis.py
@@ -10,11 +10,7 @@ from pheval.analyse.prioritisation_result_types import VariantPrioritisationResu
 from pheval.analyse.rank_stats import RankStats
 from pheval.analyse.run_data_parser import TrackInputOutputDirectories
 from pheval.post_processing.post_processing import RankedPhEvalVariantResult
-from pheval.utils.file_utils import (
-    all_files,
-    files_with_suffix,
-    obtain_phenopacket_path_from_pheval_result,
-)
+from pheval.utils.file_utils import all_files
 from pheval.utils.phenopacket_utils import GenomicVariant, PhenopacketUtil, phenopacket_reader
 
 
@@ -211,7 +207,7 @@ def _obtain_causative_variants(phenopacket_path: Path) -> List[GenomicVariant]:
 
 
 def assess_phenopacket_variant_prioritisation(
-    standardised_variant_result: Path,
+    phenopacket_path: Path,
     score_order: str,
     results_dir_and_input: TrackInputOutputDirectories,
     threshold: float,
@@ -224,7 +220,7 @@ def assess_phenopacket_variant_prioritisation(
     against the recorded causative variants for a proband in the Phenopacket.
 
     Args:
-        standardised_variant_result (Path): Path to the PhEval standardised variant result file.
+        phenopacket_path (Path): Path to the Phenopacket.
         score_order (str): The order in which scores are arranged, either ascending or descending.
         results_dir_and_input (TrackInputOutputDirectories): Input and output directories.
         threshold (float): Threshold for assessment.
@@ -232,10 +228,10 @@ def assess_phenopacket_variant_prioritisation(
         variant_rank_comparison (defaultdict): Default dictionary for variant rank comparisons.
         variant_binary_classification_stats (BinaryClassificationStats): BinaryClassificationStats class instance.
     """
-    phenopacket_path = obtain_phenopacket_path_from_pheval_result(
-        standardised_variant_result, all_files(results_dir_and_input.phenopacket_dir)
-    )
     proband_causative_variants = _obtain_causative_variants(phenopacket_path)
+    standardised_variant_result = results_dir_and_input.results_dir.joinpath(
+        f"pheval_variant_results/{phenopacket_path.stem}-pheval_variant_result.tsv"
+    )
     pheval_variant_result = read_standardised_result(standardised_variant_result)
     AssessVariantPrioritisation(
         phenopacket_path,
@@ -270,12 +266,9 @@ def benchmark_variant_prioritisation(
     """
     variant_rank_stats = RankStats()
     variant_binary_classification_stats = BinaryClassificationStats()
-    for standardised_result in files_with_suffix(
-        results_directory_and_input.results_dir.joinpath("pheval_variant_results/"),
-        ".tsv",
-    ):
+    for phenopacket_path in all_files(results_directory_and_input.phenopacket_dir):
         assess_phenopacket_variant_prioritisation(
-            standardised_result,
+            phenopacket_path,
             score_order,
             results_directory_and_input,
             threshold,

--- a/src/pheval/utils/file_utils.py
+++ b/src/pheval/utils/file_utils.py
@@ -70,35 +70,6 @@ def normalise_file_name(file_path: Path) -> str:
     return re.sub("[\u0300-\u036f]", "", normalised_file_name)
 
 
-def obtain_phenopacket_path_from_pheval_result(
-    pheval_result_path: Path, phenopacket_paths: list[Path]
-) -> Path:
-    """
-    Obtains the phenopacket file name when given a pheval result file name
-    and a list of full paths of phenopackets to be queried.
-
-    Args:
-        pheval_result_path (Path): The PhEval result.
-        phenopacket_paths (list[Path]): List of full paths of phenopackets to be queried.
-
-    Returns:
-        Path: The matching phenopacket file path from the provided list.
-    """
-    pheval_result_path_stem_stripped = pheval_result_path.stem.split("-pheval_")[0]
-    matching_phenopacket_paths = [
-        phenopacket_path
-        for phenopacket_path in phenopacket_paths
-        if phenopacket_path.stem == pheval_result_path_stem_stripped
-    ]
-    if matching_phenopacket_paths:
-        return matching_phenopacket_paths[0]
-    else:
-        raise FileNotFoundError(
-            f"Unable to find matching phenopacket file named "
-            f"{pheval_result_path_stem_stripped}.json for {pheval_result_path.name}"
-        )
-
-
 def ensure_file_exists(*files: str):
     """Ensures the existence of files passed as parameter
     Raises:


### PR DESCRIPTION
Currently, we iterate over the PhEval TSV processed output --> find the corresponding phenopacket in the test data directory --> benchmark this way.


This change will instead, iterate over the phenopackets in the test data directory --> find the corresponding PhEval TSV output (if none found this is handled) --> benchmark this way

This will allow us to account for missing results, i.e., if a tool fails on certain results no output is written then this is accounted in the new way of benchmarking