### PR TITLE
420 add early validation for inputoutput paths before running benchmarking steps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pheval"
-version = "0.6.2"
+version = "0.6.3"
 description = ""
 authors = ["Yasemin Bridges <y.bridges@qmul.ac.uk>",
   "Julius Jacobsen <j.jacobsen@qmul.ac.uk>",

--- a/src/pheval/analyse/benchmark.py
+++ b/src/pheval/analyse/benchmark.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from pathlib import Path
 from typing import List, Tuple
@@ -135,6 +136,9 @@ def benchmark_runs(benchmark_config_file: Path) -> None:
     start_time = time.perf_counter()
     logger.info("Initiated benchmarking process.")
     config = parse_run_config(benchmark_config_file)
+    if Path(f"{config.benchmark_name}.duckdb").exists():
+        logger.error(f"{config.benchmark_name}.duckdb already exists! Exiting.")
+        sys.exit(1)
     gene_analysis_runs = [run for run in config.runs if run.gene_analysis]
     variant_analysis_runs = [run for run in config.runs if run.variant_analysis]
     disease_analysis_runs = [run for run in config.runs if run.disease_analysis]

--- a/src/pheval/analyse/run_data_parser.py
+++ b/src/pheval/analyse/run_data_parser.py
@@ -41,6 +41,13 @@ class RunConfig(BaseModel):
     def set_score_order(cls, score_order):
         return score_order or "descending"
 
+    @field_validator("results_dir", mode="after")
+    @classmethod
+    def check_results_dir_exists(cls, results_dir: Path):
+        if not results_dir.exists():
+            raise FileNotFoundError(f"The specified results directory does not exist: {results_dir}")
+        return results_dir
+
 
 class SinglePlotCustomisation(BaseModel):
     """

--- a/src/pheval/analyse/run_data_parser.py
+++ b/src/pheval/analyse/run_data_parser.py
@@ -45,7 +45,9 @@ class RunConfig(BaseModel):
     @classmethod
     def check_results_dir_exists(cls, results_dir: Path):
         if not results_dir.exists():
-            raise FileNotFoundError(f"The specified results directory does not exist: {results_dir}")
+            raise FileNotFoundError(
+                f"The specified results directory does not exist: {results_dir}"
+            )
         return results_dir
 
 


### PR DESCRIPTION
Added early validation checks to the benchmarking yaml file (checking if results directory paths do exist) and a check for whether the duckdb database exists before any heavy computation. Prior the errors would arise but much later in the process. This allows for quicker debugging.