### PR TITLE
NaN values interrupt the benchmarking

### DIFF
--- a/src/pheval/analyse/benchmark_db_manager.py
+++ b/src/pheval/analyse/benchmark_db_manager.py
@@ -75,6 +75,7 @@ class BenchmarkDBManager:
                 `False` otherwise.
         """
         list_pattern = re.compile(r"^\[\s*(?:[^\[\],\s]+(?:\s*,\s*[^\[\],\s]+)*)?\s*]$")
+        entity = entity.replace("nan", "None").replace("NaN", "None")
         if list_pattern.match(str(entity)):
             list_representation = ast.literal_eval(entity)
             if isinstance(list_representation, list):


### PR DESCRIPTION
Replaced possible NaN values with None so that benchmarking can be completed successfully. This sometimes occurs with the mapping to ENSEMBL identifiers.