### PR TITLE
375 error when a pheval result cannot be found

### DIFF
--- a/src/pheval/analyse/disease_prioritisation_analysis.py
+++ b/src/pheval/analyse/disease_prioritisation_analysis.py
@@ -64,9 +64,13 @@ class AssessDiseasePrioritisation(AssessPrioritisationBase):
             elif len(result) == 0:
                 relevant_ranks.append(0)
         binary_classification_stats.add_classification(
-            self.db_connection.parse_table_into_dataclass(
-                str(standardised_disease_result_path), RankedPhEvalDiseaseResult
-            ) if standardised_disease_result_path.exists() else [],
+            (
+                self.db_connection.parse_table_into_dataclass(
+                    str(standardised_disease_result_path), RankedPhEvalDiseaseResult
+                )
+                if standardised_disease_result_path.exists()
+                else []
+            ),
             relevant_ranks,
         )
 

--- a/src/pheval/analyse/disease_prioritisation_analysis.py
+++ b/src/pheval/analyse/disease_prioritisation_analysis.py
@@ -61,10 +61,12 @@ class AssessDiseasePrioritisation(AssessPrioritisationBase):
                     f'UPDATE {self.table_name} SET "{self.column}" = ? WHERE identifier = ?',
                     (disease_match, primary_key),
                 )
+            elif len(result) == 0:
+                relevant_ranks.append(0)
         binary_classification_stats.add_classification(
             self.db_connection.parse_table_into_dataclass(
                 str(standardised_disease_result_path), RankedPhEvalDiseaseResult
-            ),
+            ) if standardised_disease_result_path.exists() else [],
             relevant_ranks,
         )
 

--- a/src/pheval/analyse/disease_prioritisation_analysis.py
+++ b/src/pheval/analyse/disease_prioritisation_analysis.py
@@ -38,11 +38,16 @@ class AssessDiseasePrioritisation(AssessPrioritisationBase):
         for _i, row in df.iterrows():
             result = (
                 self.conn.execute(
-                    f"SELECT * FROM '{standardised_disease_result_path}' "
-                    f"WHERE contains_entity_function(CAST(COALESCE(disease_identifier, '') AS VARCHAR),"
-                    f" '{row['disease_identifier']}') "
-                    f"OR contains_entity_function(CAST(COALESCE(disease_name, '') AS VARCHAR), "
-                    f"'{row['disease_name']}')"
+                    (
+                        f"SELECT * FROM '{standardised_disease_result_path}' "
+                        f"WHERE contains_entity_function(CAST(COALESCE(disease_identifier, '') AS VARCHAR),"
+                        f" '{row['disease_identifier']}') "
+                        f"OR contains_entity_function(CAST(COALESCE(disease_name, '') AS VARCHAR), "
+                        f"'{row['disease_name']}')"
+                    )
+                    if standardised_disease_result_path.exists()
+                    and standardised_disease_result_path.stat().st_size > 0
+                    else "SELECT NULL WHERE FALSE"
                 )
                 .fetchdf()
                 .to_dict(orient="records")

--- a/src/pheval/analyse/gene_prioritisation_analysis.py
+++ b/src/pheval/analyse/gene_prioritisation_analysis.py
@@ -61,9 +61,13 @@ class AssessGenePrioritisation(AssessPrioritisationBase):
             if not result:
                 relevant_ranks.append(0)
         binary_classification_stats.add_classification(
-            self.db_connection.parse_table_into_dataclass(
-                str(standardised_gene_result_path), RankedPhEvalGeneResult
-            ) if standardised_gene_result_path.exists() else [],
+            (
+                self.db_connection.parse_table_into_dataclass(
+                    str(standardised_gene_result_path), RankedPhEvalGeneResult
+                )
+                if standardised_gene_result_path.exists()
+                else []
+            ),
             relevant_ranks,
         )
 

--- a/src/pheval/analyse/gene_prioritisation_analysis.py
+++ b/src/pheval/analyse/gene_prioritisation_analysis.py
@@ -58,10 +58,12 @@ class AssessGenePrioritisation(AssessPrioritisationBase):
                     f'UPDATE {self.table_name} SET "{self.column}" = ? WHERE identifier = ?',
                     (gene_match, primary_key),
                 )
+            if not result:
+                relevant_ranks.append(0)
         binary_classification_stats.add_classification(
             self.db_connection.parse_table_into_dataclass(
                 str(standardised_gene_result_path), RankedPhEvalGeneResult
-            ),
+            ) if standardised_gene_result_path.exists() else [],
             relevant_ranks,
         )
 

