### PR TITLE
381 prepare corpus copy error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pheval"
-version = "0.4.3"
+version = "0.4.4"
 description = ""
 authors = ["Yasemin Bridges <y.bridges@qmul.ac.uk>",
   "Julius Jacobsen <j.jacobsen@qmul.ac.uk>",

--- a/src/pheval/prepare/prepare_corpus.py
+++ b/src/pheval/prepare/prepare_corpus.py
@@ -90,6 +90,10 @@ def prepare_corpus(
             )
         else:
             # if not updating phenopacket gene identifiers then copy phenopacket as is to output directory
-            shutil.copy(
-                phenopacket_path, output_dir.joinpath(f"phenopackets/{phenopacket_path.name}")
-            ) if phenopacket_path != output_dir.joinpath(f"phenopackets/{phenopacket_path.name}") else None
+            (
+                shutil.copy(
+                    phenopacket_path, output_dir.joinpath(f"phenopackets/{phenopacket_path.name}")
+                )
+                if phenopacket_path != output_dir.joinpath(f"phenopackets/{phenopacket_path.name}")
+                else None
+            )

--- a/src/pheval/prepare/prepare_corpus.py
+++ b/src/pheval/prepare/prepare_corpus.py
@@ -92,4 +92,4 @@ def prepare_corpus(
             # if not updating phenopacket gene identifiers then copy phenopacket as is to output directory
             shutil.copy(
                 phenopacket_path, output_dir.joinpath(f"phenopackets/{phenopacket_path.name}")
-            )
+            ) if phenopacket_path != output_dir.joinpath(f"phenopackets/{phenopacket_path.name}") else None


### PR DESCRIPTION
An error is thrown if a phenopacket already exists at the destination directory during the prepare corpus command. Added handling for the copying of a phenopacket