### PR TITLE
Ensure string typing when checking for string/list in gene prioritisation analysis

### DIFF
--- a/src/pheval/analyse/gene_prioritisation_analysis.py
+++ b/src/pheval/analyse/gene_prioritisation_analysis.py
@@ -155,7 +155,7 @@ class AssessGenePrioritisation:
             the original string.
         """
         list_pattern = re.compile(r"^\[\s*(?:[^\[\],\s]+(?:\s*,\s*[^\[\],\s]+)*)?\s*\]$")
-        if list_pattern.match(entity):
+        if list_pattern.match(str(entity)):
             return ast.literal_eval(entity)
         else:
             return entity


### PR DESCRIPTION
This will fix/prevent this error:
```
  File "/nfs/production/parkinso/spot/pheval/monarch_pheval_zenodo/.venv/lib/python3.10/site-packages/pheval/analyse/gene_prioritisation_analysis.py", line 158, in _check_string_representation
    if list_pattern.match(entity):
TypeError: expected string or bytes-like object
make[2]: *** [Makefile:256: results/gene_rank_stats.svg] Error 1
make[1]: *** [Makefile:515: pheval] Error 2
make: *** [Makefile:521: all] Error 2
```