### PR TITLE
333 allow multiple genes/gene identifiers for a single ranked result

### DIFF
--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -3,6 +3,7 @@ import operator
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import List, Union
 
 import pandas as pd
 
@@ -30,8 +31,8 @@ class PhEvalResult:
 class PhEvalGeneResult(PhEvalResult):
     """Minimal data required from tool-specific output for gene prioritisation result
     Args:
-        gene_symbol (str): The gene symbol for the result entry
-        gene_identifier (str): The ENSEMBL gene identifier for the result entry
+        gene_symbol (Union[List[str], str]): The gene symbol(s) for the result entry
+        gene_identifier (Union[List[str], str]): The ENSEMBL gene identifier(s) for the result entry
         score (float): The score for the gene result entry
     Notes:
         While we recommend providing the gene identifier in the ENSEMBL namespace,
@@ -39,8 +40,8 @@ class PhEvalGeneResult(PhEvalResult):
         in the analysis.
     """
 
-    gene_symbol: str
-    gene_identifier: str
+    gene_symbol: Union[List[str], str]
+    gene_identifier: Union[List[str], str]
     score: float
 
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -422,8 +422,8 @@ class TestAssessGenePrioritisation(unittest.TestCase):
                     rank=2,
                 ),
                 RankedPhEvalGeneResult(
-                    gene_symbol="PLXNA1",
-                    gene_identifier="ENSG00000114554",
+                    gene_symbol="['PLXNA1', 'GENE2']",
+                    gene_identifier="['ENSG00000114554', 'ENSG00000100000']",
                     score=0.8764,
                     rank=4,
                 ),
@@ -770,6 +770,17 @@ class TestAssessGenePrioritisation(unittest.TestCase):
                 labels=[1, 0, 0, 0],
                 scores=[0.8764, 0.5777, 0.5777, 0.3765],
             ),
+        )
+
+    def test__check_string_representation_string(self):
+        self.assertEqual(
+            self.assess_gene_prioritisation._check_string_representation("GENE1"), "GENE1"
+        )
+
+    def test__check_string_representation_list(self):
+        self.assertEqual(
+            self.assess_gene_prioritisation._check_string_representation("['GENE1', 'GENE2']"),
+            ["GENE1", "GENE2"],
         )
 
 


### PR DESCRIPTION
Some tools may output alternate gene identifiers/symbols for the same top-ranked variant (AI-MARRVEL as an example).

To allow for this, the post-processing has now allowed for either a single gene symbol/identifiers or a list of gene symbols/identifiers - this avoids breaking the other runners.

The benchmarking code for the gene analysis has also been altered - processing either a list of gene symbols/gene identifiers or a single one to match against the causative gene(s)