### PR TITLE
422 migrate linting and formatting to ruff

### DIFF
--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox
-      - name: Check code quality with flake8
-        run: tox -e flake8
+      - name: Check code quality with ruff
+        run: tox -e ruff-check
 
   test:
     strategy:

--- a/poetry.lock
+++ b/poetry.lock
@@ -154,41 +154,6 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "casefy"
 version = "1.1.0"
 description = "Utilities for string case conversion."
@@ -478,7 +443,7 @@ version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "docs"]
+groups = ["main", "docs"]
 files = [
     {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
     {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
@@ -498,7 +463,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "contourpy"
@@ -2328,7 +2293,7 @@ version = "1.1.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
@@ -2682,7 +2647,7 @@ version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs"]
+groups = ["docs"]
 files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
@@ -2812,7 +2777,7 @@ version = "4.3.8"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "docs"]
+groups = ["main", "docs"]
 files = [
     {file = "platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"},
     {file = "platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc"},
@@ -3852,6 +3817,33 @@ files = [
     {file = "rpds_py-0.25.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:35a8d1a24b5936b35c5003313bc177403d8bdef0f8b24f28b1c4a255f94ea992"},
     {file = "rpds_py-0.25.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:6099263f526efff9cf3883dfef505518730f7a7a93049b1d90d42e50a22b4793"},
     {file = "rpds_py-0.25.1.tar.gz", hash = "sha256:8960b6dac09b62dac26e75d7e2c4a22efb835d827a7278c34f72b2b84fa160e3"},
+]
+
+[[package]]
+name = "ruff"
+version = "0.4.10"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.4.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c2c4d0859305ac5a16310eec40e4e9a9dec5dcdfbe92697acd99624e8638dac"},
+    {file = "ruff-0.4.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a79489607d1495685cdd911a323a35871abfb7a95d4f98fc6f85e799227ac46e"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1dd1681dfa90a41b8376a61af05cc4dc5ff32c8f14f5fe20dba9ff5deb80cd6"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c75c53bb79d71310dc79fb69eb4902fba804a81f374bc86a9b117a8d077a1784"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18238c80ee3d9100d3535d8eb15a59c4a0753b45cc55f8bf38f38d6a597b9739"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d8f71885bce242da344989cae08e263de29752f094233f932d4f5cfb4ef36a81"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:330421543bd3222cdfec481e8ff3460e8702ed1e58b494cf9d9e4bf90db52b9d"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e9b6fb3a37b772628415b00c4fc892f97954275394ed611056a4b8a2631365e"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f54c481b39a762d48f64d97351048e842861c6662d63ec599f67d515cb417f6"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:67fe086b433b965c22de0b4259ddfe6fa541c95bf418499bedb9ad5fb8d1c631"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:acfaaab59543382085f9eb51f8e87bac26bf96b164839955f244d07125a982ef"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3cea07079962b2941244191569cf3a05541477286f5cafea638cd3aa94b56815"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:338a64ef0748f8c3a80d7f05785930f7965d71ca260904a9321d13be24b79695"},
+    {file = "ruff-0.4.10-py3-none-win32.whl", hash = "sha256:ffe3cd2f89cb54561c62e5fa20e8f182c0a444934bf430515a4b422f1ab7b7ca"},
+    {file = "ruff-0.4.10-py3-none-win_amd64.whl", hash = "sha256:67f67cef43c55ffc8cc59e8e0b97e9e60b4837c8f21e8ab5ffd5d66e196e25f7"},
+    {file = "ruff-0.4.10-py3-none-win_arm64.whl", hash = "sha256:dd1fcee327c20addac7916ca4e2653fbbf2e8388d8a6477ce5b4e986b68ae6c0"},
+    {file = "ruff-0.4.10.tar.gz", hash = "sha256:3aa4f2bc388a30d346c56524f7cacca85945ba124945fe489952aadb6b5cd804"},
 ]
 
 [[package]]
@@ -5031,4 +5023,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0.0"
-content-hash = "1307c0912aabbf6aacc28efdb0b2c82f2e2bfe70f855860059ae3abcaf0ae01e"
+content-hash = "13575ed17281380e4cd0513b80267e9f3f34845e7fbc3e4b92a4162694b32f20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,23 +54,49 @@ mkdocstrings-python = "^1.16.11"
 mkdocstrings = "^0.29.1"
 
 [tool.poetry.group.dev.dependencies]
-black = "^22.12.0"
+ruff = "^0.4.6"
 
 [tool.pytest.ini_options]
 pythonpath = [
   "src"
 ]
 
-[tool.black]
-line-length = 100
-target-version = ["py39", "py310"]
+[tool.ruff]
+line-length = 120
+target-version = "py311"
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 100
-include_trailing_comma = true
-reverse_relative = true
+src = ["src", "tests"]
+respect-gitignore = true
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "B",  # flake8-bugbear
+    "I",  # isort
+    "N",  # pep8-naming
+    "S",  # flake8-bandit
+    "C90",  # mccabe complexity
+    "PL",  # pylint
+    "RUF",  # Ruff-specific rules
+    "UP",  # pyupgrade
+    "NPY",  # NumPy-specific
+]
+ignore = [
+    "E203", "S311", "S101", "S106", "S404", "S108", "S307", "S603", "S607", "S608",
+    "B024", "B027", "N801", "N803", "N806", "N815", "E731", "C901", "B019", "PLR0913", "PLW0211"
+]
+fixable = ["ALL"]
+unfixable = ["B"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 13
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/pheval/analyse/benchmark_output_type.py
+++ b/src/pheval/analyse/benchmark_output_type.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, NamedTuple
+from typing import NamedTuple
 
 
 class BenchmarkOutputType(NamedTuple):
@@ -15,7 +15,7 @@ class BenchmarkOutputType(NamedTuple):
 
     prioritisation_type_string: str
     y_label: str
-    columns: List[str]
+    columns: list[str]
     result_directory: str
 
 
@@ -35,9 +35,7 @@ class BenchmarkOutputTypeEnum(Enum):
         ["gene_identifier", "gene_symbol"],
         "pheval_gene_results",
     )
-    VARIANT = BenchmarkOutputType(
-        "variant", "Disease-causing variants (%)", ["variant_id"], "pheval_variant_results"
-    )
+    VARIANT = BenchmarkOutputType("variant", "Disease-causing variants (%)", ["variant_id"], "pheval_variant_results")
     DISEASE = BenchmarkOutputType(
         "disease",
         "Known diseases (%)",

--- a/src/pheval/analyse/binary_classification_curves.py
+++ b/src/pheval/analyse/binary_classification_curves.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import numpy as np
 import polars as pl
 from sklearn.metrics import precision_recall_curve, roc_curve
@@ -11,7 +9,7 @@ class BinaryClassificationCurves:
     """Class for computing and storing ROC & Precision-Recall curves in Polars."""
 
     @staticmethod
-    def _compute_finite_bounds(result_scan: pl.LazyFrame) -> Tuple[float, float]:
+    def _compute_finite_bounds(result_scan: pl.LazyFrame) -> tuple[float, float]:
         """
         Compute min and max finite values in the 'score' column to handle NaN and Inf values.
         Args:
@@ -32,9 +30,7 @@ class BinaryClassificationCurves:
         )
 
     @staticmethod
-    def _clean_and_extract_data(
-        result_scan: pl.LazyFrame, max_finite: float, min_finite: float
-    ) -> pl.LazyFrame:
+    def _clean_and_extract_data(result_scan: pl.LazyFrame, max_finite: float, min_finite: float) -> pl.LazyFrame:
         """
         Normalise the 'score' column (handling NaNs and Inf values) and extract 'true_positive' labels.
 
@@ -64,9 +60,7 @@ class BinaryClassificationCurves:
         )
 
     @staticmethod
-    def _compute_roc_pr_curves(
-        run_identifier: str, labels: np.ndarray, scores: np.ndarray
-    ) -> pl.LazyFrame:
+    def _compute_roc_pr_curves(run_identifier: str, labels: np.ndarray, scores: np.ndarray) -> pl.LazyFrame:
         """
         Compute ROC and Precision-Recall curves.
 

--- a/src/pheval/analyse/binary_classification_stats.py
+++ b/src/pheval/analyse/binary_classification_stats.py
@@ -103,10 +103,7 @@ class BinaryClassificationStats:
     )
 
     F1_SCORE = (
-        pl.when(
-            2 * (pl.col("true_positives") + pl.col("false_positives") + pl.col("false_negatives"))
-            != 0
-        )
+        pl.when(2 * (pl.col("true_positives") + pl.col("false_positives") + pl.col("false_negatives")) != 0)
         .then(
             2
             * pl.col("true_positives")

--- a/src/pheval/analyse/generate_plots.py
+++ b/src/pheval/analyse/generate_plots.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pathlib import Path
+from typing import ClassVar
 
 import duckdb
 import matplotlib
@@ -32,7 +33,7 @@ class PlotTypes(Enum):
 class PlotGenerator:
     """Class to generate plots."""
 
-    palette_hex_codes = [
+    palette_hex_codes: ClassVar[list[str]] = [
         "#f4ae3d",
         "#ee5825",
         "#2b7288",
@@ -91,9 +92,7 @@ class PlotGenerator:
             {"run_identifier": "Run", "mrr": "Percentage"}
         )
 
-    def _save_fig(
-        self, benchmark_output_type: BenchmarkOutputType, y_lower_limit: int, y_upper_limit: int
-    ) -> None:
+    def _save_fig(self, benchmark_output_type: BenchmarkOutputType, y_lower_limit: int, y_upper_limit: int) -> None:
         """
         Save the generated figure.
         Args:
@@ -140,9 +139,7 @@ class PlotGenerator:
             legend=False,
             edgecolor="white",
         )
-        plt.title(
-            f"{benchmark_output_type.prioritisation_type_string.capitalize()} results - mean reciprocal rank"
-        )
+        plt.title(f"{benchmark_output_type.prioritisation_type_string.capitalize()} results - mean reciprocal rank")
         self._save_fig(benchmark_output_type, 0, 1)
 
     @staticmethod
@@ -189,17 +186,13 @@ class PlotGenerator:
         plt.title(plot_customisation.rank_plot_title, loc="center", fontsize=15)
         self._save_fig(benchmark_output_type, 0, 1)
 
-    def _generate_non_cumulative_bar_plot_data(
-        self, benchmarking_results_df: pl.DataFrame
-    ) -> pl.DataFrame:
+    def _generate_non_cumulative_bar_plot_data(self, benchmarking_results_df: pl.DataFrame) -> pl.DataFrame:
         """
         Generate data in the correct format for dataframe creation for a non-cumulative bar plot,
         appending to the self.stats attribute of the class.
         """
         return self._generate_stacked_data(benchmarking_results_df).hstack(
-            self._extract_mrr_data(benchmarking_results_df).select(
-                pl.col("Percentage").alias("MRR")
-            )
+            self._extract_mrr_data(benchmarking_results_df).select(pl.col("Percentage").alias("MRR"))
         )
 
     def generate_cumulative_bar(
@@ -309,9 +302,7 @@ def generate_plots(
     This method generates summary statistics bar plots based on the provided benchmarking results and plot type.
     """
     plot_generator = PlotGenerator(benchmark_name)
-    plot_customisation_type = getattr(
-        plot_customisation, f"{benchmark_output_type.prioritisation_type_string}_plots"
-    )
+    plot_customisation_type = getattr(plot_customisation, f"{benchmark_output_type.prioritisation_type_string}_plots")
     logger.info("Generating ROC curve visualisations.")
     plot_generator.generate_roc_curve(curves, benchmark_output_type, plot_customisation_type)
     logger.info("Generating Precision-Recall curves visualisations.")
@@ -355,8 +346,7 @@ def generate_plots_from_db(db_path: Path, config: Path) -> None:
     }
     for benchmark_output_type in BenchmarkOutputTypeEnum:
         summary_table = (
-            f"{benchmark_config_file.benchmark_name}_"
-            f"{benchmark_output_type.value.prioritisation_type_string}_summary"
+            f"{benchmark_config_file.benchmark_name}_{benchmark_output_type.value.prioritisation_type_string}_summary"
         )
         curve_table = (
             f"{benchmark_config_file.benchmark_name}_"

--- a/src/pheval/analyse/generate_rank_comparisons.py
+++ b/src/pheval/analyse/generate_rank_comparisons.py
@@ -1,5 +1,4 @@
 from itertools import combinations
-from typing import List
 
 import polars as pl
 from duckdb.duckdb import DuckDBPyConnection
@@ -11,7 +10,7 @@ from pheval.utils.logger import get_logger
 
 def calculate_rank_changes(
     conn: DuckDBPyConnection,
-    run_identifiers: List[str],
+    run_identifiers: list[str],
     true_positive_cases: pl.DataFrame,
     benchmark_type: BenchmarkOutputType,
 ) -> None:

--- a/src/pheval/analyse/run_data_parser.py
+++ b/src/pheval/analyse/run_data_parser.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List, Optional
 
 import yaml
 from pydantic import BaseModel, field_validator
@@ -28,8 +27,8 @@ class RunConfig(BaseModel):
     gene_analysis: bool
     variant_analysis: bool
     disease_analysis: bool
-    threshold: Optional[float]
-    score_order: Optional[str]
+    threshold: float | None
+    score_order: str | None
 
     @field_validator("threshold", mode="before")
     @classmethod
@@ -45,9 +44,7 @@ class RunConfig(BaseModel):
     @classmethod
     def check_results_dir_exists(cls, results_dir: Path):
         if not results_dir.exists():
-            raise FileNotFoundError(
-                f"The specified results directory does not exist: {results_dir}"
-            )
+            raise FileNotFoundError(f"The specified results directory does not exist: {results_dir}")
         return results_dir
 
 
@@ -62,10 +59,10 @@ class SinglePlotCustomisation(BaseModel):
         precision_recall_title (str): The title for the precision-recall plot.
     """
 
-    plot_type: Optional[str] = "bar_cumulative"
-    rank_plot_title: Optional[str]
-    roc_curve_title: Optional[str]
-    precision_recall_title: Optional[str]
+    plot_type: str | None = "bar_cumulative"
+    rank_plot_title: str | None
+    roc_curve_title: str | None
+    precision_recall_title: str | None
 
     @field_validator("plot_type", mode="before")
     @classmethod
@@ -95,7 +92,7 @@ class Config(BaseModel):
     """
 
     benchmark_name: str
-    runs: List[RunConfig]
+    runs: list[RunConfig]
     plot_customisation: PlotCustomisation
 
 
@@ -109,7 +106,7 @@ def parse_run_config(run_config: Path) -> Config:
     """
     logger = get_logger()
     logger.info(f"Loading benchmark configuration from {run_config}")
-    with open(run_config, "r") as f:
+    with open(run_config) as f:
         config_data = yaml.safe_load(f)
     f.close()
     config = Config(**config_data)

--- a/src/pheval/cli.py
+++ b/src/pheval/cli.py
@@ -29,7 +29,7 @@ def main(ctx, verbose=1, quiet=False):
     """Main CLI method for PhEval."""
     initialise_context(ctx)
 
-    if verbose >= 2:
+    if verbose >= 2:  # noqa
         logger.setLevel(logging.DEBUG)
     elif verbose == 1:
         logger.setLevel(logging.INFO)

--- a/src/pheval/cli_pheval_utils.py
+++ b/src/pheval/cli_pheval_utils.py
@@ -1,7 +1,6 @@
 """PhEval utils Command Line Interface"""
 
 from pathlib import Path
-from typing import List
 
 import click
 
@@ -39,9 +38,7 @@ from pheval.utils.utils import semsim_scramble
     "-c",
     required=True,
     multiple=True,
-    type=click.Choice(
-        ["jaccard_similarity", "dice_similarity", "phenodigm_score"], case_sensitive=False
-    ),
+    type=click.Choice(["jaccard_similarity", "dice_similarity", "phenodigm_score"], case_sensitive=False),
     help="Score column that will be scrambled",
 )
 @click.option(
@@ -54,9 +51,7 @@ from pheval.utils.utils import semsim_scramble
     help="""Scramble Magnitude (noise)
     that will be applied to semantic similarity score column (e.g. jaccard similarity).""",
 )
-def semsim_scramble_command(
-    input: Path, output: Path, score_column: List[str], scramble_factor: float
-):
+def semsim_scramble_command(input: Path, output: Path, score_column: list[str], scramble_factor: float):
     """Scrambles semsim profile multiplying score value by scramble factor
     Args:
         input (Path): Path file that points out to the semsim profile
@@ -125,9 +120,7 @@ def scramble_phenopackets_command(
     if phenopacket_path is None and phenopacket_dir is None:
         raise InputError("Either a phenopacket or phenopacket directory must be specified")
     else:
-        scramble_phenopackets(
-            output_dir, phenopacket_path, phenopacket_dir, scramble_factor, local_ontology_cache
-        )
+        scramble_phenopackets(output_dir, phenopacket_path, phenopacket_dir, scramble_factor, local_ontology_cache)
 
 
 @click.command("semsim-comparison")
@@ -149,9 +142,7 @@ def scramble_phenopackets_command(
     "--score-column",
     "-c",
     required=True,
-    type=click.Choice(
-        ["jaccard_similarity", "dice_similarity", "phenodigm_score"], case_sensitive=False
-    ),
+    type=click.Choice(["jaccard_similarity", "dice_similarity", "phenodigm_score"], case_sensitive=False),
     help="Score column that will be used in comparison",
 )
 @click.option(
@@ -232,9 +223,7 @@ def semsim_comparison(
     help="Gene identifier to add to phenopacket",
     type=click.Choice(["ensembl_id", "entrez_id", "hgnc_id"]),
 )
-def update_phenopackets_command(
-    phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str
-):
+def update_phenopackets_command(phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path, gene_identifier: str):
     """Update gene symbols and identifiers for phenopackets."""
     if phenopacket_path is None and phenopacket_dir is None:
         raise InputError("Either a phenopacket or phenopacket directory must be specified")
@@ -313,10 +302,10 @@ def create_spiked_vcfs_command(
     phenopacket_path: Path,
     phenopacket_dir: Path,
     output_dir: Path,
-    hg19_template_vcf: Path = None,
-    hg38_template_vcf: Path = None,
-    hg19_vcf_dir: Path = None,
-    hg38_vcf_dir: Path = None,
+    hg19_template_vcf: Path | None = None,
+    hg38_template_vcf: Path | None = None,
+    hg19_vcf_dir: Path | None = None,
+    hg38_vcf_dir: Path | None = None,
 ):
     """
     Create spiked VCF from either a Phenopacket or a Phenopacket directory.
@@ -394,9 +383,7 @@ def benchmark(
     This is the path where the phenotypic database folder will be written out.""",
     type=Path,
 )
-def semsim_to_exomiserdb_command(
-    input_file: Path, object_prefix: str, subject_prefix: str, db_path: Path
-):
+def semsim_to_exomiserdb_command(input_file: Path, object_prefix: str, subject_prefix: str, db_path: Path):
     """ingests semsim file into exomiser phenotypic database
 
     Args:

--- a/src/pheval/config_parser.py
+++ b/src/pheval/config_parser.py
@@ -39,7 +39,7 @@ class InputDirConfig:
 def parse_input_dir_config(input_dir: Path) -> InputDirConfig:
     """Reads the config file."""
     logger.info(f"Parsing config.yaml located in {input_dir}.")
-    with open(Path(input_dir).joinpath("config.yaml"), "r") as config_file:
+    with open(Path(input_dir).joinpath("config.yaml")) as config_file:
         config = yaml.safe_load(config_file)
     config_file.close()
     return from_yaml(InputDirConfig, yaml.dump(config))

--- a/src/pheval/implementations/__init__.py
+++ b/src/pheval/implementations/__init__.py
@@ -15,11 +15,9 @@ def get_implementation_resolver() -> ClassResolver[PhEvalRunner]:
     Returns:
         ClassResolver[PhEvalRunner]: _description_
     """
-    implementation_resolver: PhevalClassResolver[PhEvalRunner] = (
-        PhevalClassResolver.from_subclasses(
-            PhEvalRunner,
-            suffix="Implementation",
-        )
+    implementation_resolver: PhevalClassResolver[PhEvalRunner] = PhevalClassResolver.from_subclasses(
+        PhEvalRunner,
+        suffix="Implementation",
     )
 
     # implementation_resolver.synonyms.update(

--- a/src/pheval/infra/exomiserdb.py
+++ b/src/pheval/infra/exomiserdb.py
@@ -12,9 +12,7 @@ info_debug = log.getLogger("debug")
 
 
 class DBConnector:
-    def __init__(
-        self, jar: Path, driver: str, server: str, database: str, user: str, password: str
-    ):
+    def __init__(self, jar: Path, driver: str, server: str, database: str, user: str, password: str):
         self.jar = jar
         self.driver = driver
         self.server = server
@@ -63,7 +61,7 @@ class DBConnection:
 class ExomiserDB:
     def __init__(self, db_path: Path):
         try:
-            self.connector = DBConnector(  # noqa
+            self.connector = DBConnector(
                 jar=os.path.join(os.path.dirname(__file__), "../../../lib/h2-1.4.199.jar"),
                 driver="org.h2.Driver",
                 server=f"jdbc:h2:{db_path}",
@@ -89,7 +87,7 @@ class ExomiserDB:
             batches = reader.next_batches(batch_length)
             cursor = conn.get_cursor()
             # # TODO: Refactor this
-            with open(input_file, "r") as f:
+            with open(input_file) as f:
                 total = sum(1 for line in f)
             pbar = tqdm(total=total - 1)
             mapping_id = 1
@@ -112,12 +110,10 @@ def _format_row(mapping_id, data):
         data (_type_): row data
     """
     # TODO:Improve string escaping. Replace this code with parametrised query
-    return f"""({mapping_id}, '{data['subject_id']}', '{data['subject_label'].replace("'", "")}', '{data['object_id']}', '{data['object_label'].replace("'", "")}', {data['jaccard_similarity']}, {data['ancestor_information_content']}, {data['phenodigm_score']}, '{data['ancestor_id'].split(",")[0]}', '{data['ancestor_label'].replace("'", "")}')"""  # noqa
+    return f"""({mapping_id}, '{data["subject_id"]}', '{data["subject_label"].replace("'", "")}', '{data["object_id"]}', '{data["object_label"].replace("'", "")}', {data["jaccard_similarity"]}, {data["ancestor_information_content"]}, {data["phenodigm_score"]}, '{data["ancestor_id"].split(",")[0]}', '{data["ancestor_label"].replace("'", "")}')"""  # noqa
 
 
-def _semsim2h2(
-    input_data: pl.DataFrame, subject_prefix: str, object_prefix: str, mapping_id=1
-) -> None:
+def _semsim2h2(input_data: pl.DataFrame, subject_prefix: str, object_prefix: str, mapping_id=1) -> None:
     """This function is responsible for generate sql insertion query for each semsim profile row
 
     Args:
@@ -130,12 +126,8 @@ def _semsim2h2(
     if mapping_id == 1:
         sql += f"TRUNCATE TABLE EXOMISER.{subject_prefix}_{object_prefix}_MAPPINGS;\n"
 
-    object_id = (
-        f"{object_prefix}_ID_HIT" if subject_prefix == object_prefix else f"{object_prefix}_ID"
-    )
-    object_term = (
-        f"{object_prefix}_HIT_TERM" if subject_prefix == object_prefix else f"{object_prefix}_TERM"
-    )
+    object_id = f"{object_prefix}_ID_HIT" if subject_prefix == object_prefix else f"{object_prefix}_ID"
+    object_term = f"{object_prefix}_HIT_TERM" if subject_prefix == object_prefix else f"{object_prefix}_TERM"
     sql += f"""INSERT INTO EXOMISER.{subject_prefix}_{object_prefix}_MAPPINGS
 (MAPPING_ID, {subject_prefix}_ID, {subject_prefix}_TERM, {object_id}, {object_term}, SIMJ, IC, SCORE, LCS_ID, LCS_TERM)
 VALUES"""

--- a/src/pheval/post_processing/post_processing.py
+++ b/src/pheval/post_processing/post_processing.py
@@ -1,6 +1,6 @@
+from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Tuple
 
 import polars as pl
 
@@ -57,7 +57,7 @@ def _rank_results(results: pl.DataFrame, sort_order: SortOrder) -> pl.DataFrame:
         results = (
             results.sort("score", descending=sort_descending)
             .with_columns(
-                pl.struct(["score"] + group_by)
+                pl.struct(["score"] + group_by)  # noqa
                 .rank(method="dense", descending=sort_descending)
                 .cast(pl.Int32)
                 .alias("min_rank")
@@ -89,9 +89,7 @@ def _write_gene_result(ranked_results: pl.DataFrame, output_file: Path) -> None:
         ranked_results ([PhEvalResult]): List of ranked PhEval gene results.
         output_file (Path): Path to the output file.
     """
-    gene_output = ranked_results.select(
-        ["rank", "score", "gene_symbol", "gene_identifier", "true_positive"]
-    )
+    gene_output = ranked_results.select(["rank", "score", "gene_symbol", "gene_identifier", "true_positive"])
     _write_results_file(output_file, gene_output)
 
 
@@ -127,15 +125,11 @@ def _write_disease_result(ranked_results: pl.DataFrame, output_file: Path) -> No
         ranked_results ([PhEvalResult]): List of ranked PhEval disease results.
         output_file (Path): Path to the output file.
     """
-    disease_output = ranked_results.select(
-        ["rank", "score", "disease_identifier", "mondo_identifier", "true_positive"]
-    )
+    disease_output = ranked_results.select(["rank", "score", "disease_identifier", "mondo_identifier", "true_positive"])
     _write_results_file(output_file, disease_output)
 
 
-def _get_result_type(
-    result_type: ResultType, phenopacket_truth_set: PhenopacketTruthSet
-) -> Tuple[Callable, Callable]:
+def _get_result_type(result_type: ResultType, phenopacket_truth_set: PhenopacketTruthSet) -> tuple[Callable, Callable]:
     """
     Get the methods for extracting the entity and writing the result for a given result type.
     Args:
@@ -156,9 +150,7 @@ def _get_result_type(
             )
 
 
-def create_empty_pheval_result(
-    phenopacket_dir: Path, output_dir: Path, result_type: ResultType
-) -> None:
+def create_empty_pheval_result(phenopacket_dir: Path, output_dir: Path, result_type: ResultType) -> None:
     """
     Create an empty PhEval result for a given result type (gene, variant, or disease).
 
@@ -176,10 +168,7 @@ def create_empty_pheval_result(
     """
     if result_type in executed_results:
         return
-    logger.info(
-        f"Writing classified results for {len(all_files(phenopacket_dir))} "
-        f"phenopackets to {output_dir}"
-    )
+    logger.info(f"Writing classified results for {len(all_files(phenopacket_dir))} phenopackets to {output_dir}")
     executed_results.add(result_type)
     phenopacket_truth_set = PhenopacketTruthSet(phenopacket_dir)
     classify_method, write_method = _get_result_type(result_type, phenopacket_truth_set)
@@ -209,13 +198,9 @@ def generate_gene_result(
         phenopacket_dir (Path): Path to the Phenopacket directory
     """
     output_file = output_dir.joinpath(f"pheval_gene_results/{result_path.stem}-gene_result.parquet")
-    create_empty_pheval_result(
-        phenopacket_dir, output_dir.joinpath("pheval_gene_results"), ResultType.GENE
-    )
+    create_empty_pheval_result(phenopacket_dir, output_dir.joinpath("pheval_gene_results"), ResultType.GENE)
     ranked_results = _rank_results(results, sort_order)
-    classified_results = PhenopacketTruthSet(phenopacket_dir).merge_gene_results(
-        ranked_results, output_file
-    )
+    classified_results = PhenopacketTruthSet(phenopacket_dir).merge_gene_results(ranked_results, output_file)
     _write_gene_result(classified_results, output_file)
 
 
@@ -236,9 +221,7 @@ def generate_variant_result(
         result_path (Path): Path to the tool-specific result file.
         phenopacket_dir (Path): Path to the Phenopacket directory
     """
-    output_file = output_dir.joinpath(
-        f"pheval_variant_results/{result_path.stem}-variant_result.parquet"
-    )
+    output_file = output_dir.joinpath(f"pheval_variant_results/{result_path.stem}-variant_result.parquet")
     create_empty_pheval_result(
         phenopacket_dir,
         output_dir.joinpath("pheval_variant_results"),
@@ -247,9 +230,7 @@ def generate_variant_result(
     ranked_results = _rank_results(results, sort_order).with_columns(
         pl.concat_str(["chrom", "start", "ref", "alt"], separator="-").alias("variant_id")
     )
-    classified_results = PhenopacketTruthSet(phenopacket_dir).merge_variant_results(
-        ranked_results, output_file
-    )
+    classified_results = PhenopacketTruthSet(phenopacket_dir).merge_variant_results(ranked_results, output_file)
     _write_variant_result(classified_results, output_file)
 
 
@@ -270,9 +251,7 @@ def generate_disease_result(
         result_path (Path): Path to the tool-specific result file.
         phenopacket_dir (Path): Path to the Phenopacket directory
     """
-    output_file = output_dir.joinpath(
-        f"pheval_disease_results/{result_path.stem}-disease_result.parquet"
-    )
+    output_file = output_dir.joinpath(f"pheval_disease_results/{result_path.stem}-disease_result.parquet")
     create_empty_pheval_result(
         phenopacket_dir,
         output_dir.joinpath("pheval_disease_results"),

--- a/src/pheval/post_processing/validate_result_format.py
+++ b/src/pheval/post_processing/validate_result_format.py
@@ -1,6 +1,6 @@
+from collections.abc import Callable
 from enum import Enum
 from functools import wraps
-from typing import Callable
 
 import polars as pl
 
@@ -63,9 +63,7 @@ class ResultSchema(Enum):
                 raise ValueError(f"Missing required column: {col_name}")
 
             if results.schema[col_name] != expected_type:
-                raise TypeError(
-                    f"Column '{col_name}' has type {results.schema[col_name]}, expected {expected_type}"
-                )
+                raise TypeError(f"Column '{col_name}' has type {results.schema[col_name]}, expected {expected_type}")
 
         return True
 

--- a/src/pheval/prepare/custom_exceptions.py
+++ b/src/pheval/prepare/custom_exceptions.py
@@ -21,19 +21,18 @@ class MutuallyExclusiveOptionError(Option):
         help_ = kwargs.get("help", "")
         if self.mutually_exclusive:
             ex_str = ", ".join(self.mutually_exclusive)
-            kwargs["help"] = help_ + (
-                " NOTE: This argument is mutually exclusive with " " arguments: [" + ex_str + "]."
-            )
-        super(MutuallyExclusiveOptionError, self).__init__(*args, **kwargs)
+            kwargs["help"] = help_ + (" NOTE: This argument is mutually exclusive with  arguments: [" + ex_str + "].")
+        super().__init__(*args, **kwargs)
 
     def handle_parse_result(self, ctx, opts, args):
         if self.mutually_exclusive.intersection(opts) and self.name in opts:
             raise UsageError(
-                "Illegal usage: `{}` is mutually exclusive with "
-                "arguments `{}`.".format(self.name, ", ".join(self.mutually_exclusive))
+                "Illegal usage: `{}` is mutually exclusive with arguments `{}`.".format(
+                    self.name, ", ".join(self.mutually_exclusive)
+                )
             )
 
-        return super(MutuallyExclusiveOptionError, self).handle_parse_result(ctx, opts, args)
+        return super().handle_parse_result(ctx, opts, args)
 
 
 class IncorrectFileFormatError(Exception):

--- a/src/pheval/prepare/prepare_corpus.py
+++ b/src/pheval/prepare/prepare_corpus.py
@@ -56,15 +56,11 @@ def prepare_corpus(
     for phenopacket_path in all_files(phenopacket_dir):
         phenopacket_util = PhenopacketUtil(phenopacket_reader(phenopacket_path))
         if not phenopacket_util.observed_phenotypic_features():
-            logger.warning(
-                f"Removed {phenopacket_path.name} from the corpus due to no observed phenotypic features."
-            )
+            logger.warning(f"Removed {phenopacket_path.name} from the corpus due to no observed phenotypic features.")
             continue
         if variant_analysis:
             if phenopacket_util.check_incomplete_variant_record():
-                logger.warning(
-                    f"Removed {phenopacket_path.name} from the corpus due to missing variant fields."
-                )
+                logger.warning(f"Removed {phenopacket_path.name} from the corpus due to missing variant fields.")
                 continue
             elif phenopacket_util.check_variant_alleles():
                 logger.warning(
@@ -73,15 +69,11 @@ def prepare_corpus(
                 )
         if gene_analysis:
             if phenopacket_util.check_incomplete_gene_record():
-                logger.warning(
-                    f"Removed {phenopacket_path.name} from the corpus due to missing gene fields."
-                )
+                logger.warning(f"Removed {phenopacket_path.name} from the corpus due to missing gene fields.")
                 continue
         if disease_analysis:
             if phenopacket_util.check_incomplete_disease_record():
-                logger.warning(
-                    f"Removed {phenopacket_path.name} from the corpus due to missing disease fields."
-                )
+                logger.warning(f"Removed {phenopacket_path.name} from the corpus due to missing disease fields.")
                 continue
         logger.info(f"{phenopacket_path.name} OK!")
         if hg19_template_vcf or hg38_template_vcf:
@@ -107,13 +99,10 @@ def prepare_corpus(
         else:
             # if not updating phenopacket gene identifiers then copy phenopacket as is to output directory
             (
-                shutil.copy(
-                    phenopacket_path, output_dir.joinpath(f"phenopackets/{phenopacket_path.name}")
-                )
+                shutil.copy(phenopacket_path, output_dir.joinpath(f"phenopackets/{phenopacket_path.name}"))
                 if phenopacket_path != output_dir.joinpath(f"phenopackets/{phenopacket_path.name}")
                 else None
             )
     logger.info(
-        f"Finished preparing corpus for {phenopacket_dir}. "
-        f"Total time: {time.perf_counter() - start_time:.2f} seconds."
+        f"Finished preparing corpus for {phenopacket_dir}. Total time: {time.perf_counter() - start_time:.2f} seconds."
     )

--- a/src/pheval/prepare/update_phenopacket.py
+++ b/src/pheval/prepare/update_phenopacket.py
@@ -1,6 +1,5 @@
 import time
 from pathlib import Path
-from typing import Union
 
 import polars as pl
 from phenopackets import Family, Phenopacket
@@ -21,7 +20,7 @@ logger = get_logger()
 
 def update_outdated_gene_context(
     phenopacket_path: Path, gene_identifier: str, identifier_map: pl.DataFrame
-) -> Union[Phenopacket, Family]:
+) -> Phenopacket | Family:
     """
     Update the gene context of the Phenopacket.
 
@@ -66,15 +65,11 @@ def create_updated_phenopacket(
         to describe the gene identifiers.
     """
     identifier_map = create_gene_identifier_map() if identifier_map is None else identifier_map
-    updated_phenopacket = update_outdated_gene_context(
-        phenopacket_path, gene_identifier, identifier_map
-    )
+    updated_phenopacket = update_outdated_gene_context(phenopacket_path, gene_identifier, identifier_map)
     write_phenopacket(updated_phenopacket, output_dir.joinpath(phenopacket_path.name))
 
 
-def create_updated_phenopackets(
-    gene_identifier: str, phenopacket_dir: Path, output_dir: Path
-) -> None:
+def create_updated_phenopackets(gene_identifier: str, phenopacket_dir: Path, output_dir: Path) -> None:
     """
     Update the gene context within the interpretations for a directory of Phenopackets
     and writes the updated Phenopackets.
@@ -91,15 +86,11 @@ def create_updated_phenopackets(
     identifier_map = create_gene_identifier_map()
     for phenopacket_path in all_files(phenopacket_dir):
         logger.info(f"Updating gene context for: {phenopacket_path.name}")
-        updated_phenopacket = update_outdated_gene_context(
-            phenopacket_path, gene_identifier, identifier_map
-        )
+        updated_phenopacket = update_outdated_gene_context(phenopacket_path, gene_identifier, identifier_map)
         write_phenopacket(updated_phenopacket, output_dir.joinpath(phenopacket_path.name))
 
 
-def update_phenopackets(
-    gene_identifier: str, phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path
-) -> None:
+def update_phenopackets(gene_identifier: str, phenopacket_path: Path, phenopacket_dir: Path, output_dir: Path) -> None:
     """
     Update the gene identifiers in either a single phenopacket or a directory of phenopackets.
 
@@ -122,8 +113,6 @@ def update_phenopackets(
         logger.info(f"Updating {phenopacket_path}.")
         create_updated_phenopacket(gene_identifier, phenopacket_path, output_dir)
     elif phenopacket_dir is not None:
-        logger.info(
-            f"Updating {len(all_files(phenopacket_dir))} phenopackets in {phenopacket_dir}."
-        )
+        logger.info(f"Updating {len(all_files(phenopacket_dir))} phenopackets in {phenopacket_dir}.")
         create_updated_phenopackets(gene_identifier, phenopacket_dir, output_dir)
     logger.info(f"Updating finished! Total time: {time.perf_counter() - start_time:.2f} seconds.")

--- a/src/pheval/utils/docs_gen.py
+++ b/src/pheval/utils/docs_gen.py
@@ -13,7 +13,7 @@ def find_methods_in_python_file(file_path):
         file_path ([type]): [description]
     """
     methods = []
-    with open(file_path, "r", encoding="utf-8") as file:
+    with open(file_path, encoding="utf-8") as file:
         text = file.read()
         parsed = ast.parse(text)
         for node in ast.walk(parsed):
@@ -73,8 +73,8 @@ def print_cli_doc(file_item):
     for method in methods:
         content = f"""
 ::: mkdocs-click
-    :package: {file_item['folder'].replace("./", '').replace('/', '.')}.{file_item['basename']}
-    :module: {file_item['folder'].replace("./", '').replace('/', '.').replace('src.', '')}.{file_item['basename']}
+    :package: {file_item["folder"].replace("./", "").replace("/", ".")}.{file_item["basename"]}
+    :module: {file_item["folder"].replace("./", "").replace("/", ".").replace("src.", "")}.{file_item["basename"]}
     :command: {method}
     :depth: 4
     :style: table

--- a/src/pheval/utils/file_utils.py
+++ b/src/pheval/utils/file_utils.py
@@ -3,7 +3,6 @@ import re
 import unicodedata
 from os import path
 from pathlib import Path
-from typing import List
 
 import pandas as pd
 import yaml
@@ -80,7 +79,7 @@ def ensure_file_exists(*files: str):
             raise FileNotFoundError(f"File {file} not found")
 
 
-def ensure_columns_exists(cols: list, dataframes: List[pd.DataFrame], err_message: str = ""):
+def ensure_columns_exists(cols: list, dataframes: list[pd.DataFrame], err_message: str = ""):
     """Ensures the columns exist in dataframes passed as argument (e.g)
 
     "

--- a/src/pheval/utils/semsim_utils.py
+++ b/src/pheval/utils/semsim_utils.py
@@ -8,7 +8,7 @@ import numpy
 import pandas as pd
 import plotly.express as px
 
-import pheval.utils.file_utils as file_utils
+from pheval.utils import file_utils
 
 
 def filter_non_0_score(data: pd.DataFrame, col: str) -> pd.DataFrame:
@@ -58,9 +58,7 @@ def diff_semsim(
     if absolute_diff:
         df["diff"] = df[f"{score_column}_x"] - df[f"{score_column}_y"]
         return df[["subject_id", "object_id", "diff"]]
-    df["diff"] = df.apply(
-        lambda row: get_percentage_diff(row[f"{score_column}_x"], row[f"{score_column}_y"]), axis=1
-    )
+    df["diff"] = df.apply(lambda row: get_percentage_diff(row[f"{score_column}_x"], row[f"{score_column}_y"]), axis=1)
     return df[["subject_id", "object_id", f"{score_column}_x", f"{score_column}_y", "diff"]]
 
 
@@ -91,9 +89,7 @@ def semsim_heatmap_plot(semsim_left: Path, semsim_right: Path, score_column: str
     fig.show()
 
 
-def semsim_analysis(
-    semsim_left: Path, semsim_right: Path, score_column: str, absolute_diff=True
-) -> pd.DataFrame:
+def semsim_analysis(semsim_left: Path, semsim_right: Path, score_column: str, absolute_diff=True) -> pd.DataFrame:
     """semsim_analysis
 
     Args:
@@ -147,11 +143,11 @@ def get_percentage_diff(current_number: float, previous_number: float) -> float:
     """
     try:
         if current_number == previous_number:
-            return "{:.2%}".format(0)
+            return f"{0:.2%}"
         if current_number > previous_number:
-            number = (1 - ((current_number / previous_number))) * 100
+            number = (1 - (current_number / previous_number)) * 100
         else:
             number = (100 - ((previous_number / current_number) * 100)) * -1
-        return "{:.2%}".format(number / 100)
+        return f"{number / 100:.2%}"
     except ZeroDivisionError:
         return None

--- a/src/pheval/utils/utils.py
+++ b/src/pheval/utils/utils.py
@@ -4,7 +4,6 @@ import json
 import random
 from datetime import datetime
 from pathlib import Path
-from typing import List
 
 import pandas as pd
 import requests
@@ -42,7 +41,7 @@ def rand(df: pd.DataFrame, min_num: int, max_num: int, scramble_factor: float) -
 def semsim_scramble(
     input: Path,
     output: Path,
-    columns_to_be_scrambled: List[str],
+    columns_to_be_scrambled: list[str],
     scramble_factor: float = 0.5,
 ) -> pd.DataFrame:
     """
@@ -66,7 +65,7 @@ def semsim_scramble(
 
 def semsim_scramble_df(
     dataframe: pd.DataFrame,
-    columns_to_be_scrambled: List[str],
+    columns_to_be_scrambled: list[str],
     scramble_factor: float,
 ) -> pd.DataFrame:
     """scramble_semsim_df
@@ -136,6 +135,6 @@ def get_resource_timestamp(file_name: str) -> str | None:
         file_name (str): The file name.
     """
     if METADATA_PATH.exists():
-        with open(METADATA_PATH, "r") as f:
+        with open(METADATA_PATH) as f:
             return json.load(f).get(file_name)
     return None

--- a/tests/test_binary_classification_curves.py
+++ b/tests/test_binary_classification_curves.py
@@ -24,9 +24,7 @@ class TestBinaryClassificationCurves(unittest.TestCase):
     def test_clean_and_extract_data(self):
         """Test that scores are properly cleaned and NaNs/Inf are replaced."""
         max_finite, min_finite = BinaryClassificationCurves._compute_finite_bounds(self.test_data)
-        cleaned = BinaryClassificationCurves._clean_and_extract_data(
-            self.test_data, max_finite, min_finite
-        ).collect()
+        cleaned = BinaryClassificationCurves._clean_and_extract_data(self.test_data, max_finite, min_finite).collect()
 
         expected_cleaned_scores = [0.5, 0.0, 0.8, 0.8, 0.3, 0.3]
         expected_true_positive = [1, 0, 1, 1, 0, 0]
@@ -39,9 +37,7 @@ class TestBinaryClassificationCurves(unittest.TestCase):
         labels = np.array([1, 0, 1, 1, 0])
         scores = np.array([0.9, 0.1, 0.8, 0.4, 0.2])
 
-        curves = BinaryClassificationCurves._compute_roc_pr_curves(
-            "test_run", labels, scores
-        ).collect()
+        curves = BinaryClassificationCurves._compute_roc_pr_curves("test_run", labels, scores).collect()
         self.assertTrue(
             curves.equals(
                 pl.DataFrame(

--- a/tests/test_binary_classification_stats.py
+++ b/tests/test_binary_classification_stats.py
@@ -34,24 +34,22 @@ class TestBinaryClassificationStats(unittest.TestCase):
             ]
         )
         self.assertTrue(
-            (
-                result.equals(
-                    pl.DataFrame(
-                        [
-                            {
-                                "sensitivity": 0.75,
-                                "specificity": 0.6666666666666666,
-                                "precision": 0.6,
-                                "negative_predictive_value": 0.8,
-                                "false_positive_rate": 0.3333333333333333,
-                                "false_discovery_rate": 0.4,
-                                "false_negative_rate": 0.25,
-                                "accuracy": 0.7,
-                                "f1_score": 0.6666666666666666,
-                                "matthews_correlation_coefficient": 0.408248290463863,
-                            }
-                        ]
-                    )
+            result.equals(
+                pl.DataFrame(
+                    [
+                        {
+                            "sensitivity": 0.75,
+                            "specificity": 0.6666666666666666,
+                            "precision": 0.6,
+                            "negative_predictive_value": 0.8,
+                            "false_positive_rate": 0.3333333333333333,
+                            "false_discovery_rate": 0.4,
+                            "false_negative_rate": 0.25,
+                            "accuracy": 0.7,
+                            "f1_score": 0.6666666666666666,
+                            "matthews_correlation_coefficient": 0.408248290463863,
+                        }
+                    ]
                 )
             )
         )

--- a/tests/test_create_noisy_phenopackets.py
+++ b/tests/test_create_noisy_phenopackets.py
@@ -8,9 +8,7 @@ from pheval.prepare.create_noisy_phenopackets import HpoRandomiser, load_ontolog
 
 test_phenopacket = os.path.abspath("tests/input_dir/test_phenopacket_1.json")
 
-phenotypic_features_single_term = [
-    PhenotypicFeature(type=OntologyClass(id="HP:0000965", label="Cutis marmorata"))
-]
+phenotypic_features_single_term = [PhenotypicFeature(type=OntologyClass(id="HP:0000965", label="Cutis marmorata"))]
 phenotypic_features = [
     PhenotypicFeature(type=OntologyClass(id="HP:0000256", label="Macrocephaly")),
     PhenotypicFeature(type=OntologyClass(id="HP:0002059", label="Cerebral atrophy")),
@@ -25,9 +23,7 @@ many_phenotypic_features = [
     PhenotypicFeature(type=OntologyClass(id="HP:0003150", label="Glutaric aciduria")),
     PhenotypicFeature(type=OntologyClass(id="HP:0001332", label="Dystonia")),
     PhenotypicFeature(type=OntologyClass(id="HP:0000965", label="Cutis marmorata")),
-    PhenotypicFeature(
-        type=OntologyClass(id="HP:0007843", label="Attenuation of retinal blood vessels")
-    ),
+    PhenotypicFeature(type=OntologyClass(id="HP:0007843", label="Attenuation of retinal blood vessels")),
     PhenotypicFeature(type=OntologyClass(id="HP:0001513", label="Obesity")),
     PhenotypicFeature(type=OntologyClass(id="HP:0000608", label="Macular degeneration")),
     PhenotypicFeature(type=OntologyClass(id="HP:0000486", label="Strabismus")),
@@ -51,39 +47,21 @@ class TestHpoRandomiser(unittest.TestCase):
 
     def test_scramble_factor_proportions_default(self):
         self.assertEqual(
-            self.hpo_randomiser_default.scramble_factor_proportions(
-                phenotypic_features_single_term
-            ),
+            self.hpo_randomiser_default.scramble_factor_proportions(phenotypic_features_single_term),
             1,
         )
-        self.assertEqual(
-            self.hpo_randomiser_default.scramble_factor_proportions(phenotypic_features), 2
-        )
-        self.assertEqual(
-            self.hpo_randomiser_default.scramble_factor_proportions(many_phenotypic_features), 5
-        )
+        self.assertEqual(self.hpo_randomiser_default.scramble_factor_proportions(phenotypic_features), 2)
+        self.assertEqual(self.hpo_randomiser_default.scramble_factor_proportions(many_phenotypic_features), 5)
 
     def test_scramble_factor_0_25(self):
-        self.assertEqual(
-            self.hpo_randomiser_0_25.scramble_factor_proportions(phenotypic_features_single_term), 1
-        )
-        self.assertEqual(
-            self.hpo_randomiser_0_25.scramble_factor_proportions(phenotypic_features), 1
-        )
-        self.assertEqual(
-            self.hpo_randomiser_0_25.scramble_factor_proportions(many_phenotypic_features), 2
-        )
+        self.assertEqual(self.hpo_randomiser_0_25.scramble_factor_proportions(phenotypic_features_single_term), 1)
+        self.assertEqual(self.hpo_randomiser_0_25.scramble_factor_proportions(phenotypic_features), 1)
+        self.assertEqual(self.hpo_randomiser_0_25.scramble_factor_proportions(many_phenotypic_features), 2)
 
     def test_scramble_factor_0_75(self):
-        self.assertEqual(
-            self.hpo_randomiser_0_75.scramble_factor_proportions(phenotypic_features_single_term), 1
-        )
-        self.assertEqual(
-            self.hpo_randomiser_0_75.scramble_factor_proportions(phenotypic_features), 4
-        )
-        self.assertEqual(
-            self.hpo_randomiser_0_75.scramble_factor_proportions(many_phenotypic_features), 8
-        )
+        self.assertEqual(self.hpo_randomiser_0_75.scramble_factor_proportions(phenotypic_features_single_term), 1)
+        self.assertEqual(self.hpo_randomiser_0_75.scramble_factor_proportions(phenotypic_features), 4)
+        self.assertEqual(self.hpo_randomiser_0_75.scramble_factor_proportions(many_phenotypic_features), 8)
 
     def test_retrieve_hpo_term(self):
         self.assertEqual(
@@ -97,11 +75,7 @@ class TestHpoRandomiser(unittest.TestCase):
             3,
         )
         self.assertEqual(
-            len(
-                self.hpo_randomiser_default.retain_real_patient_terms(
-                    phenotypic_features_single_term, 2
-                )
-            ),
+            len(self.hpo_randomiser_default.retain_real_patient_terms(phenotypic_features_single_term, 2)),
             1,
         )
 
@@ -121,9 +95,7 @@ class TestHpoRandomiser(unittest.TestCase):
             len(
                 self.hpo_randomiser_default.convert_patient_terms_to_parent(
                     phenotypic_features_single_term,
-                    self.hpo_randomiser_default.retain_real_patient_terms(
-                        phenotypic_features_single_term, 1
-                    ),
+                    self.hpo_randomiser_default.retain_real_patient_terms(phenotypic_features_single_term, 1),
                     1,
                 )
             ),

--- a/tests/test_create_spiked_vcf.py
+++ b/tests/test_create_spiked_vcf.py
@@ -141,7 +141,7 @@ class TestReadVcf(unittest.TestCase):
 
     def test_read_vcf_gzipped(self):
         for line in read_vcf(self.gzipped_vcf_file):
-            self.assertFalse(isinstance(line, (bytes, bytearray)))
+            self.assertFalse(isinstance(line, (bytes | bytearray)))
 
 
 class TestVcfHeaderParser(unittest.TestCase):
@@ -201,23 +201,17 @@ class TestCheckVariantAssembly(unittest.TestCase):
 
     def test_check_variant_assembly(self):
         self.assertEqual(
-            check_variant_assembly(
-                self.causative_variants, self.vcf_header_compatible, Path("/path/to/phenopacket")
-            ),
+            check_variant_assembly(self.causative_variants, self.vcf_header_compatible, Path("/path/to/phenopacket")),
             None,
         )
 
     def test_check_variant_assembly_phenopacket_assemblies(self):
         with self.assertRaises(ValueError):
-            check_variant_assembly(
-                self.multiple_assemblies, self.vcf_header_compatible, Path("/path/to/phenopacket")
-            )
+            check_variant_assembly(self.multiple_assemblies, self.vcf_header_compatible, Path("/path/to/phenopacket"))
 
     def test_check_variant_assembly_incompatible_vcf(self):
         with self.assertRaises(IncompatibleGenomeAssemblyError):
-            check_variant_assembly(
-                self.causative_variants, self.vcf_header_incompatible, Path("/path/to/phenopacket")
-            )
+            check_variant_assembly(self.causative_variants, self.vcf_header_incompatible, Path("/path/to/phenopacket"))
 
     def test_check_variant_assembly_incorrect_variant_assembly(self):
         with self.assertRaises(IncompatibleGenomeAssemblyError):
@@ -337,18 +331,18 @@ class TestVcfSpiker(unittest.TestCase):
     def test_construct_vcf_records_single_variant(self):
         self.assertEqual(
             self.vcf_spiker.construct_vcf_records("template.vcf")[40],
-            "chr1\t886190\t.\tG\tA\t100\tPASS\t.\t" "GT\t0/1\n",
+            "chr1\t886190\t.\tG\tA\t100\tPASS\t.\tGT\t0/1\n",
         )
 
     def test_construct_vcf_records_multiple_variants(self):
         updated_records = self.vcf_spiker_multiple_variants.construct_vcf_records("template.vcf")
         self.assertEqual(
             updated_records[40],
-            "chr1\t886190\t.\tG\tA\t100\tPASS\t.\t" "GT\t0/1\n",
+            "chr1\t886190\t.\tG\tA\t100\tPASS\t.\tGT\t0/1\n",
         )
         self.assertEqual(
             updated_records[45],
-            "chr3\t61580860\t.\tG\tA\t100\tPASS\t.\t" "GT\t1/1\n",
+            "chr3\t61580860\t.\tG\tA\t100\tPASS\t.\tGT\t1/1\n",
         )
 
     def test_construct_vcf_records_new_variant_pos(self):
@@ -360,10 +354,6 @@ class TestVcfSpiker(unittest.TestCase):
 
     def test_construct_header(self):
         self.assertEqual(
-            [
-                line
-                for line in self.vcf_spiker.construct_header(hg19_vcf)
-                if line.startswith("#CHROM")
-            ],
+            [line for line in self.vcf_spiker.construct_header(hg19_vcf) if line.startswith("#CHROM")],
             ["#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tTEST1\n"],
         )

--- a/tests/test_exomiser_db_ingestion.py
+++ b/tests/test_exomiser_db_ingestion.py
@@ -53,15 +53,15 @@ class TestExomiserDBIngestion(unittest.TestCase):
             "ancestor_id": "ancestor1,ancestor2",
             "ancestor_label": "ancestor_label1",
         }
-        expected_output = "(1, 'subject1', 'label1', 'object1', 'label2', 0.5, 0.6, 0.7, 'ancestor1', 'ancestor_label1')"  # noqa
+        expected_output = (
+            "(1, 'subject1', 'label1', 'object1', 'label2', 0.5, 0.6, 0.7, 'ancestor1', 'ancestor_label1')"
+        )
         self.assertEqual(_format_row(mapping_id, data), expected_output)
 
 
 def _set_bkp_db():
     """copy an empty database to be populated in each test"""
-    shutil.copyfile(
-        f"{PHENO_FOLDER}/2302_phenotype_test.mv.db.bkp", f"{PHENO_FOLDER}/2302_phenotype_test.mv.db"
-    )
+    shutil.copyfile(f"{PHENO_FOLDER}/2302_phenotype_test.mv.db.bkp", f"{PHENO_FOLDER}/2302_phenotype_test.mv.db")
     shutil.copyfile(
         f"{PHENO_FOLDER}/2302_phenotype_test.trace.db.bkp",
         f"{PHENO_FOLDER}/2302_phenotype_test.trace.db",

--- a/tests/test_generate_plots.py
+++ b/tests/test_generate_plots.py
@@ -95,9 +95,7 @@ class TestPlotGenerator(unittest.TestCase):
 
     def test__generate_cumulative_bar_plot_data(self):
         self.assertTrue(
-            self.plot_generator._generate_cumulative_bar_plot_data(
-                self.benchmarking_results_df
-            ).equals(
+            self.plot_generator._generate_cumulative_bar_plot_data(self.benchmarking_results_df).equals(
                 pl.DataFrame(
                     [
                         {
@@ -125,9 +123,7 @@ class TestPlotGenerator(unittest.TestCase):
 
     def test__generate_non_cumulative_bar_plot_data(self):
         self.assertTrue(
-            self.plot_generator._generate_non_cumulative_bar_plot_data(
-                self.benchmarking_results_df
-            ).equals(
+            self.plot_generator._generate_non_cumulative_bar_plot_data(self.benchmarking_results_df).equals(
                 pl.DataFrame(
                     [
                         {
@@ -158,9 +154,7 @@ class TestPlotGenerator(unittest.TestCase):
     def test__extract_mrr_data(self):
         self.assertTrue(
             self.plot_generator._extract_mrr_data(self.benchmarking_results_df).equals(
-                pl.DataFrame(
-                    [{"Run": "Run1", "Percentage": 0.8}, {"Run": "Run2", "Percentage": 0.85}]
-                )
+                pl.DataFrame([{"Run": "Run1", "Percentage": 0.8}, {"Run": "Run2", "Percentage": 0.85}])
             )
         )
 

--- a/tests/test_generate_rank_comparisons.py
+++ b/tests/test_generate_rank_comparisons.py
@@ -9,7 +9,6 @@ from pheval.analyse.generate_rank_comparisons import calculate_rank_changes
 
 
 class TestCalculateRankChanges(unittest.TestCase):
-
     def setUp(self):
         self.mock_conn = MagicMock(spec=DuckDBPyConnection)
 

--- a/tests/test_phenopacket_truth_set.py
+++ b/tests/test_phenopacket_truth_set.py
@@ -136,9 +136,7 @@ class TestPhenopacketTruthSet(unittest.TestCase):
     def test_merge_gene_results(self, mock_read_parquet):
         mock_read_parquet.return_value = self.mock_gene_classified_results
         self.assertTrue(
-            self.phenopacket_truth_set.merge_gene_results(
-                self.mock_gene_ranked_results, "output_file"
-            )
+            self.phenopacket_truth_set.merge_gene_results(self.mock_gene_ranked_results, "output_file")
             .sort("gene_identifier")
             .equals(
                 pl.DataFrame(
@@ -180,9 +178,7 @@ class TestPhenopacketTruthSet(unittest.TestCase):
     def test_merge_variant_results(self, mock_read_parquet):
         mock_read_parquet.return_value = self.mock_variant_classified_results
         self.assertTrue(
-            self.phenopacket_truth_set.merge_variant_results(
-                self.mock_variant_ranked_results, "output_file"
-            )
+            self.phenopacket_truth_set.merge_variant_results(self.mock_variant_ranked_results, "output_file")
             .sort("chrom")
             .equals(
                 pl.DataFrame(

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -79,9 +79,7 @@ interpretations = [
                                 ref="G",
                                 alt="A",
                             ),
-                            allelic_state=OntologyClass(
-                                id="GENO:0000402", label="compound heterozygous"
-                            ),
+                            allelic_state=OntologyClass(id="GENO:0000402", label="compound heterozygous"),
                         ),
                     ),
                 ),
@@ -186,9 +184,7 @@ updated_interpretations = [
                                 ref="G",
                                 alt="A",
                             ),
-                            allelic_state=OntologyClass(
-                                id="GENO:0000402", label="compound heterozygous"
-                            ),
+                            allelic_state=OntologyClass(id="GENO:0000402", label="compound heterozygous"),
                         ),
                     ),
                 ),
@@ -243,24 +239,16 @@ phenotypic_features_with_excluded = [
     PhenotypicFeature(type=OntologyClass(id="HP:0100309", label="Subdural hemorrhage")),
     PhenotypicFeature(type=OntologyClass(id="HP:0003150", label="Glutaric aciduria")),
     PhenotypicFeature(type=OntologyClass(id="HP:0001332", label="Dystonia")),
-    PhenotypicFeature(
-        type=OntologyClass(id="HP:0008494", label="Inferior lens subluxation"), excluded=True
-    ),
+    PhenotypicFeature(type=OntologyClass(id="HP:0008494", label="Inferior lens subluxation"), excluded=True),
 ]
 
 phenotypic_features_all_excluded = [
     PhenotypicFeature(type=OntologyClass(id="HP:0000256", label="Macrocephaly"), excluded=True),
     PhenotypicFeature(type=OntologyClass(id="HP:0002059", label="Cerebral atrophy"), excluded=True),
-    PhenotypicFeature(
-        type=OntologyClass(id="HP:0100309", label="Subdural hemorrhage"), excluded=True
-    ),
-    PhenotypicFeature(
-        type=OntologyClass(id="HP:0003150", label="Glutaric aciduria"), excluded=True
-    ),
+    PhenotypicFeature(type=OntologyClass(id="HP:0100309", label="Subdural hemorrhage"), excluded=True),
+    PhenotypicFeature(type=OntologyClass(id="HP:0003150", label="Glutaric aciduria"), excluded=True),
     PhenotypicFeature(type=OntologyClass(id="HP:0001332", label="Dystonia"), excluded=True),
-    PhenotypicFeature(
-        type=OntologyClass(id="HP:0008494", label="Inferior lens subluxation"), excluded=True
-    ),
+    PhenotypicFeature(type=OntologyClass(id="HP:0008494", label="Inferior lens subluxation"), excluded=True),
 ]
 diseases = [Disease(term=OntologyClass(id="OMIM:219700", label="Cystic Fibrosis"))]
 
@@ -426,9 +414,7 @@ class TestPhenopacketUtil(unittest.TestCase):
         self.assertEqual(self.family.sample_id(), "test-subject-1")
 
     def test_phenotypic_features_phenopacket(self):
-        self.assertEqual(
-            list(self.phenopacket.phenotypic_features()), phenotypic_features_with_excluded
-        )
+        self.assertEqual(list(self.phenopacket.phenotypic_features()), phenotypic_features_with_excluded)
         self.assertEqual(
             list(self.phenopacket_excluded_pf.phenotypic_features()),
             phenotypic_features_all_excluded,
@@ -439,9 +425,7 @@ class TestPhenopacketUtil(unittest.TestCase):
 
     def test_observed_phenotypic_features(self):
         self.assertEqual(list(self.phenopacket_excluded_pf.observed_phenotypic_features()), [])
-        self.assertEqual(
-            list(self.phenopacket.observed_phenotypic_features()), phenotypic_features_none_excluded
-        )
+        self.assertEqual(list(self.phenopacket.observed_phenotypic_features()), phenotypic_features_none_excluded)
 
     def test_negated_phenotypic_features_all_excluded(self):
         self.assertEqual(
@@ -545,9 +529,7 @@ class TestPhenopacketUtil(unittest.TestCase):
         self.assertEqual(list(self.family.files()), phenopacket_files)
 
     def test_vcf_file_data(self):
-        vcf_file_data = self.phenopacket.vcf_file_data(
-            Path("test-phenopacket-1.json"), Path("input_dir")
-        )
+        vcf_file_data = self.phenopacket.vcf_file_data(Path("test-phenopacket-1.json"), Path("input_dir"))
         self.assertEqual(
             vcf_file_data,
             File(
@@ -556,13 +538,9 @@ class TestPhenopacketUtil(unittest.TestCase):
             ),
         )
         with self.assertRaises(IncompatibleGenomeAssemblyError):
-            self.family_incorrect_files.vcf_file_data(
-                Path("test-phenopacket-1.json"), Path("input_dir")
-            )
+            self.family_incorrect_files.vcf_file_data(Path("test-phenopacket-1.json"), Path("input_dir"))
         with self.assertRaises(IncorrectFileFormatError):
-            self.family_incorrect_file_format.vcf_file_data(
-                Path("test-phenopacket-1.json"), Path("input_dir")
-            )
+            self.family_incorrect_file_format.vcf_file_data(Path("test-phenopacket-1.json"), Path("input_dir"))
 
     def test_diagnosed_genes(self):
         self.assertEqual(
@@ -630,33 +608,23 @@ class TestPhenopacketRebuilder(unittest.TestCase):
         ]
 
     def test_update_interpretations_phenopacket(self):
-        phenopacket_updated_interpretations = self.phenopacket_rebuilder.update_interpretations(
-            updated_interpretations
-        )
+        phenopacket_updated_interpretations = self.phenopacket_rebuilder.update_interpretations(updated_interpretations)
         self.assertNotEqual(
             list(updated_interpretations),
             list(self.phenopacket_rebuilder.phenopacket.interpretations),
         )
-        self.assertEqual(
-            list(phenopacket_updated_interpretations.interpretations), updated_interpretations
-        )
+        self.assertEqual(list(phenopacket_updated_interpretations.interpretations), updated_interpretations)
 
     def test_update_interpretations_family(self):
-        family_updated_interpretations = self.family_rebuilder.update_interpretations(
-            updated_interpretations
-        )
+        family_updated_interpretations = self.family_rebuilder.update_interpretations(updated_interpretations)
         self.assertNotEqual(
             list(updated_interpretations),
             list(self.family_rebuilder.phenopacket.proband.interpretations),
         )
-        self.assertEqual(
-            list(family_updated_interpretations.proband.interpretations), updated_interpretations
-        )
+        self.assertEqual(list(family_updated_interpretations.proband.interpretations), updated_interpretations)
 
     def test_add_randomised_hpo_phenopacket(self):
-        random_phenopacket = self.phenopacket_rebuilder.add_randomised_hpo(
-            self.randomised_phenotype
-        )
+        random_phenopacket = self.phenopacket_rebuilder.add_randomised_hpo(self.randomised_phenotype)
         self.assertNotEqual(
             random_phenopacket.phenotypic_features,
             self.phenopacket_rebuilder.phenopacket.phenotypic_features,
@@ -678,11 +646,7 @@ class TestPhenopacketRebuilder(unittest.TestCase):
                 file_attributes={"fileFormat": "vcf", "genomeAssembly": "GRCh37"},
             )
         )
-        vcf_file = [
-            file
-            for file in updated_phenopacket.files
-            if file.file_attributes["fileFormat"] == "vcf"
-        ][0]
+        vcf_file = next(file for file in updated_phenopacket.files if file.file_attributes["fileFormat"] == "vcf")
         self.assertEqual(vcf_file.uri, str(Path("input_dir/test_vcf_dir/test_1.vcf").absolute()))
 
 
@@ -697,15 +661,11 @@ class TestGeneIdentifierUpdater(unittest.TestCase):
         cls.gene_identifier_updater_entrez = GeneIdentifierUpdater(
             gene_identifier="entrez_id", identifier_map=identifier_map
         )
-        cls.find_symbol = GeneIdentifierUpdater(
-            gene_identifier="hgnc_id", identifier_map=identifier_map
-        )
+        cls.find_symbol = GeneIdentifierUpdater(gene_identifier="hgnc_id", identifier_map=identifier_map)
 
     def test_find_identifier(self):
         self.assertEqual(self.gene_identifier_updater_ens.find_identifier("A2M"), "ENSG00000175899")
-        self.assertEqual(
-            self.gene_identifier_updater_ens.find_identifier("GBA1"), "ENSG00000177628"
-        )
+        self.assertEqual(self.gene_identifier_updater_ens.find_identifier("GBA1"), "ENSG00000177628")
         self.assertEqual(self.gene_identifier_updater_entrez.find_identifier("A2M"), "2")
         self.assertEqual(self.gene_identifier_updater_entrez.find_identifier("GBA1"), "2629")
 

--- a/tests/test_rank_stats.py
+++ b/tests/test_rank_stats.py
@@ -52,7 +52,7 @@ class TestRanks(unittest.TestCase):
                 Ranks.NUMBER_OF_SAMPLES,
             ]
         ).collect()
-        self.assertTrue((result.equals(self.result)))
+        self.assertTrue(result.equals(self.result))
 
     def test_mrr(self):
         """Test Mean Reciprocal Rank (MRR) calculation."""
@@ -139,11 +139,7 @@ class TestRanks(unittest.TestCase):
             Ranks._average_precision_at_k(self.test_df, 1)
             .collect()
             .sort("file_path")
-            .equals(
-                pl.DataFrame(
-                    [{"file_path": "file1", "ap@1": 1.0}, {"file_path": "file3", "ap@1": 1.0}]
-                )
-            )
+            .equals(pl.DataFrame([{"file_path": "file1", "ap@1": 1.0}, {"file_path": "file3", "ap@1": 1.0}]))
         )
         self.assertTrue(
             Ranks._average_precision_at_k(self.test_df, 3)
@@ -203,6 +199,4 @@ class TestRanks(unittest.TestCase):
         self.assertAlmostEqual(Ranks._calculate_ndcg_at_k([1, 2, 4], 5), 0.858, places=3)
 
     def test_mean_normalised_discounted_cumulative_gain(self):
-        self.assertAlmostEqual(
-            Ranks.mean_normalised_discounted_cumulative_gain(self.test_df, 3), 0.301, places=3
-        )
+        self.assertAlmostEqual(Ranks.mean_normalised_discounted_cumulative_gain(self.test_df, 3), 0.301, places=3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,7 @@ class TestSemsimUtils(unittest.TestCase):
             "phenodigm_score",
         ]
 
-        with open(output_file, "r", encoding="utf-8") as f:
+        with open(output_file, encoding="utf-8") as f:
             lines = f.readlines()
             input_file = pd.read_csv(semsim_file, sep="\t")
             self.assertEqual(len(lines), len(input_file) + 1)

--- a/tests/test_validate_result_format.py
+++ b/tests/test_validate_result_format.py
@@ -57,9 +57,7 @@ class TestResultSchema(unittest.TestCase):
     def test_null_grouping_id(self):
         """Test that null values in `grouping_id` raise ValueError."""
         invalid_df = self.valid_gene_df.with_columns(pl.lit(None).alias("grouping_id"))
-        with self.assertRaises(
-            ValueError, msg="'grouping_id' column should not contain null values if provided."
-        ):
+        with self.assertRaises(ValueError, msg="'grouping_id' column should not contain null values if provided."):
             ResultSchema.GENE_RESULT_SCHEMA.validate(invalid_df)
 
     def test_missing_grouping_id_column(self):

--- a/tox.ini
+++ b/tox.ini
@@ -6,77 +6,31 @@
 [tox]
 isolated_build = true
 envlist =
-    lint
-    flake8
     py
+    ruff
 
 [testenv]
+deps =
+    pytest
+    coverage
 commands =
     coverage run -p -m pytest --durations=20 {posargs:tests} --basetemp /tmp
     coverage combine
     coverage xml
-deps =
-    pytest
-    coverage
 
-[testenv:lint]
-deps =
-    black
-    isort
-skip_install = true
-commands =
-    black .
-    isort .
-description = Run linters.
-
-[testenv:flake8]
+[testenv:ruff]
+description = Run Ruff linter formatter
 skip_install = true
 deps =
-    flake8<5.0.0
-    flake8-bandit
-    flake8-black
-    flake8-bugbear
-    flake8-colors
-    flake8-isort
-    pep8-naming
+    ruff
 commands =
-    flake8 src/ tests/
-description = Run the flake8 tool with several plugins (bandit, docstrings, import order, pep8 naming).
+    ruff check . --fix --config={toxinidir}/pyproject.toml
+    ruff format . --config={toxinidir}/pyproject.toml
 
-#########################
-# Flake8 Configuration  #
-# (.flake8)             #
-#########################
-[flake8]
-ignore =
-    #E203
-    W503
-    S311
-    #C901 # needs code change so ignoring for now.
-    #E731 # needs code change so ignoring for now.
-    #S101 # asserts are fine
-    #S106 # flags false positives with test_table_filler
-    #N801 # mixed case is bad but there's a lot of auto-generated code
-    #N815 # same ^
-    #S404 # Consider possible security implications associated with the subprocess module.
-    #S108 # Probable insecure usage of temp file/directory.
-    #S307 # Use of possibly insecure function - consider using safer ast.literal_eval.
-    #S603 # subprocess call - check for execution of untrusted input.
-    #S607 # Starting a process with a partial executable path ["open" in both cases]
-    S608 # Possible SQL injection vector through string-based query construction.
-    #B024 # StreamingWriter is an abstract base class, but it has no abstract methods. 
-         # Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
-    #B027 # empty method in an abstract base class, but has no abstract decorator. Consider adding @abstractmethod
-    #N803 # math-oriented classes can ignore this (e.g. hypergeometric.py)
-    #N806 # math-oriented classes can ignore this (e.g. hypergeometric.py)
-    #B019
-
-max-line-length = 120
-max-complexity = 13
-import-order-style = pycharm
-application-import-names =
-    pheval
-    pheval_utils
-    tests
-# exclude =
-#    datamodels   ## datamodels are auto-generated
+[testenv:ruff-check]
+description = Run Ruff linter and formatter checks
+skip_install = true
+deps = ruff
+commands =
+    ruff check . --config={toxinidir}/pyproject.toml
+    ruff format --check . --config={toxinidir}/pyproject.toml


### PR DESCRIPTION
## Migrate to Ruff and update CI

This PR replaces flake8, black, and isort with Ruff for linting and formatting.

### Changes:
- Added `ruff` configuration to `tox.ini` and `pyproject.toml`
- Added `tox -e ruff` for auto-fixing and formatting locally
- Added `tox -e ruff-check` for CI-safe linting (check-only)
- Removed flake8 and lint environments
- Updated GitHub Actions to use `tox -e ruff-check` in the lint job