### PR TITLE
357 remove duplicated code in variant/gene/disease analysis

### DIFF
--- a/src/pheval/analyse/assess_prioritisation_base.py
+++ b/src/pheval/analyse/assess_prioritisation_base.py
@@ -1,0 +1,108 @@
+from typing import Union
+
+from pheval.analyse.benchmark_db_manager import BenchmarkDBManager
+from pheval.post_processing.post_processing import (
+    RankedPhEvalDiseaseResult,
+    RankedPhEvalGeneResult,
+    RankedPhEvalVariantResult,
+)
+
+
+class AssessPrioritisationBase:
+    def __init__(
+        self,
+        db_connection: BenchmarkDBManager,
+        table_name: str,
+        column: str,
+        threshold: float,
+        score_order: str,
+    ):
+        """
+        Initialise AssessPrioritisationBase class
+
+        Args:
+            db_connection (BenchmarkDBManager): DB connection.
+            table_name (str): Table name.
+            column (str): Column name.
+            threshold (float): Threshold for scores
+            score_order (str): Score order for results, either ascending or descending
+
+        """
+        self.threshold = threshold
+        self.score_order = score_order
+        self.db_connection = db_connection
+        self.conn = db_connection.conn
+        self.column = column
+        self.table_name = table_name
+        db_connection.add_column_integer_default(
+            table_name=table_name, column=self.column, default=0
+        )
+
+    def _assess_with_threshold_ascending_order(
+        self,
+        result_entry: Union[
+            RankedPhEvalGeneResult, RankedPhEvalDiseaseResult, RankedPhEvalVariantResult
+        ],
+    ) -> int:
+        """
+        Record the prioritisation rank if it meets the ascending order threshold.
+
+
+        Args:
+            result_entry (Union[RankedPhEvalGeneResult, RankedPhEvalDiseaseResult, RankedPhEvalVariantResult]):
+                Ranked PhEval result entry
+
+        Returns:
+            int: Recorded prioritisation rank
+        """
+        if float(self.threshold) > float(result_entry.score):
+            return result_entry.rank
+        else:
+            return 0
+
+    def _assess_with_threshold(
+        self,
+        result_entry: Union[
+            RankedPhEvalGeneResult, RankedPhEvalDiseaseResult, RankedPhEvalVariantResult
+        ],
+    ) -> int:
+        """
+        Record the prioritisation rank if it meets the score threshold.
+
+        Args:
+            result_entry (Union[RankedPhEvalGeneResult, RankedPhEvalDiseaseResult, RankedPhEvalVariantResult]):
+                Ranked PhEval result entry
+
+        Returns:
+            int: Recorded prioritisation rank
+        """
+        if float(self.threshold) < float(result_entry.score):
+            return result_entry.rank
+        else:
+            return 0
+
+    def _record_matched_entity(
+        self,
+        standardised_result: Union[
+            RankedPhEvalGeneResult, RankedPhEvalDiseaseResult, RankedPhEvalVariantResult
+        ],
+    ) -> int:
+        """
+        Return the rank result - handling the specification of a threshold.
+        Args:
+            standardised_result (Union[RankedPhEvalGeneResult, RankedPhEvalDiseaseResult, RankedPhEvalVariantResult]):
+                Ranked PhEval disease result entry
+
+        Returns:
+            int: Recorded entity prioritisation rank
+        """
+        if float(self.threshold) == 0.0:
+            return standardised_result.rank
+        else:
+            return (
+                self._assess_with_threshold(standardised_result)
+                if self.score_order != "ascending"
+                else self._assess_with_threshold_ascending_order(
+                    standardised_result,
+                )
+            )

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -73,7 +73,7 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         assess_ascending_order_threshold = copy(self.assess_gene_prioritisation_ascending_order)
         assess_ascending_order_threshold.threshold = 0.1
         self.assertEqual(
-            assess_ascending_order_threshold._assess_gene_with_threshold_ascending_order(
+            assess_ascending_order_threshold._assess_with_threshold_ascending_order(
                 result_entry=RankedPhEvalGeneResult(
                     gene_symbol="PLXNA1",
                     gene_identifier="ENSG00000114554",
@@ -88,7 +88,7 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         assess_ascending_order_threshold = copy(self.assess_gene_prioritisation_ascending_order)
         assess_ascending_order_threshold.threshold = 0.9
         self.assertEqual(
-            assess_ascending_order_threshold._assess_gene_with_threshold_ascending_order(
+            assess_ascending_order_threshold._assess_with_threshold_ascending_order(
                 result_entry=RankedPhEvalGeneResult(
                     gene_symbol="PLXNA1",
                     gene_identifier="ENSG00000114554",
@@ -103,7 +103,7 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         assess_with_threshold = copy(self.assess_gene_prioritisation)
         assess_with_threshold.threshold = 0.9
         self.assertEqual(
-            assess_with_threshold._assess_gene_with_threshold(
+            assess_with_threshold._assess_with_threshold(
                 result_entry=RankedPhEvalGeneResult(
                     gene_symbol="PLXNA1",
                     gene_identifier="ENSG00000114554",
@@ -118,7 +118,7 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         assess_with_threshold = copy(self.assess_gene_prioritisation)
         assess_with_threshold.threshold = 0.5
         self.assertEqual(
-            assess_with_threshold._assess_gene_with_threshold(
+            assess_with_threshold._assess_with_threshold(
                 result_entry=RankedPhEvalGeneResult(
                     gene_symbol="PLXNA1",
                     gene_identifier="ENSG00000114554",
@@ -213,7 +213,7 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         assess_with_threshold = copy(self.assess_variant_prioritisation_ascending_order)
         assess_with_threshold.threshold = 0.01
         self.assertEqual(
-            assess_with_threshold._assess_variant_with_threshold_ascending_order(
+            assess_with_threshold._assess_with_threshold_ascending_order(
                 result_entry=RankedPhEvalVariantResult(
                     chromosome="3",
                     start=126741108,
@@ -231,7 +231,7 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         assess_with_threshold = copy(self.assess_variant_prioritisation_ascending_order)
         assess_with_threshold.threshold = 0.9
         self.assertEqual(
-            assess_with_threshold._assess_variant_with_threshold_ascending_order(
+            assess_with_threshold._assess_with_threshold_ascending_order(
                 result_entry=RankedPhEvalVariantResult(
                     chromosome="3",
                     start=126741108,
@@ -249,7 +249,7 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         assess_with_threshold = copy(self.assess_variant_prioritisation)
         assess_with_threshold.threshold = 0.9
         self.assertEqual(
-            assess_with_threshold._assess_variant_with_threshold(
+            assess_with_threshold._assess_with_threshold(
                 result_entry=RankedPhEvalVariantResult(
                     chromosome="3",
                     start=126741108,
@@ -267,7 +267,7 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         assess_with_threshold = copy(self.assess_variant_prioritisation)
         assess_with_threshold.threshold = 0.01
         self.assertEqual(
-            assess_with_threshold._assess_variant_with_threshold(
+            assess_with_threshold._assess_with_threshold(
                 result_entry=RankedPhEvalVariantResult(
                     chromosome="3",
                     start=126741108,
@@ -382,7 +382,7 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         assess_ascending_order_threshold = copy(self.assess_disease_prioritisation_ascending_order)
         assess_ascending_order_threshold.threshold = 0.1
         self.assertEqual(
-            assess_ascending_order_threshold._assess_disease_with_threshold_ascending_order(
+            assess_ascending_order_threshold._assess_with_threshold_ascending_order(
                 result_entry=RankedPhEvalDiseaseResult(
                     disease_name="Glutaric aciduria type 1",
                     disease_identifier="OMIM:231670",
@@ -397,7 +397,7 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         assess_ascending_order_threshold = copy(self.assess_disease_prioritisation_ascending_order)
         assess_ascending_order_threshold.threshold = 0.9
         self.assertEqual(
-            assess_ascending_order_threshold._assess_disease_with_threshold_ascending_order(
+            assess_ascending_order_threshold._assess_with_threshold_ascending_order(
                 result_entry=RankedPhEvalDiseaseResult(
                     disease_name="Glutaric aciduria type 1",
                     disease_identifier="OMIM:231670",
@@ -412,7 +412,7 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         assess_with_threshold = copy(self.assess_disease_prioritisation)
         assess_with_threshold.threshold = 0.9
         self.assertEqual(
-            assess_with_threshold._assess_disease_with_threshold(
+            assess_with_threshold._assess_with_threshold(
                 result_entry=RankedPhEvalDiseaseResult(
                     disease_identifier="OMIM:231670",
                     disease_name="Glutaric aciduria type 1",
@@ -427,7 +427,7 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         assess_with_threshold = copy(self.assess_disease_prioritisation)
         assess_with_threshold.threshold = 0.5
         self.assertEqual(
-            assess_with_threshold._assess_disease_with_threshold(
+            assess_with_threshold._assess_with_threshold(
                 result_entry=RankedPhEvalDiseaseResult(
                     disease_identifier="OMIM:231670",
                     disease_name="Glutaric aciduria type 1",


### PR DESCRIPTION
Removed the duplicated methods/code found in `gene_prioritisation_analysis.py`, `variant_prioritisation_analysis.py`, and `gene_prioritisation_analysis.py`.

The duplicated methods were extracted into a common base class and so inherited in the new subclasses.