### PR TITLE
Ensure type matching in benchmark for variants

### DIFF
--- a/src/pheval/analyse/variant_prioritisation_analysis.py
+++ b/src/pheval/analyse/variant_prioritisation_analysis.py
@@ -162,8 +162,8 @@ class AssessVariantPrioritisation:
             variant_match = VariantPrioritisationResult(self.phenopacket_path, variant)
             for result in self.standardised_variant_results:
                 result_variant = GenomicVariant(
-                    chrom=result.chromosome,
-                    pos=result.start,
+                    chrom=str(result.chromosome),
+                    pos=int(result.start),
                     ref=result.ref,
                     alt=result.alt,
                 )

--- a/src/pheval/utils/phenopacket_utils.py
+++ b/src/pheval/utils/phenopacket_utils.py
@@ -468,10 +468,12 @@ class PhenopacketUtil:
         for i in pheno_interpretation:
             for g in i.diagnosis.genomic_interpretations:
                 variant = GenomicVariant(
-                    chrom=g.variant_interpretation.variation_descriptor.vcf_record.chrom.replace(
-                        "chr", ""
+                    chrom=str(
+                        g.variant_interpretation.variation_descriptor.vcf_record.chrom.replace(
+                            "chr", ""
+                        )
                     ),
-                    pos=g.variant_interpretation.variation_descriptor.vcf_record.pos,
+                    pos=int(g.variant_interpretation.variation_descriptor.vcf_record.pos),
                     ref=g.variant_interpretation.variation_descriptor.vcf_record.ref,
                     alt=g.variant_interpretation.variation_descriptor.vcf_record.alt,
                 )


### PR DESCRIPTION
The variants may be read in as strings/integers for the position - which may result in a failed match for different types. Now chromosomes are explicitly str and position int