--- a/src/pheval/analyse/gene_prioritisation_analysis.py
+++ b/src/pheval/analyse/gene_prioritisation_analysis.py
@@ -36,11 +36,16 @@ class AssessGenePrioritisation(AssessPrioritisationBase):
         for _i, row in df.iterrows():
             result = (
                 self.conn.execute(
-                    f"SELECT * FROM '{standardised_gene_result_path}' "
-                    f"WHERE contains_entity_function(CAST(COALESCE(gene_identifier, '') AS VARCHAR),"
-                    f" '{row['gene_identifier']}') "
-                    f"OR contains_entity_function(CAST(COALESCE(gene_symbol, '') AS VARCHAR), "
-                    f"'{row['gene_symbol']}')"
+                    (
+                        f"SELECT * FROM '{standardised_gene_result_path}' "
+                        f"WHERE contains_entity_function(CAST(COALESCE(gene_identifier, '') AS VARCHAR), "
+                        f"'{row['gene_identifier']}') "
+                        f"OR contains_entity_function(CAST(COALESCE(gene_symbol, '') AS VARCHAR), "
+                        f"'{row['gene_symbol']}')"
+                    )
+                    if standardised_gene_result_path.exists()
+                    and standardised_gene_result_path.stat().st_size > 0
+                    else "SELECT NULL WHERE FALSE"
                 )
                 .fetchdf()
                 .to_dict(orient="records")

--- a/src/pheval/analyse/variant_prioritisation_analysis.py
+++ b/src/pheval/analyse/variant_prioritisation_analysis.py
@@ -15,10 +15,10 @@ class AssessVariantPrioritisation(AssessPrioritisationBase):
     """Class for assessing variant prioritisation based on thresholds and scoring orders."""
 
     def assess_variant_prioritisation(
-        self,
-        standardised_variant_result_path: Path,
-        phenopacket_path: Path,
-        binary_classification_stats: BinaryClassificationStats,
+            self,
+            standardised_variant_result_path: Path,
+            phenopacket_path: Path,
+            binary_classification_stats: BinaryClassificationStats,
     ) -> None:
         """
         Assess variant prioritisation.
@@ -75,16 +75,16 @@ class AssessVariantPrioritisation(AssessPrioritisationBase):
         binary_classification_stats.add_classification(
             self.db_connection.parse_table_into_dataclass(
                 str(standardised_variant_result_path), RankedPhEvalVariantResult
-            ),
+            ) if standardised_variant_result_path.exists() else [],
             relevant_ranks,
         )
 
 
 def assess_phenopacket_variant_prioritisation(
-    phenopacket_path: Path,
-    run: RunConfig,
-    variant_binary_classification_stats: BinaryClassificationStats,
-    variant_benchmarker: AssessVariantPrioritisation,
+        phenopacket_path: Path,
+        run: RunConfig,
+        variant_binary_classification_stats: BinaryClassificationStats,
+        variant_benchmarker: AssessVariantPrioritisation,
 ) -> None:
     """
     Assess variant prioritisation for a Phenopacket by comparing PhEval standardised variant results
@@ -107,10 +107,10 @@ def assess_phenopacket_variant_prioritisation(
 
 
 def benchmark_variant_prioritisation(
-    benchmark_name: str,
-    run: RunConfig,
-    score_order: str,
-    threshold: float,
+        benchmark_name: str,
+        run: RunConfig,
+        score_order: str,
+        threshold: float,
 ):
     """
     Benchmark a directory based on variant prioritisation results.

--- a/src/pheval/analyse/variant_prioritisation_analysis.py
+++ b/src/pheval/analyse/variant_prioritisation_analysis.py
@@ -15,10 +15,10 @@ class AssessVariantPrioritisation(AssessPrioritisationBase):
     """Class for assessing variant prioritisation based on thresholds and scoring orders."""
 
     def assess_variant_prioritisation(
-            self,
-            standardised_variant_result_path: Path,
-            phenopacket_path: Path,
-            binary_classification_stats: BinaryClassificationStats,
+        self,
+        standardised_variant_result_path: Path,
+        phenopacket_path: Path,
+        binary_classification_stats: BinaryClassificationStats,
     ) -> None:
         """
         Assess variant prioritisation.
@@ -73,18 +73,22 @@ class AssessVariantPrioritisation(AssessPrioritisationBase):
             elif len(result) == 0:
                 relevant_ranks.append(0)
         binary_classification_stats.add_classification(
-            self.db_connection.parse_table_into_dataclass(
-                str(standardised_variant_result_path), RankedPhEvalVariantResult
-            ) if standardised_variant_result_path.exists() else [],
+            (
+                self.db_connection.parse_table_into_dataclass(
+                    str(standardised_variant_result_path), RankedPhEvalVariantResult
+                )
+                if standardised_variant_result_path.exists()
+                else []
+            ),
             relevant_ranks,
         )
 
 
 def assess_phenopacket_variant_prioritisation(
-        phenopacket_path: Path,
-        run: RunConfig,
-        variant_binary_classification_stats: BinaryClassificationStats,
-        variant_benchmarker: AssessVariantPrioritisation,
+    phenopacket_path: Path,
+    run: RunConfig,
+    variant_binary_classification_stats: BinaryClassificationStats,
+    variant_benchmarker: AssessVariantPrioritisation,
 ) -> None:
     """
     Assess variant prioritisation for a Phenopacket by comparing PhEval standardised variant results
@@ -107,10 +111,10 @@ def assess_phenopacket_variant_prioritisation(
 
 
 def benchmark_variant_prioritisation(
-        benchmark_name: str,
-        run: RunConfig,
-        score_order: str,
-        threshold: float,
+    benchmark_name: str,
+    run: RunConfig,
+    score_order: str,
+    threshold: float,
 ):
     """
     Benchmark a directory based on variant prioritisation results.

--- a/src/pheval/analyse/variant_prioritisation_analysis.py
+++ b/src/pheval/analyse/variant_prioritisation_analysis.py
@@ -44,12 +44,16 @@ class AssessVariantPrioritisation(AssessPrioritisationBase):
             )
             result = (
                 self.conn.execute(
-                    f"SELECT * FROM '{standardised_variant_result_path}' "
-                    f"WHERE "
-                    f"chromosome == '{causative_variant.chrom}' AND "
-                    f"start == {causative_variant.pos} AND "
-                    f"ref == '{causative_variant.ref}' AND "
-                    f"alt == '{causative_variant.alt}'"
+                    (
+                        f"SELECT * FROM '{standardised_variant_result_path}' "
+                        f"WHERE "
+                        f"chromosome == '{causative_variant.chrom}' AND "
+                        f"start == {causative_variant.pos} AND "
+                        f"ref == '{causative_variant.ref}' AND "
+                        f"alt == '{causative_variant.alt}'"
+                    )
+                    if standardised_variant_result_path.exists()
+                    else "SELECT NULL WHERE FALSE"
                 )
                 .fetchdf()
                 .to_dict(orient="records")
@@ -66,7 +70,8 @@ class AssessVariantPrioritisation(AssessPrioritisationBase):
                     f'UPDATE {self.table_name} SET "{self.column}" = ? WHERE identifier = ?',
                     (variant_match, primary_key),
                 )
-
+            elif len(result) == 0:
+                relevant_ranks.append(0)
         binary_classification_stats.add_classification(
             self.db_connection.parse_table_into_dataclass(
                 str(standardised_variant_result_path), RankedPhEvalVariantResult

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,7 @@
 import unittest
 from copy import copy
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import duckdb
 
@@ -130,9 +130,13 @@ class TestAssessGenePrioritisation(unittest.TestCase):
         )
 
     def test_assess_gene_prioritisation_no_threshold(self):
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.return_value = True
+        mock_path.stat.return_value.st_size = 100
+        mock_path.__str__.return_value = "result"
         self.db_connector.add_contains_function()
         self.assess_gene_prioritisation.assess_gene_prioritisation(
-            "result",
+            mock_path,
             Path("/path/to/phenopacket_1.json"),
             self.binary_classification_stats,
         )
@@ -150,7 +154,7 @@ class TestAssessGenePrioritisation(unittest.TestCase):
                 true_positives=1,
                 true_negatives=3,
                 false_positives=0,
-                false_negatives=0,
+                false_negatives=1,
                 labels=[1, 0, 0, 0],
                 scores=[0.8764, 0.5777, 0.5777, 0.3765],
             ),
@@ -282,9 +286,13 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
         )
 
     def test_assess_variant_prioritisation(self):
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.return_value = True
+        mock_path.stat.return_value.st_size = 100
+        mock_path.__str__.return_value = "result"
         self.db_connector.add_contains_function()
         self.assess_variant_prioritisation.assess_variant_prioritisation(
-            "result",
+            mock_path,
             Path("/path/to/phenopacket_1.json"),
             self.binary_classification_stats,
         )
@@ -318,7 +326,7 @@ class TestAssessVariantPrioritisation(unittest.TestCase):
                 true_positives=0,
                 true_negatives=0,
                 false_positives=2,
-                false_negatives=1,
+                false_negatives=2,
                 labels=[0, 0, 1],
                 scores=[0.0484, 0.0484, 0.0484],
             ),
@@ -439,9 +447,13 @@ class TestAssessDiseasePrioritisation(unittest.TestCase):
         )
 
     def test_assess_disease_prioritisation(self):
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.return_value = True
+        mock_path.stat.return_value.st_size = 100
+        mock_path.__str__.return_value = "result"
         self.db_connector.add_contains_function()
         self.assess_disease_prioritisation.assess_disease_prioritisation(
-            "result",
+            mock_path,
             Path("/path/to/phenopacket_1.json"),
             self.binary_classification_stats,
         )

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,7 @@
 import unittest
 from copy import copy
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import duckdb
 


### PR DESCRIPTION
Adds handling if a PhEval TSV result file is not found for a corresponding phenopacket. 

Some tools generate an empty raw results file or don't generate results at all when it fails for a sample - added handling to support this.